### PR TITLE
fix(profiler): lay out flame chart by real span offsets

### DIFF
--- a/packages/pipe-ui/app/dashboard/profiler-flame-chart.tsx
+++ b/packages/pipe-ui/app/dashboard/profiler-flame-chart.tsx
@@ -9,35 +9,69 @@ import { getHeatColor } from '~/dashboard/profiler'
 
 type FlatNode = ProfilerResult & {
   depth: number
-  startOffset: number
+  /**
+   * Stable hierarchical identity of this node (e.g. `batch/apply transformers/decoder`).
+   * Used as the React key so rows don't remount when timings shift.
+   * `calcStats` merges same-named siblings, so this path is unique within a tree.
+   */
+  path: string
+  /** X position on the canvas, in percent (0–100). */
+  xPercent: number
+  /** Width on the canvas, in percent (0–100). */
   widthPercent: number
 }
 
-function flattenByDepth(
-  nodes: ProfilerResult[],
-  depth: number,
-  parentStartOffset: number,
-  parentWidthPercent: number,
-): FlatNode[] {
+type ParentFrame = {
+  /** `ProfilerResult.startOffset` of the parent (ms, summed across samples). */
+  msOffset: number
+  /** `ProfilerResult.totalTime` of the parent (ms, summed across samples). */
+  totalTime: number
+  /** Canvas x position of the parent, in percent. */
+  xPercent: number
+  /** Canvas width of the parent, in percent. */
+  widthPercent: number
+  /** Hierarchical path of the parent (empty string at the root level). */
+  path: string
+}
+
+function flattenByDepth(nodes: ProfilerResult[], depth: number, parent: ParentFrame): FlatNode[] {
   const result: FlatNode[] = []
+
+  // Legacy fallback: if children don't carry real offsets, lay them out sequentially
+  // inside the parent using duration ratios (this preserves the pre-alpha.7 behavior).
+  const hasRealOffsets = nodes.every((n) => typeof n.startOffset === 'number')
   const siblingTotal = nodes.reduce((sum, n) => sum + n.totalTime, 0)
-  let offset = parentStartOffset
+  const denom = parent.totalTime > 0 ? parent.totalTime : siblingTotal > 0 ? siblingTotal : 1
+  let seqOffsetPercent = parent.xPercent
 
   for (const node of nodes) {
-    const widthPercent = siblingTotal > 0 ? (node.totalTime / siblingTotal) * parentWidthPercent : 0
+    let xPercent: number
+    let widthPercent: number
 
-    result.push({
-      ...node,
-      depth,
-      startOffset: offset,
-      widthPercent,
-    })
-
-    if (node.children.length > 0) {
-      result.push(...flattenByDepth(node.children, depth + 1, offset, widthPercent))
+    if (hasRealOffsets) {
+      const relStart = (node.startOffset as number) - parent.msOffset
+      widthPercent = (node.totalTime / denom) * parent.widthPercent
+      xPercent = parent.xPercent + (relStart / denom) * parent.widthPercent
+    } else {
+      widthPercent = siblingTotal > 0 ? (node.totalTime / siblingTotal) * parent.widthPercent : 0
+      xPercent = seqOffsetPercent
+      seqOffsetPercent += widthPercent
     }
 
-    offset += widthPercent
+    const path = parent.path ? `${parent.path}/${node.name}` : node.name
+    result.push({ ...node, depth, path, xPercent, widthPercent })
+
+    if (node.children.length > 0) {
+      result.push(
+        ...flattenByDepth(node.children, depth + 1, {
+          msOffset: node.startOffset ?? 0,
+          totalTime: node.totalTime,
+          xPercent,
+          widthPercent,
+          path,
+        }),
+      )
+    }
   }
 
   return result
@@ -158,7 +192,33 @@ export function FlameChart({
     return current
   }, [profilers, zoomPath])
 
-  const flat = useMemo(() => flattenByDepth(zoomedRoot, 0, 0, 100), [zoomedRoot])
+  const flat = useMemo(() => {
+    // Top-level roots have no spatial relationship (they're independent trees —
+    // typically just one `batch` aggregate). Pack them sequentially across the
+    // canvas, proportional to their totalTime. Inside each root, children use
+    // their real startOffset (ms relative to their root).
+    const result: FlatNode[] = []
+    const rootsTotal = zoomedRoot.reduce((sum, n) => sum + n.totalTime, 0)
+    let xPercent = 0
+    for (const root of zoomedRoot) {
+      const widthPercent = rootsTotal > 0 ? (root.totalTime / rootsTotal) * 100 : 0
+      const path = root.name
+      result.push({ ...root, depth: 0, path, xPercent, widthPercent })
+      if (root.children.length > 0) {
+        result.push(
+          ...flattenByDepth(root.children, 1, {
+            msOffset: root.startOffset ?? 0,
+            totalTime: root.totalTime,
+            xPercent,
+            widthPercent,
+            path,
+          }),
+        )
+      }
+      xPercent += widthPercent
+    }
+    return result
+  }, [zoomedRoot])
   const depthMap = useMemo(() => groupByDepth(flat), [flat])
   const maxDepth = useMemo(() => Math.max(...Array.from(depthMap.keys()), 0), [depthMap])
 
@@ -201,7 +261,8 @@ export function FlameChart({
             root
           </button>
           {zoomPath.map((name, i) => (
-            <span key={name} className="flex items-center gap-1">
+            // eslint-disable-next-line react/no-array-index-key -- breadcrumb segments can repeat by name
+            <span key={`${i}-${name}`} className="flex items-center gap-1">
               <ChevronRight className="w-3 h-3 text-white/30" />
               <button
                 type="button"
@@ -227,10 +288,10 @@ export function FlameChart({
 
                 return (
                   <div
-                    key={`${node.name}-${node.startOffset}`}
+                    key={node.path}
                     className="flame-cell"
                     style={{
-                      left: `${node.startOffset}%`,
+                      left: `${node.xPercent}%`,
                       width: `${width}%`,
                       minWidth: width > 0 ? 4 : 0,
                       backgroundColor: color,

--- a/packages/pipe-ui/app/dashboard/profiler.tsx
+++ b/packages/pipe-ui/app/dashboard/profiler.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import { Flame, ListTree, Settings } from 'lucide-react'
 import { type ComponentType, useEffect, useRef, useState } from 'react'
+
+import { Flame, ListTree, Settings } from 'lucide-react'
 
 import { Switch } from '~/components/ui/switch'
 import { PanelLoading } from '~/dashboard/panel-loading'
 import { FlameChart } from '~/dashboard/profiler-flame-chart'
-import { type ApiProfilerResult, useProfilers } from '~/hooks/use-metrics'
 import { useLocalStorage } from '~/hooks/use-local-storage'
+import { type ApiProfilerResult, useProfilers } from '~/hooks/use-metrics'
 import { useServerIndex } from '~/hooks/use-server-context'
 import { cn } from '~/lib/utils'
 
@@ -17,6 +18,12 @@ type TimeMode = 'total' | 'avg'
 export type ProfilerResult = {
   name: string
   totalTime: number
+  /**
+   * Summed start offset (ms) across aggregated batches, relative to each batch's root.
+   * Stays in lock-step with `totalTime`, so ratios (`startOffset / totalTime`) survive aggregation.
+   * `undefined` when the SDK did not provide offsets (legacy fallback).
+   */
+  startOffset?: number
   selfTime: number
   percent: number
   labels?: string[]
@@ -62,6 +69,9 @@ function calcStats({
       item = {
         name: profiler.name,
         totalTime: 0,
+        // Leave `startOffset` undefined initially; only seed to 0 when the first
+        // sample carries an offset, so legacy SDKs keep producing `undefined`.
+        startOffset: typeof profiler.startOffset === 'number' ? 0 : undefined,
         selfTime: 0,
         percent: 0,
         labels: profiler.labels,
@@ -72,6 +82,9 @@ function calcStats({
 
     item.totalTime += Number(profiler.totalTime)
     item.selfTime += Number(selfTime)
+    if (typeof profiler.startOffset === 'number') {
+      item.startOffset = (item.startOffset ?? 0) + Number(profiler.startOffset)
+    }
 
     const timeForPercent = percentage.excludeChildren ? item.selfTime : item.totalTime
     item.percent = (timeForPercent / percentage.totalSpentTime) * 100
@@ -178,9 +191,7 @@ function Segmented<T extends string>({
             aria-pressed={active}
             className={cn(
               'flex items-center gap-1 px-2 h-6 text-xxs rounded-sm transition-colors cursor-pointer',
-              active
-                ? 'bg-white/10 text-white shadow-sm'
-                : 'text-white/50 hover:text-white/80 hover:bg-white/[0.04]',
+              active ? 'bg-white/10 text-white shadow-sm' : 'text-white/50 hover:text-white/80 hover:bg-white/[0.04]',
             )}
           >
             {Icon && <Icon className="size-3" />}

--- a/packages/pipe-ui/app/hooks/use-metrics.ts
+++ b/packages/pipe-ui/app/hooks/use-metrics.ts
@@ -188,11 +188,21 @@ export function usePipe(serverIndex: number, id: string) {
 export type ApiProfilerResult = {
   name: string
   totalTime: number
+  /** Start offset (ms) relative to the root span of the tree. Optional — absent from SDK < 1.0.0-alpha.7. */
+  startOffset?: number
   labels?: string[]
   children: ApiProfilerResult[]
 }
 
-export function useProfilers({ enabled = true, serverIndex, pipeId }: { enabled?: boolean; serverIndex: number; pipeId: string }) {
+export function useProfilers({
+  enabled = true,
+  serverIndex,
+  pipeId,
+}: {
+  enabled?: boolean
+  serverIndex: number
+  pipeId: string
+}) {
   return useQuery({
     queryKey: ['pipe/profiler', serverIndex, pipeId],
     queryFn: async () => {
@@ -217,12 +227,22 @@ export type ApiExemplarResult = {
   name: string
   data: any
   elapsed?: number
+  /** Start offset (ms) relative to the root span of the tree. Optional — absent from SDK < 1.0.0-alpha.7. */
+  startOffset?: number
   dataSize?: number
   labels?: string[]
   children: ApiExemplarResult[]
 }
 
-export function useTransformationExemplar({ enabled = true, serverIndex, pipeId }: { enabled?: boolean; serverIndex: number; pipeId: string }) {
+export function useTransformationExemplar({
+  enabled = true,
+  serverIndex,
+  pipeId,
+}: {
+  enabled?: boolean
+  serverIndex: number
+  pipeId: string
+}) {
   return useQuery({
     queryKey: ['pipe/exemplars/transformation', serverIndex, pipeId],
     queryFn: async () => {

--- a/packages/pipe-ui/package.json
+++ b/packages/pipe-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subsquid/pipes-ui",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subsquid/pipes",
   "type": "module",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "sideEffects": false,
   "author": "Subsquid Team",
   "files": [

--- a/packages/subsquid-pipes/src/core/profiling.test.ts
+++ b/packages/subsquid-pipes/src/core/profiling.test.ts
@@ -108,4 +108,56 @@ describe('Span', () => {
 
     expect(ended).toContain('child')
   })
+
+  it('exposes `started` on Profiler so consumers can compute relative offsets', async () => {
+    const root = Span.root('root', true)
+    // Give the root a moment before the first child starts
+    await new Promise((r) => setTimeout(r, 5))
+    const a = root.start('a')
+    a.end()
+    await new Promise((r) => setTimeout(r, 5))
+    const b = root.start('b')
+    b.end()
+
+    // `started` is on the Profiler interface and returns high-res timestamps.
+    expect(typeof root.started).toBe('number')
+    expect(typeof a.started).toBe('number')
+    expect(typeof b.started).toBe('number')
+
+    // Relative offsets grow monotonically as children start later.
+    expect(a.started - root.started).toBeGreaterThan(0)
+    expect(b.started - a.started).toBeGreaterThan(0)
+  })
+
+  it('transform() can produce per-span offsets relative to the root', async () => {
+    const root = Span.root('root', true)
+    await new Promise((r) => setTimeout(r, 5))
+    const a = root.start('a')
+    a.end()
+    await new Promise((r) => setTimeout(r, 5))
+    const b = root.start('b')
+    const bChild = b.start('b.child')
+    bChild.end()
+    b.end()
+
+    const rootStarted = root.started
+    type Out = { name: string; startOffset: number; children: Out[] }
+    const tree = root.transform<Out>((span, children) => ({
+      name: span.name,
+      startOffset: span.started - rootStarted,
+      children,
+    }))
+
+    expect(tree.name).toBe('root')
+    expect(tree.startOffset).toBe(0)
+    expect(tree.children).toHaveLength(2)
+    const [aOut, bOut] = tree.children
+    expect(aOut.name).toBe('a')
+    expect(bOut.name).toBe('b')
+    expect(aOut.startOffset).toBeGreaterThan(0)
+    expect(bOut.startOffset).toBeGreaterThan(aOut.startOffset)
+    // Nested child's offset is also measured from the root, not its direct parent
+    expect(bOut.children[0].name).toBe('b.child')
+    expect(bOut.children[0].startOffset).toBeGreaterThanOrEqual(bOut.startOffset)
+  })
 })

--- a/packages/subsquid-pipes/src/core/profiling.ts
+++ b/packages/subsquid-pipes/src/core/profiling.ts
@@ -24,6 +24,8 @@ export interface SpanHooks {
 
 export interface Profiler {
   name: string
+  /** High-resolution timestamp (from `performance.now()`) at which the span started. */
+  started: number
   elapsed: number
   hidden: boolean
   labels: string[]
@@ -173,6 +175,7 @@ export class Span implements Profiler {
 
 export class DummyProfiler implements Profiler {
   name: string = ''
+  started: number = 0
   elapsed: number = 0
   hidden: boolean = false
   labels: string[] = []

--- a/packages/subsquid-pipes/src/metrics/node/node-metrics-server.ts
+++ b/packages/subsquid-pipes/src/metrics/node/node-metrics-server.ts
@@ -75,13 +75,17 @@ function parseDate(date: any): Date | null {
 type ProfilerResult = {
   name: string
   totalTime: number
+  /** Offset (ms) of this span's start relative to the root of the profiler tree. */
+  startOffset: number
   children: ProfilerResult[]
 }
 
 function transformProfiler(profiler: Profiler): ProfilerResult {
+  const rootStarted = profiler.started
   return profiler.transform((span, children) => ({
     name: span.name,
     totalTime: span.elapsed,
+    startOffset: span.started - rootStarted,
     children,
   }))
 }
@@ -90,6 +94,7 @@ type TransformationResult = {
   name: string
   data: any
   elapsed?: number
+  startOffset?: number
   dataSize?: number
   labels?: string[]
   children: TransformationResult[]
@@ -124,20 +129,49 @@ function packExemplar(value: any): any {
   return value
 }
 
+/**
+ * The `metrics processing` span is started after the root batch span has
+ * already ended, so its real wall-clock offset exceeds `root.elapsed`. We
+ * reposition it to start right at the root's previous end and extend the
+ * root's duration so the tree stays internally consistent (child offsets
+ * always fall within [0, parent.totalTime]).
+ */
+function patchMetricsProcessing(root: ProfilerResult, metricsElapsed: number): void {
+  const lastChild = root.children.at(-1)
+  if (!lastChild || lastChild.name !== 'metrics processing') return
+
+  lastChild.totalTime = metricsElapsed
+  lastChild.startOffset = root.totalTime
+  root.totalTime += metricsElapsed
+}
+
+function patchMetricsProcessingExemplar(root: TransformationResult, metricsElapsed: number): void {
+  const lastChild = root.children.at(-1)
+  if (!lastChild || lastChild.name !== 'metrics processing') return
+
+  const rootElapsed = root.elapsed ?? 0
+  lastChild.elapsed = metricsElapsed
+  lastChild.startOffset = rootElapsed
+  root.elapsed = rootElapsed + metricsElapsed
+}
+
 function transformExemplar(profiler: Profiler): TransformationResult {
+  const rootStarted = profiler.started
   return profiler.transform((span, children) => {
-    const data = span.data != null
-      ? JSON.stringify(packExemplar(span.data), (k: string, v: any) => {
-          if (typeof v === 'bigint') return v.toString() + 'n'
-          if (v instanceof Date) return v.toISOString()
-          return v
-        })
-      : null
+    const data =
+      span.data != null
+        ? JSON.stringify(packExemplar(span.data), (k: string, v: any) => {
+            if (typeof v === 'bigint') return v.toString() + 'n'
+            if (v instanceof Date) return v.toISOString()
+            return v
+          })
+        : null
 
     return {
       name: span.name,
       data,
       elapsed: span.elapsed || undefined,
+      startOffset: span.started - rootStarted,
       dataSize: data ? data.length : undefined,
       labels: span.labels.length > 0 ? span.labels : undefined,
       children,
@@ -308,9 +342,10 @@ class ExpressMetricServer implements MetricsServer {
           transformation: pipeData?.transformationExemplar,
           batch: lastBatch
             ? {
-                from: lastBatch.batch.blocksCount > 0
-                  ? lastBatch.stream.state.current.number - lastBatch.batch.blocksCount + 1
-                  : lastBatch.stream.state.current.number,
+                from:
+                  lastBatch.batch.blocksCount > 0
+                    ? lastBatch.stream.state.current.number - lastBatch.batch.blocksCount + 1
+                    : lastBatch.stream.state.current.number,
                 to: lastBatch.stream.state.current.number,
                 blocksCount: lastBatch.batch.blocksCount,
                 bytesSize: lastBatch.batch.bytesSize,
@@ -372,8 +407,7 @@ class ExpressMetricServer implements MetricsServer {
     const data = this.registerPipe(ctx.id)
 
     data.lastBatch = ctx
-    data.transformationExemplar = transformExemplar(ctx.profiler)
-
+    const exemplar = transformExemplar(ctx.profiler)
     const profiler = transformProfiler(ctx.profiler)
 
     data.profilers.push({
@@ -383,8 +417,19 @@ class ExpressMetricServer implements MetricsServer {
     data.profilers = data.profilers.slice(-MAX_HISTORY)
     span.end()
 
-    // Update total time for the root metrics processing
-    profiler.children[profiler.children.length - 1].totalTime = span.elapsed
+    // `metrics processing` is started AFTER the root batch span ends
+    // (see `PortalSource.batchEnd`). That means:
+    //  - its `elapsed` wasn't captured at transform time (patched below), and
+    //  - its real `startOffset` is beyond `root.elapsed`, which would push it
+    //    off the right edge of the flame chart canvas.
+    //
+    // Reposition the child at the end of the root and extend the root's
+    // duration so both visualizations (profiler tree and exemplar) stay
+    // internally consistent.
+    patchMetricsProcessing(profiler, span.elapsed)
+    patchMetricsProcessingExemplar(exemplar, span.elapsed)
+
+    data.transformationExemplar = exemplar
   }
 
   get metrics() {


### PR DESCRIPTION
## Summary
- Expose `started` on the `Profiler` interface — `Span.started` (wall-clock `performance.now()`) was already captured but not reachable through the interface, so exporters couldn't see it.
- `node-metrics-server` now serializes a per-span `startOffset` (ms relative to each tree's root) in both `/profiler` and `/exemplars/transformation` payloads.
- pipe-ui: carry `startOffset` through `calcStats` aggregation (summed in lock-step with `totalTime`, so ratios survive averaging) and rewrite `flattenByDepth` to position children by real offset instead of a running duration accumulator.
- Legacy fallback: when `startOffset` is missing (older SDK builds), the flame chart falls back to the old sequential layout.
- Bump `@subsquid/pipes` and `@subsquid/pipes-ui` to `1.0.0-alpha.7`.

## Root cause
`Span.started` was captured in the constructor but never serialized. Both `transformProfiler()` and `transformExemplar()` exported only `{ name, totalTime, children }`, forcing the UI to fabricate each child's `x` position:

```ts
// packages/pipe-ui/app/dashboard/profiler-flame-chart.tsx (before)
const siblingTotal = nodes.reduce((s, n) => s + n.totalTime, 0)
let offset = parentStartOffset
for (const node of nodes) {
  const widthPercent = (node.totalTime / siblingTotal) * parentWidthPercent
  result.push({ ...node, startOffset: offset, widthPercent })
  offset += widthPercent   // <-- fabricated from duration, not real offset
}
```

Consequences: (a) children always stretched to fill 100% of the parent, (b) nested spans were mis-aligned, (c) parent self-time was invisible.

## Fix
After fix, children are positioned via:
```
x_child = ((child.startOffset - parent.startOffset) / parent.totalTime) * parent.widthPercent
w_child = (child.totalTime / parent.totalTime) * parent.widthPercent
```
Self-time now shows as empty space. Gaps and overlaps are rendered truthfully.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 71.4% | +0.1 | 81.6% | +0.3 |
| src/core | 84.1% | +1.0 | 86.8% | +0.8 |
| src/portal-client/query | 94.1% | +0.0 | 89.8% | +0.2 |
| src/testing | 86.5% | +0.0 | 83.3% | +0.2 |

`src/core` jumps +1.0% stmts / +0.8% branches from the new profiling tests.

## Test plan
- [x] New tests in `src/core/profiling.test.ts`:
  - `exposes 'started' on Profiler so consumers can compute relative offsets`
  - `transform() can produce per-span offsets relative to the root` (covers nested children and sibling ordering)
- [x] Full SDK unit suite: 257/257 passing (`pnpm vitest run --exclude='**/drizzle-target.test.ts' --exclude='**/clickhouse-store.test.ts'`)
- [x] pipe-ui typecheck clean (`pnpm typecheck`)
- [x] Biome clean on touched files
- [ ] Visual smoke test: run a local pipe, open Flame tab, verify `batch` is 100%, children are positioned at their real offsets, self-time shows as empty space
- [ ] Backward compat: point pipe-ui at a pre-alpha.7 SDK — legacy fallback in `flattenByDepth` keeps the sequential layout so nothing crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)