### PR TITLE
feat(pipe-ui): restyle server selector, add runtime info

### DIFF
--- a/packages/pipe-ui/app/dashboard/sidebar.tsx
+++ b/packages/pipe-ui/app/dashboard/sidebar.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { AlertCircle } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { AlertCircle, ChevronsUpDown } from 'lucide-react'
+
 import { displayEstimatedTime } from '~/dashboard/formatters'
-import { ApiStatus, type Pipe, PipeStatus, useStats } from '~/hooks/use-metrics'
+import { type ApiStats, ApiStatus, type Pipe, PipeStatus, useServerStatuses, useStats } from '~/hooks/use-metrics'
 import { useServerIndex } from '~/hooks/use-server-context'
 import { type Server, useServers } from '~/hooks/use-servers'
 
@@ -14,7 +15,7 @@ function CircularProgress({ percent }: { percent: number }) {
   const offset = circumference - (percent / 100) * circumference
 
   return (
-    <svg width="26" height="26" viewBox="0 0 16 16">
+    <svg width="26" height="26" viewBox="0 0 16 16" className="shrink-0 block">
       <defs>
         <linearGradient id="progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#433485" />
@@ -83,7 +84,7 @@ function PipeSelector({
 
   return (
     <div>
-      <div className="text-xs font-normal text-muted-foreground mb-1">Pipes</div>
+      <div className="text-xs font-normal text-muted-foreground mb-1.5">Pipes</div>
 
       <div className="flex flex-col gap-1">
         {pipes.map((pipe) => (
@@ -96,7 +97,7 @@ function PipeSelector({
                 : 'bg-secondary/50 text-muted-foreground border-border hover:bg-secondary'
             }`}
           >
-            <div className="flex items-center gap-1.5 mb-1.5">
+            <div className="flex items-start gap-1.5 mb-0.5">
               {pipe.dataset?.metadata?.logo_url && (
                 <img src={pipe.dataset.metadata.logo_url} alt="" className="w-4 h-4" />
               )}
@@ -117,7 +118,8 @@ function PipeSelector({
             ) : (
               <div
                 className={
-                  'flex w-full font-thin justify-between' + (pipe.status === PipeStatus.Syncing ? ' animate-pulse' : '')
+                  'flex w-full text-[10px] font-thin justify-between' +
+                  (pipe.status === PipeStatus.Syncing ? ' animate-pulse' : '')
                 }
               >
                 <div>{pipe.progress.percent.toFixed(2)}%</div>
@@ -132,34 +134,150 @@ function PipeSelector({
   )
 }
 
-function ServerSelect({ servers, connected, version }: { servers: Server[]; connected: boolean; version?: string }) {
+function StatusDot({ connected }: { connected: boolean }) {
+  return (
+    <span className="relative inline-flex shrink-0 items-center justify-center">
+      {connected && (
+        <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-emerald-400 opacity-60" />
+      )}
+      <span
+        className={`relative inline-flex h-[7px] w-[7px] rounded-full ${
+          connected ? 'bg-emerald-400 shadow-[0_0_6px_0_rgba(52,211,153,0.8)]' : 'bg-gray-500'
+        }`}
+      />
+    </span>
+  )
+}
+
+function ServerSelect({
+  servers,
+  connected,
+  statuses,
+}: {
+  servers: Server[]
+  connected: boolean
+  statuses?: Map<number, boolean>
+}) {
   const { serverIndex, setServerIndex } = useServerIndex()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const current = servers[serverIndex] ?? servers[0]
+  const label = current?.name || current?.url || 'Select server'
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <div className="text-xs font-normal text-muted-foreground mb-1">Server</div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="group relative w-full h-auto py-3 px-3 text-sm text-left rounded-lg border border-border hover:border-border/80 bg-gradient-to-b from-white/[0.04] to-white/[0.01] hover:from-white/[0.06] hover:to-white/[0.02] transition-all"
+      >
+        <div className="flex items-center gap-2.5 w-full min-w-0">
+          <StatusDot connected={connected} />
+          <div className="flex flex-col items-start min-w-0 flex-1">
+            <span className="text-xs text-foreground truncate w-full text-left font-normal">{label}</span>
+            <span className="text-[10px] leading-tight text-muted-foreground">
+              {connected ? 'Connected' : 'Disconnected'}
+            </span>
+          </div>
+          <ChevronsUpDown className="size-3.5 opacity-40 group-hover:opacity-70 transition-opacity shrink-0" />
+        </div>
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-0.5 w-full rounded-lg border border-border/80 bg-popover/95 backdrop-blur-md shadow-xl shadow-black/30 overflow-hidden animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 duration-150">
+          <div className="p-1 flex flex-col gap-0.5">
+            {servers.map((server, index) => {
+              const isSelected = index === serverIndex
+              const online = statuses?.get(index)
+              return (
+                <button
+                  key={server.url}
+                  type="button"
+                  onClick={() => {
+                    setServerIndex(index)
+                    setOpen(false)
+                  }}
+                  className={`flex items-center gap-2.5 w-full rounded-md px-2.5 py-2 text-left transition-colors ${
+                    isSelected
+                      ? 'bg-white/[0.06] text-foreground'
+                      : 'text-muted-foreground hover:bg-white/[0.05] hover:text-foreground'
+                  }`}
+                >
+                  <span
+                    className={`inline-flex shrink-0 h-[6px] w-[6px] rounded-full ${
+                      online === true
+                        ? 'bg-emerald-400 shadow-[0_0_4px_0_rgba(52,211,153,0.6)]'
+                        : online === false
+                          ? 'bg-red-400/80'
+                          : 'bg-gray-500/50'
+                    }`}
+                  />
+                  <div className="flex flex-col items-start gap-0.5 min-w-0 flex-1">
+                    <span className="text-xs truncate w-full font-normal">{server.name || server.url}</span>
+                    {server.name && <span className="text-[10px] text-muted-foreground truncate">{server.url}</span>}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RuntimeInfo({
+  runtime,
+  sdkVersion,
+  entryPoint,
+}: {
+  runtime?: ApiStats['runtime']
+  sdkVersion?: string
+  entryPoint?: string
+}) {
+  if (!runtime && !sdkVersion && !entryPoint) return null
+
+  const runtimeLabels: Record<string, string> = {
+    bun: 'Bun',
+    deno: 'Deno',
+    node: 'Node',
+    unknown: 'Unknown',
+  }
+  const runtimeLabel = runtime?.name ? (runtimeLabels[runtime.name] ?? 'Unknown') : 'Unknown'
 
   return (
     <div>
-      <div className="text-xs font-normal text-muted-foreground mb-1 w-[60px]">Server</div>
-      <Select value={String(serverIndex)} onValueChange={(v: string) => setServerIndex(Number(v))}>
-        <SelectTrigger className="w-full h-auto py-1.5 text-sm">
-          <div className="flex flex-col items-start gap-0.5 w-full">
-            <SelectValue />
-            <div className="flex items-center gap-1.5 text-muted-foreground w-full">
-              <div className={`w-[6px] h-[6px] rounded-full shrink-0 ${connected ? 'bg-teal-400' : 'bg-gray-500'}`} />
-              {connected ? (
-                version && <span className="text-[10px]">{version}</span>
-              ) : (
-                <span className="text-[10px]">Disconnected</span>
-              )}
-            </div>
+      <div className="text-xs font-normal text-muted-foreground mb-1">Runtime</div>
+      <div className="rounded-lg border border-border bg-white/[0.015] px-2.5 py-2 flex flex-col gap-1.5 text-[10px]">
+        {runtime?.version && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-muted-foreground">{runtimeLabel}</span>
+            <span className="font-mono text-foreground/90">v{runtime.version}</span>
           </div>
-        </SelectTrigger>
-        <SelectContent>
-          {servers.map((server, index) => (
-            <SelectItem key={server.url} value={String(index)}>
-              {server.name || server.url}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        )}
+        {sdkVersion && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-muted-foreground">SDK</span>
+            <span className="font-mono text-foreground/90">v{sdkVersion}</span>
+          </div>
+        )}
+        {entryPoint && (
+          <div className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground">Entry point</span>
+            <span className="text-foreground/90 break-all">{entryPoint}</span>
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -176,30 +294,18 @@ export function Sidebar({
   const { serverIndex } = useServerIndex()
   const { data } = useStats(serverIndex)
   const { data: servers } = useServers()
+  const { data: statuses } = useServerStatuses(servers?.length ?? 0)
   const connected = data?.status === ApiStatus.Connected
 
   return (
-    <div className="flex-[0_220px]">
-      <div className="w-full mb-2">
+    <div className="w-[250px] shrink-0 flex flex-col gap-4">
+      <div>
         <h1 className="text-2xl font-normal mb-2">Pipes SDK</h1>
-
-        {servers && (
-          <div className="mt-2 mb-3">
-            <ServerSelect servers={servers} connected={connected} version={data?.sdk?.version} />
-          </div>
-        )}
+        {servers && <ServerSelect servers={servers} connected={connected} statuses={statuses} />}
       </div>
-      {/*<PortalStatus url={data?.pipes[0]?.portal.url} />*/}
 
-      <div className="mt-2">
-        <PipeSelector pipes={pipes} selectedPipeId={selectedPipeId} onSelectPipe={onSelectPipe} />
-      </div>
-      {data?.code?.filename && (
-        <div className="my-2">
-          <div className="text-xs font-normal text-muted-foreground mb-0.5">Entry point</div>
-          <div className="text-foreground text-xs">{data?.code?.filename}</div>
-        </div>
-      )}
+      <PipeSelector pipes={pipes} selectedPipeId={selectedPipeId} onSelectPipe={onSelectPipe} />
+      <RuntimeInfo runtime={data?.runtime} sdkVersion={data?.sdk?.version} entryPoint={data?.code?.filename} />
     </div>
   )
 }

--- a/packages/pipe-ui/app/hooks/use-metrics.ts
+++ b/packages/pipe-ui/app/hooks/use-metrics.ts
@@ -68,6 +68,10 @@ export type ApiStats = {
   sdk: {
     version: string
   }
+  runtime?: {
+    name: 'bun' | 'node' | 'deno' | 'unknown'
+    version: string
+  }
   code?: {
     filename: string
   }
@@ -174,6 +178,27 @@ export function useStats(serverIndex: number) {
 
     retry: false,
     refetchInterval: 1000,
+  })
+}
+
+export function useServerStatuses(count: number) {
+  return useQuery({
+    queryKey: ['server-statuses', count],
+    queryFn: async (): Promise<Map<number, boolean>> => {
+      const results = await Promise.allSettled(
+        Array.from({ length: count }, (_, i) =>
+          fetch(`/api/metrics/stats?_server=${i}`, { signal: AbortSignal.timeout(3000) }).then((r) => r.ok),
+        ),
+      )
+      const map = new Map<number, boolean>()
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i]
+        map.set(i, r.status === 'fulfilled' && r.value)
+      }
+      return map
+    },
+    refetchInterval: 5000,
+    retry: false,
   })
 }
 

--- a/packages/pipe-ui/config.yaml
+++ b/packages/pipe-ui/config.yaml
@@ -1,0 +1,5 @@
+metrics_server_url:
+  - url: http://localhost:9090
+    name: Local Dev
+  - url: http://localhost:9091
+    name: Staging

--- a/packages/subsquid-pipes/src/metrics/node/node-metrics-server.ts
+++ b/packages/subsquid-pipes/src/metrics/node/node-metrics-server.ts
@@ -29,6 +29,10 @@ export type Stats = {
   sdk: {
     version: string
   }
+  runtime: {
+    name: 'bun' | 'node' | 'deno' | 'unknown'
+    version: string
+  }
   code: {
     filename: string
   }
@@ -55,6 +59,20 @@ export type Stats = {
   usage: {
     memory: number
   }
+}
+
+function detectRuntime(): Stats['runtime'] {
+  const versions = (process as any)?.versions ?? {}
+  if (typeof versions.bun === 'string' && versions.bun) {
+    return { name: 'bun', version: versions.bun }
+  }
+  if (typeof versions.deno === 'string' && versions.deno) {
+    return { name: 'deno', version: versions.deno }
+  }
+  if (typeof versions.node === 'string' && versions.node) {
+    return { name: 'node', version: versions.node }
+  }
+  return { name: 'unknown', version: '' }
 }
 
 function parseDate(date: any): Date | null {
@@ -284,6 +302,7 @@ class ExpressMetricServer implements MetricsServer {
         sdk: {
           version: npmVersion,
         },
+        runtime: detectRuntime(),
         usage: {
           memory: memory?.values?.[0]?.value || 0,
         },


### PR DESCRIPTION
## Summary
- **Redesigned server selector** — gradient-tinted card with pulsing glowing status dot, "Connected/Disconnected" label, `ChevronsUpDown` icon, and dropdown items that show server name + URL
- **New runtime info panel** below the selector showing Node/Bun/Deno version and SDK version
- **Backend `detectRuntime()`** in the metrics server reports `process.versions.bun` / `.deno` / `.node` in the `/stats` payload

## Test plan
- [ ] Start a pipe on Node and verify the sidebar shows `Node vX.Y.Z` and the SDK version
- [ ] Start a pipe on Bun and verify it shows `Bun vX.Y.Z`
- [ ] Disconnect the server and verify the selector shows the gray dot + "Disconnected"
- [ ] With multiple servers configured, verify the dropdown renders each item cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)