### PR TITLE
feat(clickhouse): managed rollback — probe, chunked, semaphore, structured logs

### DIFF
--- a/packages/subsquid-pipes/src/core/portal-source.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.ts
@@ -109,6 +109,15 @@ export type PortalSourceOptions<Query> = {
     onStart?: (data: StartEvent) => void
     onProgress?: (progress: ProgressEvent) => void
   }
+  /**
+   * Optional jittered delay applied before the fork-retry loop re-reads from
+   * the portal. Spreads multi-container reconnect storms after a fork. Actual
+   * delay is `baseMs * (0.5 + random * jitter * 2)`.
+   */
+  forkRetryBackoff?: {
+    baseMs?: number
+    jitter?: number
+  }
 }
 
 export class PortalSource<Q extends QueryBuilder<any>, T = any> {
@@ -116,6 +125,7 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
   readonly #options: {
     profiler: boolean | SpanHooks
     cache?: PortalCache
+    forkRetryBackoff?: { baseMs?: number; jitter?: number }
   }
   readonly #queryBuilder: Q
   readonly #logger: Logger
@@ -155,6 +165,7 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
     this.#options = {
       cache: options.cache,
       profiler: typeof options.profiler === 'undefined' ? process.env.NODE_ENV !== 'production' : options.profiler,
+      forkRetryBackoff: options.forkRetryBackoff,
     }
 
     this.#metricServer = options.metrics ?? noopMetricsServer()
@@ -418,6 +429,14 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
             await self.forkTransformers(forkProfiler, forkedCursor)
 
             cursor = forkedCursor
+
+            const backoff = self.#options.forkRetryBackoff
+            if (backoff) {
+              const baseMs = backoff.baseMs ?? 250
+              const jitter = backoff.jitter ?? 0.5
+              const delay = baseMs * (0.5 + Math.random() * jitter * 2)
+              await new Promise((resolve) => setTimeout(resolve, delay))
+            }
           } finally {
             await self.stop()
           }

--- a/packages/subsquid-pipes/src/targets/clickhouse/__experiments__/insert-select-final-idempotency.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/__experiments__/insert-select-final-idempotency.test.ts
@@ -1,0 +1,172 @@
+import { createClient } from '@clickhouse/client'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * PC-9 empirical validation: is `INSERT INTO t (cols, sign) SELECT cols, -1 FROM t FINAL WHERE <pred>`
+ * idempotent on CollapsingMergeTree once previous tombstones are in place?
+ *
+ * Skipped by default. Run explicitly with `RUN_PC9_MATRIX=1 pnpm vitest run src/targets/clickhouse/__experiments__/insert-select-final-idempotency.test.ts`
+ * against each ClickHouse server version in the PC-9 matrix. Record every
+ * `{ch_version, async_insert, merges_state, second_run_inserted_rows}` tuple
+ * in `.agent-dev/2026-04-16-ch-rollback-storm/pc9-matrix.md`.
+ */
+
+const runPc9 = process.env['RUN_PC9_MATRIX'] === '1'
+const describeIfEnabled = runPc9 ? describe : describe.skip
+
+const url = process.env['TEST_CLICKHOUSE_URL'] || 'http://localhost:10123'
+const username = process.env['TEST_CLICKHOUSE_USERNAME'] || 'default'
+const password = process.env['TEST_CLICKHOUSE_PASSWORD'] || 'default'
+
+const ROW_COUNT = 1_000_000
+const PARTITION_PREDICATE = 'pipe_id = {pipeId:String}'
+
+type Matrix = { asyncInsert: 0 | 1; mergesState: 'on' | 'stop'; withMv: boolean }
+
+const matrix: Matrix[] = [
+  { asyncInsert: 0, mergesState: 'on', withMv: false },
+  { asyncInsert: 1, mergesState: 'on', withMv: false },
+  { asyncInsert: 0, mergesState: 'stop', withMv: false },
+  { asyncInsert: 1, mergesState: 'stop', withMv: false },
+  { asyncInsert: 0, mergesState: 'on', withMv: true },
+  { asyncInsert: 1, mergesState: 'on', withMv: true },
+]
+
+describeIfEnabled('PC-9 INSERT SELECT FINAL idempotency matrix', () => {
+  const client = createClient({ url, username, password })
+
+  async function resetTables(withMv: boolean) {
+    await client.command({ query: 'DROP TABLE IF EXISTS t_mv_target SYNC' })
+    await client.command({ query: 'DROP TABLE IF EXISTS t_mv SYNC' })
+    await client.command({ query: 'DROP TABLE IF EXISTS t SYNC' })
+
+    await client.command({
+      query: `
+        CREATE TABLE t (
+          pipe_id String,
+          block_number UInt64,
+          payload String,
+          sign Int8
+        ) ENGINE = CollapsingMergeTree(sign)
+        ORDER BY (pipe_id, block_number)
+      `,
+    })
+
+    if (withMv) {
+      await client.command({
+        query: `
+          CREATE TABLE t_mv_target (
+            pipe_id String,
+            total_blocks AggregateFunction(sum, Int64)
+          ) ENGINE = AggregatingMergeTree()
+          ORDER BY pipe_id
+        `,
+      })
+      await client.command({
+        query: `
+          CREATE MATERIALIZED VIEW t_mv TO t_mv_target AS
+          SELECT pipe_id, sumState(toInt64(sign)) AS total_blocks
+          FROM t
+          GROUP BY pipe_id
+        `,
+      })
+    }
+  }
+
+  async function seedRows() {
+    await client.command({
+      query: `
+        INSERT INTO t (pipe_id, block_number, payload, sign)
+        SELECT 'p1', number, concat('x', toString(number)), 1
+        FROM numbers(${ROW_COUNT})
+      `,
+    })
+  }
+
+  async function countPhysicalRows(): Promise<number> {
+    const res = await client.query({
+      query: 'SELECT count() AS c FROM t',
+      format: 'JSONEachRow',
+    })
+    const [row] = await res.json<{ c: string }>()
+    return Number(row?.c ?? 0)
+  }
+
+  async function runRollback(asyncInsert: 0 | 1): Promise<number> {
+    const before = await countPhysicalRows()
+    await client.command({
+      query: `
+        INSERT INTO t (pipe_id, block_number, payload, sign)
+        SELECT pipe_id, block_number, payload, -1 AS sign
+        FROM t FINAL
+        WHERE ${PARTITION_PREDICATE}
+      `,
+      query_params: { pipeId: 'p1' },
+      clickhouse_settings: {
+        async_insert: asyncInsert,
+        wait_for_async_insert: 1,
+      },
+    })
+    const after = await countPhysicalRows()
+    return after - before
+  }
+
+  async function mvTargetSum(): Promise<number | null> {
+    try {
+      const res = await client.query({
+        query: `SELECT sumMerge(total_blocks) AS s FROM t_mv_target WHERE pipe_id = 'p1'`,
+        format: 'JSONEachRow',
+      })
+      const [row] = await res.json<{ s: string }>()
+      return Number(row?.s ?? 0)
+    } catch {
+      return null
+    }
+  }
+
+  beforeAll(async () => {
+    const res = await client.query({ query: 'SELECT version() AS v', format: 'JSONEachRow' })
+    const [{ v }] = await res.json<{ v: string }>()
+    // biome-ignore lint/suspicious/noConsole: matrix output
+    console.log(`[PC-9] ClickHouse version: ${v}`)
+  })
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  for (const cell of matrix) {
+    it(`${cell.mergesState === 'stop' ? 'STOP MERGES' : 'MERGES ON'} / async_insert=${cell.asyncInsert} / ${cell.withMv ? 'with MV' : 'no MV'}`, async () => {
+      await resetTables(cell.withMv)
+      await seedRows()
+
+      if (cell.mergesState === 'stop') {
+        await client.command({ query: 'SYSTEM STOP MERGES t' })
+      }
+
+      const firstRun = await runRollback(cell.asyncInsert)
+      const secondRun = await runRollback(cell.asyncInsert)
+
+      if (cell.mergesState === 'stop') {
+        await client.command({ query: 'SYSTEM START MERGES t' })
+      }
+
+      const mvFirst = cell.withMv ? await mvTargetSum() : null
+      // biome-ignore lint/suspicious/noConsole: matrix output
+      console.log(
+        `[PC-9] cell=${JSON.stringify(cell)} firstRunInserted=${firstRun} secondRunInserted=${secondRun} mvFirst=${mvFirst}`,
+      )
+
+      // The first run must produce ROW_COUNT tombstones; the second must produce zero.
+      // Any non-zero second-run count flips the Phase-0 decision to branch (b) (temp-table fallback).
+      expect(firstRun).toBe(ROW_COUNT)
+      expect(secondRun).toBe(0)
+
+      if (cell.withMv) {
+        const mvSecond = await mvTargetSum()
+        expect(mvFirst).toBe(0)
+        expect(mvSecond).toBe(0)
+      }
+    }, 120_000)
+  }
+})

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   CheckpointTableEnsurer,
   type ColumnIntrospector,
+  RollbackSemaphore,
   type RollbackTarget,
   assertScopeIsolation,
   buildCheckpointTableDDL,
@@ -15,6 +16,8 @@ import {
   deriveMaxCursorOffsetCheck,
   dispatchRollback,
   extractIdentifiers,
+  getRollbackSemaphore,
+  jitteredBackoff,
   probeHasWorkToDo,
   resolveRollbackSettings,
   resolveTargetTable,
@@ -795,5 +798,104 @@ describe('dispatchRollback (chunked)', () => {
     })
     expect(result.kind).toBe('chunked')
     expect(command).toHaveBeenCalled()
+  })
+})
+
+describe('jitteredBackoff', () => {
+  it('computes base * (0.5 + random * jitter * 2) with injected rng', () => {
+    expect(jitteredBackoff(100, 0.5, () => 0)).toBe(50)
+    expect(jitteredBackoff(100, 0.5, () => 1)).toBe(150)
+    expect(jitteredBackoff(100, 0.5, () => 0.5)).toBe(100)
+  })
+
+  it('respects jitter=0 (no spread)', () => {
+    expect(jitteredBackoff(200, 0, () => 0)).toBe(100)
+    expect(jitteredBackoff(200, 0, () => 1)).toBe(100)
+  })
+
+  it('defaults to Math.random and falls inside [0.5×base, 1.5×base] for default jitter', () => {
+    for (let i = 0; i < 100; i++) {
+      const d = jitteredBackoff(1000, 0.5)
+      expect(d).toBeGreaterThanOrEqual(500)
+      expect(d).toBeLessThanOrEqual(1500)
+    }
+  })
+})
+
+describe('RollbackSemaphore', () => {
+  it('rejects concurrency < 1', () => {
+    expect(() => new RollbackSemaphore({ concurrency: 0, baseMs: 0, jitter: 0 })).toThrow()
+  })
+
+  it('caps in-flight at concurrency', async () => {
+    const sem = new RollbackSemaphore({ concurrency: 2, baseMs: 0, jitter: 0 })
+    let maxInFlight = 0
+    let active = 0
+
+    const work = async () => {
+      const release = await sem.acquire()
+      active++
+      maxInFlight = Math.max(maxInFlight, active)
+      await new Promise((r) => setTimeout(r, 5))
+      active--
+      release()
+    }
+
+    await Promise.all(Array.from({ length: 10 }, () => work()))
+    expect(maxInFlight).toBe(2)
+    expect(sem.inFlight).toBe(0)
+  })
+
+  it('runs acquires serially when concurrency = 1', async () => {
+    const sem = new RollbackSemaphore({ concurrency: 1, baseMs: 0, jitter: 0 })
+    const order: number[] = []
+
+    const work = async (id: number) => {
+      const release = await sem.acquire()
+      order.push(id)
+      await new Promise((r) => setTimeout(r, 2))
+      release()
+    }
+
+    await Promise.all([work(1), work(2), work(3)])
+    expect(order).toEqual([1, 2, 3])
+    expect(sem.inFlight).toBe(0)
+  })
+
+  it('applies jittered delay when waking waiters', async () => {
+    const sem = new RollbackSemaphore({ concurrency: 1, baseMs: 60, jitter: 0, rng: () => 0.5 })
+
+    const release1 = await sem.acquire()
+    const startedAt = Date.now()
+    let resumedAt = 0
+    const p = sem.acquire().then((r) => {
+      resumedAt = Date.now()
+      r()
+    })
+    release1()
+    await p
+    expect(resumedAt - startedAt).toBeGreaterThanOrEqual(25)
+  })
+})
+
+describe('getRollbackSemaphore', () => {
+  it('returns the same instance for the same (client, db) tuple', () => {
+    const client = {}
+    const a = getRollbackSemaphore({ client, db: 'default', concurrency: 2, baseMs: 10, jitter: 0 })
+    const b = getRollbackSemaphore({ client, db: 'default', concurrency: 2, baseMs: 10, jitter: 0 })
+    expect(a).toBe(b)
+  })
+
+  it('partitions by db', () => {
+    const client = {}
+    const a = getRollbackSemaphore({ client, db: 'db1', concurrency: 2, baseMs: 10, jitter: 0 })
+    const b = getRollbackSemaphore({ client, db: 'db2', concurrency: 2, baseMs: 10, jitter: 0 })
+    expect(a).not.toBe(b)
+  })
+
+  it('partitions by client', () => {
+    const a = getRollbackSemaphore({ client: {}, db: 'default', concurrency: 2, baseMs: 10, jitter: 0 })
+    const b = getRollbackSemaphore({ client: {}, db: 'default', concurrency: 2, baseMs: 10, jitter: 0 })
+    expect(a).not.toBe(b)
   })
 })

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  type ColumnIntrospector,
+  type RollbackTarget,
+  assertScopeIsolation,
+  buildMonolithicInsertSelectSql,
+  cursorColumnIsInSortKey,
+  extractIdentifiers,
+  resolveRollbackSettings,
+  resolveTargetTable,
+  runMonolithicCleanup,
+  sortKeyIdentifiers,
+  splitSortKeyEntries,
+} from '~/targets/clickhouse/clickhouse-rollback.js'
+import type { ClickhouseStore } from '~/targets/clickhouse/clickhouse-store.js'
+
+describe('resolveRollbackSettings', () => {
+  it('applies defaults when called with undefined', () => {
+    const r = resolveRollbackSettings()
+    expect(r).toEqual({
+      targets: [],
+      concurrency: 2,
+      chunkSize: 500_000,
+      retryBackoff: { baseMs: 250, jitter: 0.5 },
+      checkpointTable: '_sqd_rollback_checkpoint',
+    })
+  })
+
+  it('preserves user overrides and fills partial backoff', () => {
+    const r = resolveRollbackSettings({
+      targets: [{ table: 't', scopeWhere: '1' }],
+      concurrency: 5,
+      retryBackoff: { baseMs: 1000 },
+    })
+    expect(r.concurrency).toBe(5)
+    expect(r.chunkSize).toBe(500_000)
+    expect(r.retryBackoff).toEqual({ baseMs: 1000, jitter: 0.5 })
+    expect(r.targets).toHaveLength(1)
+  })
+})
+
+describe('splitSortKeyEntries', () => {
+  it('splits a simple tuple with outer parens', () => {
+    expect(splitSortKeyEntries('(a, b, c)')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('accepts no outer parens', () => {
+    expect(splitSortKeyEntries('a, b')).toEqual(['a', 'b'])
+  })
+
+  it('handles backtick-quoted identifiers containing commas-in-name', () => {
+    expect(splitSortKeyEntries('(`a,b`, c)')).toEqual(['`a,b`', 'c'])
+  })
+
+  it('respects paren depth for function-call entries', () => {
+    expect(splitSortKeyEntries('(toYYYYMM(ts), id)')).toEqual(['toYYYYMM(ts)', 'id'])
+  })
+
+  it('respects nested function-call paren depth', () => {
+    expect(splitSortKeyEntries('(cityHash64(a, b), c)')).toEqual(['cityHash64(a, b)', 'c'])
+  })
+})
+
+describe('extractIdentifiers', () => {
+  it('extracts a bare identifier', () => {
+    expect(Array.from(extractIdentifiers('block_number'))).toEqual(['block_number'])
+  })
+
+  it('skips function names but keeps operands', () => {
+    const ids = Array.from(extractIdentifiers('toYYYYMM(ts)'))
+    expect(ids).toContain('ts')
+    expect(ids).not.toContain('toYYYYMM')
+  })
+
+  it('extracts backtick-quoted identifiers', () => {
+    const ids = Array.from(extractIdentifiers('`weird name`'))
+    expect(ids).toEqual(['weird name'])
+  })
+
+  it('extracts nested function operands', () => {
+    const ids = Array.from(extractIdentifiers('cityHash64(a, b)'))
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    expect(ids).not.toContain('cityHash64')
+  })
+})
+
+describe('cursorColumnIsInSortKey (NB5 parity branches)', () => {
+  it('simple accept', () => {
+    expect(cursorColumnIsInSortKey('(block_number, id)', 'block_number')).toBe(true)
+  })
+
+  it('simple reject', () => {
+    expect(cursorColumnIsInSortKey('(block_number, id)', 'ts')).toBe(false)
+  })
+
+  it('accepts backtick-quoted sort key entries', () => {
+    expect(cursorColumnIsInSortKey('(`block_number`, id)', 'block_number')).toBe(true)
+  })
+
+  it('accepts when there are no outer parens', () => {
+    expect(cursorColumnIsInSortKey('block_number, id', 'id')).toBe(true)
+  })
+
+  it('accepts identifier used as an expression operand', () => {
+    expect(cursorColumnIsInSortKey('(toYYYYMM(ts), id)', 'ts')).toBe(true)
+  })
+
+  it('rejects when only the function name matches', () => {
+    expect(cursorColumnIsInSortKey('(toYYYYMM(ts), id)', 'toYYYYMM')).toBe(false)
+  })
+
+  it('accepts identifier as nested function argument', () => {
+    expect(cursorColumnIsInSortKey('(cityHash64(a, b), c)', 'b')).toBe(true)
+  })
+})
+
+describe('sortKeyIdentifiers', () => {
+  it('is the union of all entry identifiers', () => {
+    const ids = sortKeyIdentifiers('(toYYYYMM(ts), `x`, id)')
+    expect(ids.has('ts')).toBe(true)
+    expect(ids.has('x')).toBe(true)
+    expect(ids.has('id')).toBe(true)
+  })
+})
+
+describe('buildMonolithicInsertSelectSql', () => {
+  it('produces INSERT SELECT FINAL with sign=-1', () => {
+    const sql = buildMonolithicInsertSelectSql({
+      table: '"db"."t"',
+      columns: ['id', 'ts', 'sign'],
+      scopeWhere: 'id = {id:UInt64}',
+    })
+    expect(sql).toContain('INSERT INTO "db"."t" (id, ts, sign)')
+    expect(sql).toContain('SELECT id, ts, -1 AS sign')
+    expect(sql).toContain('FROM "db"."t" FINAL')
+    expect(sql).toContain('WHERE (id = {id:UInt64})')
+  })
+
+  it('excludes sign from the projected/inserted column list exactly once', () => {
+    const sql = buildMonolithicInsertSelectSql({
+      table: 't',
+      columns: ['a', 'sign', 'b'],
+      scopeWhere: '1',
+    })
+    expect(sql).toContain('(a, b, sign)')
+    expect(sql).toContain('SELECT a, b, -1 AS sign')
+  })
+
+  it('throws when no columns are provided', () => {
+    expect(() => buildMonolithicInsertSelectSql({ table: 't', columns: [], scopeWhere: '1' })).toThrow(
+      /no insertable columns/,
+    )
+  })
+})
+
+describe('resolveTargetTable', () => {
+  it('resolves unqualified table against defaultDb', () => {
+    expect(resolveTargetTable('t', 'mydb')).toEqual({
+      db: 'mydb',
+      unqualifiedTable: 't',
+      qualifiedTable: '"mydb"."t"',
+    })
+  })
+
+  it('splits db.tbl form', () => {
+    expect(resolveTargetTable('foo.bar', 'mydb')).toEqual({
+      db: 'foo',
+      unqualifiedTable: 'bar',
+      qualifiedTable: '"foo"."bar"',
+    })
+  })
+})
+
+describe('assertScopeIsolation', () => {
+  it('allows a single target with empty scopeWhere', () => {
+    const targets: RollbackTarget[] = [{ table: 't', scopeWhere: '' }]
+    expect(() => assertScopeIsolation(targets)).not.toThrow()
+  })
+
+  it('allows multiple targets on the same table with non-empty scopes', () => {
+    const targets: RollbackTarget[] = [
+      { table: 't', scopeWhere: "writer = 'a'" },
+      { table: 't', scopeWhere: "writer = 'b'" },
+    ]
+    expect(() => assertScopeIsolation(targets)).not.toThrow()
+  })
+
+  it('throws when multiple targets share a table and any scope is empty', () => {
+    const targets: RollbackTarget[] = [
+      { table: 't', scopeWhere: '' },
+      { table: 't', scopeWhere: "writer = 'b'" },
+    ]
+    expect(() => assertScopeIsolation(targets)).toThrow(/cross-writer tombstoning/)
+  })
+})
+
+describe('runMonolithicCleanup schema-drift retry', () => {
+  function makeStore(commands: Array<{ resolve?: unknown; reject?: unknown }>): ClickhouseStore {
+    let i = 0
+    const command = vi.fn(async () => {
+      const step = commands[i++]
+      if (!step) throw new Error('unexpected extra command call')
+      if (step.reject !== undefined) throw step.reject
+      return step.resolve
+    })
+    return { command } as unknown as ClickhouseStore
+  }
+
+  function makeIntrospector(columns: string[]) {
+    const invalidate = vi.fn()
+    const columnsFor = vi.fn(async () => columns)
+    return { invalidate, columnsFor, clear: vi.fn() } as unknown as ColumnIntrospector & {
+      invalidate: ReturnType<typeof vi.fn>
+      columnsFor: ReturnType<typeof vi.fn>
+    }
+  }
+
+  it('retries once after a schema-drift error and invalidates the cache', async () => {
+    const drift = Object.assign(new Error('mismatched'), { type: 'UNKNOWN_IDENTIFIER' })
+    const store = makeStore([{ reject: drift }, { resolve: undefined }])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    const result = await runMonolithicCleanup({
+      store,
+      introspector,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+    })
+
+    expect(result).toEqual({ kind: 'monolithic', table: '"db"."t"', rowsCanceled: null })
+    expect((introspector as any).invalidate).toHaveBeenCalledTimes(1)
+    expect((introspector as any).invalidate).toHaveBeenCalledWith('db', 't')
+  })
+
+  it('rethrows on a second consecutive schema-drift error', async () => {
+    const drift = Object.assign(new Error('mismatched'), { type: 'THERE_IS_NO_COLUMN' })
+    const store = makeStore([{ reject: drift }, { reject: drift }])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    await expect(
+      runMonolithicCleanup({
+        store,
+        introspector,
+        db: 'db',
+        table: '"db"."t"',
+        unqualifiedTable: 't',
+        scopeWhere: '1',
+      }),
+    ).rejects.toBe(drift)
+  })
+
+  it('rethrows non-schema-drift errors immediately without retrying', async () => {
+    const other = new Error('network exploded')
+    const store = makeStore([{ reject: other }])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    await expect(
+      runMonolithicCleanup({
+        store,
+        introspector,
+        db: 'db',
+        table: '"db"."t"',
+        unqualifiedTable: 't',
+        scopeWhere: '1',
+      }),
+    ).rejects.toBe(other)
+    expect((introspector as any).invalidate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -5,8 +5,11 @@ import {
   type RollbackTarget,
   assertScopeIsolation,
   buildMonolithicInsertSelectSql,
+  buildProbeSql,
   cursorColumnIsInSortKey,
+  dispatchRollback,
   extractIdentifiers,
+  probeHasWorkToDo,
   resolveRollbackSettings,
   resolveTargetTable,
   runMonolithicCleanup,
@@ -193,6 +196,157 @@ describe('assertScopeIsolation', () => {
       { table: 't', scopeWhere: "writer = 'b'" },
     ]
     expect(() => assertScopeIsolation(targets)).toThrow(/cross-writer tombstoning/)
+  })
+})
+
+describe('buildProbeSql', () => {
+  it('uses no FINAL and parameterizes column identifier + safeCursor', () => {
+    const sql = buildProbeSql({ table: '"db"."t"', scopeWhere: "writer = 'x'" })
+    expect(sql).not.toMatch(/FINAL/)
+    expect(sql).toContain('SELECT 1')
+    expect(sql).toContain('FROM "db"."t"')
+    expect(sql).toContain("WHERE (writer = 'x')")
+    expect(sql).toContain('{cursorColumn:Identifier}')
+    expect(sql).toContain('{safeCursor:UInt64}')
+    expect(sql).toContain('LIMIT 1')
+  })
+})
+
+describe('probeHasWorkToDo', () => {
+  function makeStore(rows: unknown[]) {
+    const query = vi.fn(async () => ({
+      json: async () => rows,
+    }))
+    return { store: { query } as unknown as ClickhouseStore, query }
+  }
+
+  it('returns false when the probe row set is empty', async () => {
+    const { store, query } = makeStore([])
+    const result = await probeHasWorkToDo({
+      store,
+      table: '"db"."t"',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 42 },
+    })
+    expect(result).toBe(false)
+    const call = (query.mock.calls as any[])[0]![0] as { query_params: Record<string, unknown> }
+    expect(call.query_params).toEqual({ cursorColumn: 'block_number', safeCursor: 42 })
+  })
+
+  it('returns true when the probe returns any row', async () => {
+    const { store } = makeStore([{ '1': 1 }])
+    const result = await probeHasWorkToDo({
+      store,
+      table: '"db"."t"',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 42 },
+    })
+    expect(result).toBe(true)
+  })
+
+  it('merges user queryParams without clobbering probe-reserved names', async () => {
+    const { store, query } = makeStore([])
+    await probeHasWorkToDo({
+      store,
+      table: 't',
+      scopeWhere: 'id = {id:UInt64}',
+      cursorColumn: 'bn',
+      safeCursor: { number: 99 },
+      queryParams: { id: 7 },
+    })
+    const call = (query.mock.calls as any[])[0]![0] as { query_params: Record<string, unknown> }
+    expect(call.query_params).toEqual({ id: 7, cursorColumn: 'bn', safeCursor: 99 })
+  })
+})
+
+describe('dispatchRollback', () => {
+  function makeStore(probeRows: unknown[] = []) {
+    const query = vi.fn(async () => ({ json: async () => probeRows }))
+    const command = vi.fn(async () => undefined)
+    return { store: { query, command } as unknown as ClickhouseStore, query, command }
+  }
+  function makeIntrospector(columns: string[]) {
+    return {
+      columnsFor: vi.fn(async () => columns),
+      invalidate: vi.fn(),
+      clear: vi.fn(),
+    } as unknown as ColumnIntrospector
+  }
+
+  it('short-circuits when cursorColumn+safeCursor are present and probe is empty', async () => {
+    const { store, command } = makeStore([])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    const result = await dispatchRollback({
+      store,
+      introspector,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 100 },
+    })
+
+    expect(result).toEqual({ kind: 'short_circuit', table: '"db"."t"' })
+    expect(command).not.toHaveBeenCalled()
+  })
+
+  it('runs monolithic when probe returns rows', async () => {
+    const { store, command } = makeStore([{ '1': 1 }])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    const result = await dispatchRollback({
+      store,
+      introspector,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 100 },
+    })
+
+    expect(result).toMatchObject({ kind: 'monolithic', table: '"db"."t"' })
+    expect(command).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips probe and runs monolithic when cursorColumn is absent', async () => {
+    const { store, query, command } = makeStore([])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    const result = await dispatchRollback({
+      store,
+      introspector,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+    })
+
+    expect(result).toMatchObject({ kind: 'monolithic' })
+    expect(query).not.toHaveBeenCalled()
+    expect(command).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips probe and runs monolithic when safeCursor is absent', async () => {
+    const { store, query, command } = makeStore([])
+    const introspector = makeIntrospector(['id', 'sign'])
+
+    await dispatchRollback({
+      store,
+      introspector,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+    })
+
+    expect(query).not.toHaveBeenCalled()
+    expect(command).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -899,3 +899,182 @@ describe('getRollbackSemaphore', () => {
     expect(a).not.toBe(b)
   })
 })
+
+describe('dispatchRollback log events (Phase 5)', () => {
+  const makeLogger = () => {
+    const events: Array<{ payload: any; msg: string }> = []
+    const fn = (payload: any, msg: string) => events.push({ payload, msg })
+    return {
+      logger: { info: fn, debug: fn, warn: fn, error: fn } as any,
+      events,
+    }
+  }
+
+  it('emits start with probeKind=none + end (monolithic) when no cursorColumn', async () => {
+    const { logger, events } = makeLogger()
+    const command = vi.fn().mockResolvedValue(undefined)
+    const query = vi.fn()
+    const store = { command, query } as unknown as ClickhouseStore
+    const introspector = {
+      columnsFor: vi.fn().mockResolvedValue(['id', 'value', 'sign']),
+      invalidate: vi.fn(),
+    } as unknown as ColumnIntrospector
+
+    await dispatchRollback({
+      store,
+      introspector,
+      db: 'default',
+      table: '"default"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      logger,
+      reason: 'offset_check',
+      stream: 'pipe1',
+    })
+
+    const starts = events.filter((e) => e.payload.event === 'rollback.start')
+    const ends = events.filter((e) => e.payload.event === 'rollback.end')
+    expect(starts).toHaveLength(1)
+    expect(ends).toHaveLength(1)
+    expect(starts[0]!.payload).toMatchObject({
+      event: 'rollback.start',
+      stream: 'pipe1',
+      table: '"default"."t"',
+      reason: 'offset_check',
+      cursorColumn: null,
+      safeCursor: null,
+      probeKind: 'none',
+    })
+    expect(ends[0]!.payload).toMatchObject({
+      event: 'rollback.end',
+      kind: 'monolithic',
+      stream: 'pipe1',
+      table: '"default"."t"',
+    })
+    expect(typeof ends[0]!.payload.totalDurationMs).toBe('number')
+  })
+
+  it('emits start + short_circuit end when probe finds no work', async () => {
+    const { logger, events } = makeLogger()
+    const query = vi.fn().mockResolvedValue({
+      json: async () => [],
+    })
+    const command = vi.fn()
+    const store = { command, query } as unknown as ClickhouseStore
+    const introspector = {
+      columnsFor: vi.fn(),
+      invalidate: vi.fn(),
+    } as unknown as ColumnIntrospector
+
+    await dispatchRollback({
+      store,
+      introspector,
+      db: 'default',
+      table: '"default"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 100, hash: 'h', timestamp: 0 },
+      logger,
+      reason: 'offset_check',
+      stream: 'pipe1',
+    })
+
+    const starts = events.filter((e) => e.payload.event === 'rollback.start')
+    const ends = events.filter((e) => e.payload.event === 'rollback.end')
+    expect(starts[0]!.payload).toMatchObject({
+      probeKind: 'exists',
+      cursorColumn: 'block_number',
+      safeCursor: 100,
+    })
+    expect(ends[0]!.payload).toMatchObject({
+      event: 'rollback.end',
+      kind: 'short_circuit',
+    })
+    expect(command).not.toHaveBeenCalled()
+  })
+
+  it('end-event keys exactly match the discriminated union (no stray fields)', async () => {
+    const { logger, events } = makeLogger()
+    const query = vi.fn().mockResolvedValue({ json: async () => [] })
+    const store = { command: vi.fn(), query } as unknown as ClickhouseStore
+    const introspector = {
+      columnsFor: vi.fn(),
+      invalidate: vi.fn(),
+    } as unknown as ColumnIntrospector
+
+    await dispatchRollback({
+      store,
+      introspector,
+      db: 'default',
+      table: '"default"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      safeCursor: { number: 100, hash: 'h', timestamp: 0 },
+      logger,
+    })
+
+    const end = events.find((e) => e.payload.event === 'rollback.end')!.payload
+    expect(Object.keys(end).sort()).toEqual(['event', 'kind', 'stream', 'table', 'totalDurationMs'].sort())
+  })
+})
+
+describe('runChunkedRollback log events (Phase 5)', () => {
+  it('emits a rollback.chunk event per completed chunk with chunkFrom/chunkTo/durationMs', async () => {
+    const events: Array<{ payload: any; msg: string }> = []
+    const fn = (payload: any, msg: string) => events.push({ payload, msg })
+    const logger = { info: fn, debug: fn, warn: fn, error: fn } as any
+
+    const command = vi.fn().mockResolvedValue(undefined)
+    const query = vi
+      .fn()
+      // readCheckpoint → no existing
+      .mockResolvedValueOnce({ json: async () => [] })
+      // deriveMaxCursorOffsetCheck → max=200
+      .mockResolvedValueOnce({ json: async () => [{ m: 200 }] })
+    const store = { command, query } as unknown as ClickhouseStore
+    const introspector = {
+      columnsFor: vi.fn().mockResolvedValue(['block_number', 'value', 'sign']),
+      invalidate: vi.fn(),
+    } as unknown as ColumnIntrospector
+    const ensurer = new CheckpointTableEnsurer()
+
+    const result = await runChunkedRollback({
+      store,
+      introspector,
+      ensurer,
+      db: 'default',
+      table: '"default"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      stream: 's1',
+      chunkSize: 50,
+      checkpointTable: '_sqd_rollback_checkpoint',
+      safeCursor: { number: 100, hash: 'h', timestamp: 0 },
+      reason: 'offset_check',
+      logger,
+    })
+
+    expect(result.kind).toBe('chunked')
+    const chunkEvents = events.filter((e) => e.payload.event === 'rollback.chunk')
+    expect(chunkEvents).toHaveLength(2)
+    expect(chunkEvents[0]!.payload).toMatchObject({
+      event: 'rollback.chunk',
+      stream: 's1',
+      table: '"default"."t"',
+      chunkIndex: 0,
+      chunkFrom: 100,
+      chunkTo: 150,
+    })
+    expect(chunkEvents[1]!.payload).toMatchObject({
+      chunkIndex: 1,
+      chunkFrom: 150,
+      chunkTo: 200,
+    })
+    for (const e of chunkEvents) {
+      expect(typeof e.payload.durationMs).toBe('number')
+    }
+  })
+})

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -876,6 +876,39 @@ describe('RollbackSemaphore', () => {
     await p
     expect(resumedAt - startedAt).toBeGreaterThanOrEqual(25)
   })
+
+  it('does not let a fast-path acquire steal a handed-off slot during wake-up delay', async () => {
+    // Reserve-on-handoff invariant: when `release()` finds a queued waiter,
+    // it must keep `#inFlight` at the cap so a fresh `acquire()` arriving
+    // during the jittered wake-up window cannot pass the fast path.
+    const sem = new RollbackSemaphore({ concurrency: 1, baseMs: 100, jitter: 0, rng: () => 0.5 })
+
+    const release1 = await sem.acquire()
+    const waiterP = sem.acquire()
+
+    release1()
+
+    // Fast-path acquire during the wake-up delay window. With the bug, this
+    // resolved immediately and pushed `#inFlight` to 2.
+    let stolen = false
+    const freshP = sem.acquire().then((r) => {
+      stolen = true
+      return r
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+    expect(sem.inFlight).toBeLessThanOrEqual(1)
+    expect(stolen).toBe(false)
+
+    const waiterRelease = await waiterP
+    expect(sem.inFlight).toBe(1)
+    waiterRelease()
+
+    const freshRelease = await freshP
+    expect(sem.inFlight).toBe(1)
+    freshRelease()
+    expect(sem.inFlight).toBe(0)
+  })
 })
 
 describe('getRollbackSemaphore', () => {
@@ -992,6 +1025,37 @@ describe('dispatchRollback log events (Phase 5)', () => {
       kind: 'short_circuit',
     })
     expect(command).not.toHaveBeenCalled()
+  })
+
+  it('reports probeKind=none when cursorColumn is set but safeCursor is missing', async () => {
+    // The probe only runs when BOTH cursorColumn and safeCursor are present;
+    // the start event must reflect that.
+    const { logger, events } = makeLogger()
+    const command = vi.fn().mockResolvedValue(undefined)
+    const query = vi.fn()
+    const store = { command, query } as unknown as ClickhouseStore
+    const introspector = {
+      columnsFor: vi.fn().mockResolvedValue(['id', 'value', 'sign']),
+      invalidate: vi.fn(),
+    } as unknown as ColumnIntrospector
+
+    await dispatchRollback({
+      store,
+      introspector,
+      db: 'default',
+      table: '"default"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'block_number',
+      logger,
+    })
+
+    const start = events.find((e) => e.payload.event === 'rollback.start')!.payload
+    expect(start).toMatchObject({
+      probeKind: 'none',
+      cursorColumn: 'block_number',
+      safeCursor: null,
+    })
   })
 
   it('end-event keys exactly match the discriminated union (no stray fields)', async () => {

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.test.ts
@@ -1,18 +1,28 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  CheckpointTableEnsurer,
   type ColumnIntrospector,
   type RollbackTarget,
   assertScopeIsolation,
+  buildCheckpointTableDDL,
+  buildChunkInsertSelectSql,
   buildMonolithicInsertSelectSql,
   buildProbeSql,
+  computeChunkBounds,
   cursorColumnIsInSortKey,
+  deriveMaxCursorBlockchainFork,
+  deriveMaxCursorOffsetCheck,
   dispatchRollback,
   extractIdentifiers,
   probeHasWorkToDo,
   resolveRollbackSettings,
   resolveTargetTable,
+  runChunkedRollback,
   runMonolithicCleanup,
+  sanitizeIdentifier,
+  snapshotOrphanPattern,
+  snapshotTableName,
   sortKeyIdentifiers,
   splitSortKeyEntries,
 } from '~/targets/clickhouse/clickhouse-rollback.js'
@@ -423,5 +433,367 @@ describe('runMonolithicCleanup schema-drift retry', () => {
       }),
     ).rejects.toBe(other)
     expect((introspector as any).invalidate).not.toHaveBeenCalled()
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// Phase 3 — chunked/resumable rollback
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeChunkBounds', () => {
+  it('returns zero chunks when range is empty', () => {
+    expect(computeChunkBounds({ safeCursor: 100, maxCursor: 100, chunkSize: 10 })).toEqual({
+      totalChunks: 0,
+      chunks: [],
+    })
+    expect(computeChunkBounds({ safeCursor: 100, maxCursor: 90, chunkSize: 10 })).toEqual({
+      totalChunks: 0,
+      chunks: [],
+    })
+  })
+
+  it('tiles (safeCursor, maxCursor] with half-open chunks', () => {
+    const r = computeChunkBounds({ safeCursor: 100, maxCursor: 250, chunkSize: 50 })
+    expect(r.totalChunks).toBe(3)
+    expect(r.chunks).toEqual([
+      { chunkFrom: 100, chunkTo: 150 },
+      { chunkFrom: 150, chunkTo: 200 },
+      { chunkFrom: 200, chunkTo: 250 },
+    ])
+  })
+
+  it('pins last chunkTo to maxCursor for non-divisible ranges', () => {
+    const r = computeChunkBounds({ safeCursor: 0, maxCursor: 25, chunkSize: 10 })
+    expect(r.totalChunks).toBe(3)
+    expect(r.chunks[2]).toEqual({ chunkFrom: 20, chunkTo: 25 })
+  })
+
+  it('rejects non-positive chunkSize', () => {
+    expect(() => computeChunkBounds({ safeCursor: 0, maxCursor: 10, chunkSize: 0 })).toThrow(/chunkSize/)
+  })
+})
+
+describe('deriveMaxCursorBlockchainFork', () => {
+  it('returns syncCurrent.number without running SQL', () => {
+    expect(deriveMaxCursorBlockchainFork({ syncCurrent: { number: 9_999 } })).toBe(9_999)
+  })
+})
+
+describe('deriveMaxCursorOffsetCheck', () => {
+  it('returns coalesce(max(col), safeCursor) from the server', async () => {
+    const query = vi.fn(async () => ({ json: async () => [{ m: 777 }] }))
+    const store = { query } as unknown as ClickhouseStore
+    const m = await deriveMaxCursorOffsetCheck({
+      store,
+      table: '"db"."t"',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      safeCursor: { number: 500 },
+    })
+    expect(m).toBe(777)
+    const call = (query.mock.calls as any[])[0]![0]
+    expect(call.query_params).toMatchObject({ cursorColumn: 'bn', safeCursor: 500 })
+    expect(call.query).not.toMatch(/FINAL/)
+  })
+
+  it('falls back to safeCursor when the server returns no row', async () => {
+    const query = vi.fn(async () => ({ json: async () => [] }))
+    const store = { query } as unknown as ClickhouseStore
+    const m = await deriveMaxCursorOffsetCheck({
+      store,
+      table: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      safeCursor: { number: 42 },
+    })
+    expect(m).toBe(42)
+  })
+})
+
+describe('snapshot table naming (5b)', () => {
+  it('sanitizes punctuation and mixed case to [a-z0-9_]', () => {
+    expect(sanitizeIdentifier('Foo-Bar.Baz Qux')).toBe('foo_bar_baz_qux')
+    expect(sanitizeIdentifier('abc123')).toBe('abc123')
+  })
+
+  it('builds deterministic snapshot table names', () => {
+    expect(snapshotTableName({ streamSafe: 's1', tableSafe: 't1', startedAtUnix: 1_234_567_890 })).toBe(
+      '_sqd_chunk_snapshot_s1_t1_1234567890',
+    )
+  })
+
+  it('builds an anchored regex pattern that avoids LIKE _ wildcard collisions', () => {
+    const pattern = snapshotOrphanPattern('s1', 't1')
+    const rx = new RegExp(pattern)
+    expect(rx.test('_sqd_chunk_snapshot_s1_t1_1234567890')).toBe(true)
+    expect(rx.test('_sqd_chunk_snapshot_s1_t1_other')).toBe(false)
+    expect(rx.test('_sqd_chunk_snapshot_s1_t1_')).toBe(false)
+    expect(rx.test('_sqd_chunk_snapshot_s1other_t1_1234567890')).toBe(false)
+  })
+})
+
+describe('buildChunkInsertSelectSql', () => {
+  it('produces a half-open bounded INSERT SELECT FINAL', () => {
+    const sql = buildChunkInsertSelectSql({
+      table: '"db"."t"',
+      columns: ['id', 'ts', 'sign'],
+      scopeWhere: '1',
+    })
+    expect(sql).toContain('INSERT INTO "db"."t" (id, ts, sign)')
+    expect(sql).toContain('SELECT id, ts, -1 AS sign')
+    expect(sql).toContain('FROM "db"."t" FINAL')
+    expect(sql).toContain('WHERE (1)')
+    expect(sql).toContain('{cursorColumn:Identifier} >  {chunkFrom:UInt64}')
+    expect(sql).toContain('{cursorColumn:Identifier} <= {chunkTo:UInt64}')
+  })
+})
+
+describe('buildCheckpointTableDDL', () => {
+  it('declares all 7 non-sign columns and TTL + ORDER BY', () => {
+    const ddl = buildCheckpointTableDDL('"db"."_sqd_rollback_checkpoint"')
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS "db"."_sqd_rollback_checkpoint"')
+    expect(ddl).toContain('stream              String')
+    expect(ddl).toContain('table_name          String')
+    expect(ddl).toContain('started_at          DateTime')
+    expect(ddl).toContain('safe_cursor         UInt64')
+    expect(ddl).toContain('max_cursor          UInt64')
+    expect(ddl).toContain('chunk_size          UInt64')
+    expect(ddl).toContain('last_completed_chunk Int64')
+    expect(ddl).toContain('ENGINE = CollapsingMergeTree(sign)')
+    expect(ddl).toContain('ORDER BY (stream, table_name, started_at)')
+    expect(ddl).toContain('TTL started_at + INTERVAL 7 DAY')
+  })
+})
+
+describe('CheckpointTableEnsurer', () => {
+  it('issues the DDL once per (db, table) key', async () => {
+    const command = vi.fn(async () => undefined)
+    const store = { command } as unknown as ClickhouseStore
+    const ensurer = new CheckpointTableEnsurer()
+
+    const q1 = await ensurer.ensure({ store, db: 'db', checkpointTable: '_sqd_rollback_checkpoint' })
+    const q2 = await ensurer.ensure({ store, db: 'db', checkpointTable: '_sqd_rollback_checkpoint' })
+    expect(q1).toBe('"db"."_sqd_rollback_checkpoint"')
+    expect(q1).toBe(q2)
+    expect(command).toHaveBeenCalledTimes(1)
+
+    await ensurer.ensure({ store, db: 'other', checkpointTable: '_sqd_rollback_checkpoint' })
+    expect(command).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('runChunkedRollback', () => {
+  type MockStore = {
+    command: ReturnType<typeof vi.fn>
+    query: ReturnType<typeof vi.fn>
+  }
+
+  function buildStore(opts: { checkpointRows: unknown[]; maxCursor?: number }): {
+    store: ClickhouseStore
+    mock: MockStore
+  } {
+    const command = vi.fn(async () => undefined)
+    // order of query() calls: (1) read checkpoint, (2) maybe deriveMaxCursor
+    const results: Array<{ json: () => Promise<unknown[]> }> = [{ json: async () => opts.checkpointRows }]
+    if (opts.maxCursor !== undefined) {
+      results.push({ json: async () => [{ m: opts.maxCursor }] })
+    }
+    let i = 0
+    const query = vi.fn(async () => {
+      const r = results[i++]
+      if (!r) throw new Error('unexpected extra query call')
+      return r
+    })
+    return { store: { command, query } as unknown as ClickhouseStore, mock: { command, query } }
+  }
+
+  function introspector(columns: string[]) {
+    return {
+      columnsFor: vi.fn(async () => columns),
+      invalidate: vi.fn(),
+      clear: vi.fn(),
+    } as unknown as ColumnIntrospector
+  }
+
+  it('fresh rollback: derives max_cursor, writes init, runs N chunks + advances, retires', async () => {
+    const { store, mock } = buildStore({ checkpointRows: [], maxCursor: 220 })
+    const ensurer = new CheckpointTableEnsurer()
+    const result = await runChunkedRollback({
+      store,
+      introspector: introspector(['id', 'sign']),
+      ensurer,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      stream: 's1',
+      chunkSize: 100,
+      checkpointTable: '_sqd_rollback_checkpoint',
+      safeCursor: { number: 100 },
+      reason: 'offset_check',
+    })
+    // commands: ensure-DDL + init-write + 2 chunk INSERTs + 2 advances + retire = 7
+    expect(mock.command).toHaveBeenCalledTimes(7)
+    expect(result).toMatchObject({
+      kind: 'chunked',
+      table: '"db"."t"',
+      chunksPlanned: 2,
+      chunksCompleted: 2,
+      resumed: false,
+    })
+  })
+
+  it('blockchain_fork: uses syncCurrent.number as max_cursor, never runs derive SELECT', async () => {
+    const { store, mock } = buildStore({ checkpointRows: [] }) // no maxCursor → query will fail if called
+    const ensurer = new CheckpointTableEnsurer()
+    const result = await runChunkedRollback({
+      store,
+      introspector: introspector(['id', 'sign']),
+      ensurer,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      stream: 's1',
+      chunkSize: 50,
+      checkpointTable: '_sqd_rollback_checkpoint',
+      safeCursor: { number: 0 },
+      reason: 'blockchain_fork',
+      syncCurrent: { number: 120 },
+    })
+    expect(result).toMatchObject({ kind: 'chunked', chunksPlanned: 3, chunksCompleted: 3, resumed: false })
+    // query was used only for readCheckpoint (one call)
+    expect(mock.query).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws if blockchain_fork and syncCurrent is absent', async () => {
+    const { store } = buildStore({ checkpointRows: [] })
+    await expect(
+      runChunkedRollback({
+        store,
+        introspector: introspector(['id', 'sign']),
+        ensurer: new CheckpointTableEnsurer(),
+        db: 'db',
+        table: '"db"."t"',
+        unqualifiedTable: 't',
+        scopeWhere: '1',
+        cursorColumn: 'bn',
+        stream: 's1',
+        chunkSize: 50,
+        checkpointTable: '_sqd_rollback_checkpoint',
+        safeCursor: { number: 0 },
+        reason: 'blockchain_fork',
+      }),
+    ).rejects.toThrow(/syncCurrent/)
+  })
+
+  it('resume: skips init write and picks up at last_completed_chunk + 1', async () => {
+    const { store, mock } = buildStore({
+      checkpointRows: [
+        {
+          stream: 's1',
+          table_name: '"db"."t"',
+          safe_cursor: 100,
+          max_cursor: 220,
+          chunk_size: 100,
+          last_completed_chunk: 0, // completed chunk 0; should run chunk 1 next
+          started_at_unix: 1_700_000_000,
+        },
+      ],
+    })
+    const ensurer = new CheckpointTableEnsurer()
+    const result = await runChunkedRollback({
+      store,
+      introspector: introspector(['id', 'sign']),
+      ensurer,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      stream: 's1',
+      chunkSize: 100, // ignored — resume pulls chunk_size from checkpoint
+      checkpointTable: '_sqd_rollback_checkpoint',
+      safeCursor: { number: 100 },
+      reason: 'offset_check',
+    })
+    // commands: ensure-DDL + 1 chunk INSERT + 1 advance + retire = 4 (no init-write)
+    expect(mock.command).toHaveBeenCalledTimes(4)
+    expect(result).toMatchObject({ chunksPlanned: 2, chunksCompleted: 1, resumed: true })
+  })
+
+  it('PC-3 shortcut: resume with last_completed_chunk+1 == totalChunks runs no chunks', async () => {
+    const { store, mock } = buildStore({
+      checkpointRows: [
+        {
+          stream: 's1',
+          table_name: '"db"."t"',
+          safe_cursor: 100,
+          max_cursor: 220,
+          chunk_size: 100,
+          last_completed_chunk: 1, // all 2 chunks done; only retire remains
+          started_at_unix: 1_700_000_000,
+        },
+      ],
+    })
+    const ensurer = new CheckpointTableEnsurer()
+    const result = await runChunkedRollback({
+      store,
+      introspector: introspector(['id', 'sign']),
+      ensurer,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      stream: 's1',
+      chunkSize: 100,
+      checkpointTable: '_sqd_rollback_checkpoint',
+      safeCursor: { number: 100 },
+      reason: 'offset_check',
+    })
+    // commands: ensure-DDL + retire = 2 (no chunk, no advance)
+    expect(mock.command).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({ chunksPlanned: 2, chunksCompleted: 0, resumed: true })
+  })
+})
+
+describe('dispatchRollback (chunked)', () => {
+  it('runs chunked path when probe returns rows and chunked config is supplied', async () => {
+    const probe = { json: async () => [{ '1': 1 }] } // probe hit
+    const max = { json: async () => [{ m: 200 }] }
+    const readCp = { json: async () => [] }
+    const results = [probe, readCp, max]
+    let i = 0
+    const query = vi.fn(async () => results[i++]!)
+    const command = vi.fn(async () => undefined)
+    const store = { query, command } as unknown as ClickhouseStore
+    const introspectorMock = {
+      columnsFor: vi.fn(async () => ['id', 'sign']),
+      invalidate: vi.fn(),
+      clear: vi.fn(),
+    } as unknown as ColumnIntrospector
+
+    const result = await dispatchRollback({
+      store,
+      introspector: introspectorMock,
+      db: 'db',
+      table: '"db"."t"',
+      unqualifiedTable: 't',
+      scopeWhere: '1',
+      cursorColumn: 'bn',
+      safeCursor: { number: 100 },
+      chunked: {
+        ensurer: new CheckpointTableEnsurer(),
+        stream: 's1',
+        chunkSize: 50,
+        checkpointTable: '_sqd_rollback_checkpoint',
+        reason: 'offset_check',
+      },
+    })
+    expect(result.kind).toBe('chunked')
+    expect(command).toHaveBeenCalled()
   })
 })

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -361,6 +361,464 @@ export async function runMonolithicCleanup(params: {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Chunked + resumable rollback (Phase 3)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Per-chunk half-open window `(chunkFrom, chunkTo]`. Symmetric with probe's `> safeCursor`. */
+export type ChunkBounds = { chunkFrom: number; chunkTo: number }
+
+/**
+ * Compute the chunk tiling for `(safeCursor, maxCursor]` with `chunkSize`.
+ * Chunk n covers `(safeCursor + n*size, min(safeCursor + (n+1)*size, maxCursor)]`.
+ * Empty range (`maxCursor <= safeCursor`) yields `totalChunks = 0`.
+ */
+export function computeChunkBounds(params: { safeCursor: number; maxCursor: number; chunkSize: number }): {
+  totalChunks: number
+  chunks: ChunkBounds[]
+} {
+  const { safeCursor, maxCursor, chunkSize } = params
+  if (chunkSize <= 0) throw new Error('clickhouseTarget: chunkSize must be > 0')
+  const total = maxCursor - safeCursor
+  if (total <= 0) return { totalChunks: 0, chunks: [] }
+  const totalChunks = Math.ceil(total / chunkSize)
+  const chunks: ChunkBounds[] = []
+  for (let n = 0; n < totalChunks; n++) {
+    const chunkFrom = safeCursor + chunkSize * n
+    const chunkTo = Math.min(chunkFrom + chunkSize, maxCursor)
+    chunks.push({ chunkFrom, chunkTo })
+  }
+  return { totalChunks, chunks }
+}
+
+/** Derive `max_cursor` for the `offset_check` path via a bounded MAX query (no FINAL). */
+export async function deriveMaxCursorOffsetCheck(params: {
+  store: ClickhouseStore
+  table: string
+  scopeWhere: string
+  cursorColumn: string
+  safeCursor: BlockCursor
+  queryParams?: Record<string, unknown>
+}): Promise<number> {
+  const { store, table, scopeWhere, cursorColumn, safeCursor, queryParams } = params
+  const sql = `SELECT coalesce(max({cursorColumn:Identifier}), {safeCursor:UInt64}) AS m
+FROM ${table}
+WHERE (${scopeWhere})
+  AND {cursorColumn:Identifier} > {safeCursor:UInt64}`
+  const res = await store.query({
+    query: sql,
+    format: 'JSONEachRow',
+    query_params: { ...(queryParams ?? {}), cursorColumn, safeCursor: safeCursor.number },
+  })
+  const rows = await res.json<{ m: string | number }>()
+  if (rows.length === 0) return safeCursor.number
+  return Number(rows[0]!.m)
+}
+
+/**
+ * Derive `max_cursor` for the `blockchain_fork` path. Never queries the store —
+ * returns `syncCurrent.number` captured at fork-handler entry via
+ * `state.snapshotCurrent()` (R-B freeze).
+ */
+export function deriveMaxCursorBlockchainFork(params: { syncCurrent: BlockCursor }): number {
+  return params.syncCurrent.number
+}
+
+/** Sanitize a stream/table identifier to `[a-z0-9_]` form for snapshot-table naming (5b). */
+export function sanitizeIdentifier(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '_')
+}
+
+/** Build the chunk-snapshot temp-table name used by Phase-0 branch (b) / Step 5b. */
+export function snapshotTableName(params: { streamSafe: string; tableSafe: string; startedAtUnix: number }): string {
+  const { streamSafe, tableSafe, startedAtUnix } = params
+  return `_sqd_chunk_snapshot_${streamSafe}_${tableSafe}_${startedAtUnix}`
+}
+
+/** Build the anchored regex pattern that matches orphan snapshot tables for a (stream, table) pair. */
+export function snapshotOrphanPattern(streamSafe: string, tableSafe: string): string {
+  return `^_sqd_chunk_snapshot_${streamSafe}_${tableSafe}_[0-9]+$`
+}
+
+/** DDL for the checkpoint table. */
+export function buildCheckpointTableDDL(qualifiedTable: string): string {
+  return `CREATE TABLE IF NOT EXISTS ${qualifiedTable}
+(
+  stream              String,
+  table_name          String,
+  started_at          DateTime,
+  safe_cursor         UInt64,
+  max_cursor          UInt64,
+  chunk_size          UInt64,
+  last_completed_chunk Int64,
+  sign                Int8
+) ENGINE = CollapsingMergeTree(sign)
+  ORDER BY (stream, table_name, started_at)
+  TTL started_at + INTERVAL 7 DAY`
+}
+
+type CheckpointRow = {
+  stream: string
+  table_name: string
+  safe_cursor: number
+  max_cursor: number
+  chunk_size: number
+  last_completed_chunk: number
+  started_at_unix: number
+}
+
+/**
+ * Lazy `CREATE TABLE IF NOT EXISTS` for the per-database checkpoint table.
+ * Caches the "already created" flag by `(store, db, checkpointTable)` so a
+ * hot rollback path doesn't re-issue DDL every invocation.
+ */
+export class CheckpointTableEnsurer {
+  #created = new Set<string>()
+
+  async ensure(params: { store: ClickhouseStore; db: string; checkpointTable: string }): Promise<string> {
+    const { store, db, checkpointTable } = params
+    const qualified = `"${db}"."${checkpointTable}"`
+    const key = `${db}.${checkpointTable}`
+    if (this.#created.has(key)) return qualified
+    await store.command({ query: buildCheckpointTableDDL(qualified) })
+    this.#created.add(key)
+    return qualified
+  }
+
+  /** Test-only: clears the per-(db, table) created cache. */
+  reset() {
+    this.#created.clear()
+  }
+}
+
+async function readCheckpoint(params: {
+  store: ClickhouseStore
+  qualifiedCheckpointTable: string
+  stream: string
+  tableName: string
+}): Promise<CheckpointRow | null> {
+  const { store, qualifiedCheckpointTable, stream, tableName } = params
+  const res = await store.query({
+    query: `SELECT stream, table_name, safe_cursor, max_cursor, chunk_size, last_completed_chunk,
+       toUnixTimestamp(started_at) AS started_at_unix
+FROM ${qualifiedCheckpointTable} FINAL
+WHERE stream = {stream:String} AND table_name = {table:String}
+ORDER BY started_at DESC
+LIMIT 1`,
+    format: 'JSONEachRow',
+    query_params: { stream, table: tableName },
+  })
+  const rows = await res.json<{
+    stream: string
+    table_name: string
+    safe_cursor: string | number
+    max_cursor: string | number
+    chunk_size: string | number
+    last_completed_chunk: string | number
+    started_at_unix: string | number
+  }>()
+  if (rows.length === 0) return null
+  const r = rows[0]!
+  return {
+    stream: r.stream,
+    table_name: r.table_name,
+    safe_cursor: Number(r.safe_cursor),
+    max_cursor: Number(r.max_cursor),
+    chunk_size: Number(r.chunk_size),
+    last_completed_chunk: Number(r.last_completed_chunk),
+    started_at_unix: Number(r.started_at_unix),
+  }
+}
+
+async function writeInitialCheckpoint(params: {
+  store: ClickhouseStore
+  qualifiedCheckpointTable: string
+  row: Omit<CheckpointRow, 'started_at_unix' | 'last_completed_chunk'>
+  startedAtUnix: number
+}): Promise<void> {
+  const { store, qualifiedCheckpointTable, row, startedAtUnix } = params
+  await store.command({
+    query: `INSERT INTO ${qualifiedCheckpointTable}
+(stream, table_name, started_at, safe_cursor, max_cursor, chunk_size, last_completed_chunk, sign)
+VALUES ({stream:String}, {table:String}, fromUnixTimestamp({startedAtUnix:UInt32}),
+        {safeCursor:UInt64}, {maxCursor:UInt64}, {chunkSize:UInt64}, -1, 1)`,
+    query_params: {
+      stream: row.stream,
+      table: row.table_name,
+      startedAtUnix,
+      safeCursor: row.safe_cursor,
+      maxCursor: row.max_cursor,
+      chunkSize: row.chunk_size,
+    },
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
+  })
+}
+
+async function advanceCheckpoint(params: {
+  store: ClickhouseStore
+  qualifiedCheckpointTable: string
+  row: Omit<CheckpointRow, 'started_at_unix' | 'last_completed_chunk'>
+  startedAtUnix: number
+  prev: number
+  next: number
+}): Promise<void> {
+  const { store, qualifiedCheckpointTable, row, startedAtUnix, prev, next } = params
+  // Two-row INSERT: sign=-1 on prev, sign=+1 on next. Non-sign columns byte-equal.
+  await store.command({
+    query: `INSERT INTO ${qualifiedCheckpointTable}
+(stream, table_name, started_at, safe_cursor, max_cursor, chunk_size, last_completed_chunk, sign)
+VALUES
+  ({stream:String}, {table:String}, fromUnixTimestamp({startedAtUnix:UInt32}),
+   {safeCursor:UInt64}, {maxCursor:UInt64}, {chunkSize:UInt64}, {prev:Int64}, -1),
+  ({stream:String}, {table:String}, fromUnixTimestamp({startedAtUnix:UInt32}),
+   {safeCursor:UInt64}, {maxCursor:UInt64}, {chunkSize:UInt64}, {next:Int64}, 1)`,
+    query_params: {
+      stream: row.stream,
+      table: row.table_name,
+      startedAtUnix,
+      safeCursor: row.safe_cursor,
+      maxCursor: row.max_cursor,
+      chunkSize: row.chunk_size,
+      prev,
+      next,
+    },
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
+  })
+}
+
+async function retireCheckpoint(params: {
+  store: ClickhouseStore
+  qualifiedCheckpointTable: string
+  row: Omit<CheckpointRow, 'started_at_unix'>
+  startedAtUnix: number
+}): Promise<void> {
+  const { store, qualifiedCheckpointTable, row, startedAtUnix } = params
+  await store.command({
+    query: `INSERT INTO ${qualifiedCheckpointTable}
+(stream, table_name, started_at, safe_cursor, max_cursor, chunk_size, last_completed_chunk, sign)
+VALUES ({stream:String}, {table:String}, fromUnixTimestamp({startedAtUnix:UInt32}),
+        {safeCursor:UInt64}, {maxCursor:UInt64}, {chunkSize:UInt64}, {last:Int64}, -1)`,
+    query_params: {
+      stream: row.stream,
+      table: row.table_name,
+      startedAtUnix,
+      safeCursor: row.safe_cursor,
+      maxCursor: row.max_cursor,
+      chunkSize: row.chunk_size,
+      last: row.last_completed_chunk,
+    },
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 1 },
+  })
+}
+
+/**
+ * Build the per-chunk INSERT SELECT FINAL statement (Phase 3 Step 5a —
+ * provisional Phase-0 branch (a)). Chunk uses half-open `(chunkFrom, chunkTo]`.
+ */
+export function buildChunkInsertSelectSql(params: { table: string; columns: string[]; scopeWhere: string }): string {
+  const { table, columns, scopeWhere } = params
+  if (columns.length === 0) {
+    throw new Error(`clickhouseTarget: no insertable columns resolved for table ${table}`)
+  }
+  const nonSignCols = columns.filter((c) => c !== 'sign')
+  const colList = nonSignCols.join(', ')
+  return `INSERT INTO ${table} (${colList}, sign)
+SELECT ${colList}, -1 AS sign
+FROM ${table} FINAL
+WHERE (${scopeWhere})
+  AND {cursorColumn:Identifier} >  {chunkFrom:UInt64}
+  AND {cursorColumn:Identifier} <= {chunkTo:UInt64}`
+}
+
+export type ChunkedRollbackContext = {
+  store: ClickhouseStore
+  introspector: ColumnIntrospector
+  ensurer: CheckpointTableEnsurer
+  db: string
+  table: string
+  unqualifiedTable: string
+  scopeWhere: string
+  cursorColumn: string
+  queryParams?: Record<string, unknown>
+  stream: string
+  chunkSize: number
+  checkpointTable: string
+  /** Required. For `offset_check` use `safeCursor` directly; for `blockchain_fork` the cursor is the fork-resolved one. */
+  safeCursor: BlockCursor
+  /** Required — which `max_cursor` derivation branch to pick. */
+  reason: RollbackReason
+  /** Only used when `reason === 'blockchain_fork'`. */
+  syncCurrent?: BlockCursor
+  logger?: Logger
+}
+
+/**
+ * Orchestrates a chunked, resumable rollback for one target:
+ *   1. ensure checkpoint table exists
+ *   2. resume check (FINAL read)
+ *   3. on fresh: derive `max_cursor` per `reason`, write initial checkpoint (sign=+1)
+ *   4. chunk loop: INSERT SELECT FINAL per chunk, then atomic 2-row advance
+ *   5. retire write (sign=-1)
+ *   6. return `{kind: 'chunked', chunksPlanned, chunksCompleted, resumed}`
+ *
+ * PC-3 shortcut: if resume found `last_completed_chunk + 1 === totalChunks`,
+ * skip the chunk loop and jump straight to retire.
+ */
+export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<RollbackResult> {
+  const {
+    store,
+    introspector,
+    ensurer,
+    db,
+    table,
+    unqualifiedTable,
+    scopeWhere,
+    cursorColumn,
+    queryParams,
+    stream,
+    chunkSize,
+    checkpointTable,
+    safeCursor,
+    reason,
+    syncCurrent,
+    logger,
+  } = ctx
+
+  const qualifiedCheckpointTable = await ensurer.ensure({ store, db, checkpointTable })
+
+  const existing = await readCheckpoint({
+    store,
+    qualifiedCheckpointTable,
+    stream,
+    tableName: table,
+  })
+
+  let resumed = false
+  let safe_cursor: number
+  let max_cursor: number
+  let chunk_size: number
+  let startedAtUnix: number
+  let last_completed_chunk: number
+
+  if (existing) {
+    resumed = true
+    safe_cursor = existing.safe_cursor
+    max_cursor = existing.max_cursor
+    chunk_size = existing.chunk_size
+    last_completed_chunk = existing.last_completed_chunk
+    startedAtUnix = existing.started_at_unix
+    logger?.debug?.(
+      { event: 'rollback.chunked.resume', table, last_completed_chunk, max_cursor },
+      'resumed chunked rollback from checkpoint',
+    )
+  } else {
+    // Fresh rollback: derive max_cursor per reason.
+    if (reason === 'blockchain_fork') {
+      if (!syncCurrent) {
+        throw new Error('clickhouseTarget: blockchain_fork chunked rollback requires syncCurrent')
+      }
+      max_cursor = deriveMaxCursorBlockchainFork({ syncCurrent })
+    } else {
+      max_cursor = await deriveMaxCursorOffsetCheck({
+        store,
+        table,
+        scopeWhere,
+        cursorColumn,
+        safeCursor,
+        queryParams,
+      })
+    }
+    safe_cursor = safeCursor.number
+    chunk_size = chunkSize
+    startedAtUnix = Math.floor(Date.now() / 1000)
+    last_completed_chunk = -1
+
+    await writeInitialCheckpoint({
+      store,
+      qualifiedCheckpointTable,
+      row: {
+        stream,
+        table_name: table,
+        safe_cursor,
+        max_cursor,
+        chunk_size,
+      },
+      startedAtUnix,
+    })
+  }
+
+  const { totalChunks, chunks } = computeChunkBounds({
+    safeCursor: safe_cursor,
+    maxCursor: max_cursor,
+    chunkSize: chunk_size,
+  })
+
+  const columns = await introspector.columnsFor(db, unqualifiedTable)
+  const chunkSql = buildChunkInsertSelectSql({ table, columns, scopeWhere })
+
+  let chunksCompleted = 0
+  const nextChunkIndex = last_completed_chunk + 1
+
+  // PC-3 shortcut: if fully completed before crash, skip chunk loop.
+  if (nextChunkIndex < totalChunks) {
+    for (let n = nextChunkIndex; n < totalChunks; n++) {
+      const { chunkFrom, chunkTo } = chunks[n]!
+      await store.command({
+        query: chunkSql,
+        query_params: {
+          ...(queryParams ?? {}),
+          cursorColumn,
+          chunkFrom,
+          chunkTo,
+        },
+      })
+      await advanceCheckpoint({
+        store,
+        qualifiedCheckpointTable,
+        row: {
+          stream,
+          table_name: table,
+          safe_cursor,
+          max_cursor,
+          chunk_size,
+        },
+        startedAtUnix,
+        prev: last_completed_chunk,
+        next: n,
+      })
+      last_completed_chunk = n
+      chunksCompleted++
+    }
+  }
+
+  await retireCheckpoint({
+    store,
+    qualifiedCheckpointTable,
+    row: {
+      stream,
+      table_name: table,
+      safe_cursor,
+      max_cursor,
+      chunk_size,
+      last_completed_chunk,
+    },
+    startedAtUnix,
+  })
+
+  logger?.debug?.(
+    { event: 'rollback.chunked.end', table, chunksPlanned: totalChunks, chunksCompleted, resumed },
+    'chunked rollback complete',
+  )
+
+  return {
+    kind: 'chunked',
+    table,
+    chunksPlanned: totalChunks,
+    chunksCompleted,
+    resumed,
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Dispatch: probe → short-circuit | monolithic (Phase 2 Step 2)
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -372,6 +830,20 @@ export async function runMonolithicCleanup(params: {
  * Phase 3 will replace the monolithic fallthrough with the chunked/resumable
  * path when both inputs are present.
  */
+/**
+ * Opt-in chunked-path configuration. Only the SDK-managed rollback populates
+ * this; the user-facing `store.removeAllRows` leaves it undefined and gets
+ * probe + monolithic behavior.
+ */
+export type ChunkedDispatchConfig = {
+  ensurer: CheckpointTableEnsurer
+  stream: string
+  chunkSize: number
+  checkpointTable: string
+  reason: RollbackReason
+  syncCurrent?: BlockCursor
+}
+
 export async function dispatchRollback(params: {
   store: ClickhouseStore
   introspector: ColumnIntrospector
@@ -383,6 +855,7 @@ export async function dispatchRollback(params: {
   safeCursor?: BlockCursor
   queryParams?: Record<string, unknown>
   logger?: Logger
+  chunked?: ChunkedDispatchConfig
 }): Promise<RollbackResult> {
   const {
     store,
@@ -395,6 +868,7 @@ export async function dispatchRollback(params: {
     safeCursor,
     queryParams,
     logger,
+    chunked,
   } = params
 
   if (cursorColumn && safeCursor) {
@@ -412,6 +886,28 @@ export async function dispatchRollback(params: {
         'managed rollback short-circuited; probe found no rows past safeCursor',
       )
       return { kind: 'short_circuit', table }
+    }
+
+    // Probe returned true — choose chunked path if configured, else monolithic.
+    if (chunked) {
+      return runChunkedRollback({
+        store,
+        introspector,
+        ensurer: chunked.ensurer,
+        db,
+        table,
+        unqualifiedTable,
+        scopeWhere,
+        cursorColumn,
+        queryParams,
+        stream: chunked.stream,
+        chunkSize: chunked.chunkSize,
+        checkpointTable: chunked.checkpointTable,
+        safeCursor,
+        reason: chunked.reason,
+        syncCurrent: chunked.syncCurrent,
+        logger,
+      })
     }
   }
 
@@ -457,6 +953,13 @@ export type ManagedRollbackContext = {
   logger?: Logger
   /** Phase 3 consumer: the in-memory cursor captured before `state.fork()` ran. */
   syncCurrent?: BlockCursor
+  /** Phase 3: required when any target has a `cursorColumn`. */
+  chunked?: {
+    ensurer: CheckpointTableEnsurer
+    stream: string
+    chunkSize: number
+    checkpointTable: string
+  }
 }
 
 /**
@@ -479,6 +982,18 @@ export async function runManagedRollback(
   const results: RollbackResult[] = []
   for (const target of targets) {
     const { db, unqualifiedTable, qualifiedTable } = resolveTargetTable(target.table, ctx.defaultDb)
+    const chunkedCfg: ChunkedDispatchConfig | undefined =
+      ctx.chunked && target.cursorColumn
+        ? {
+            ensurer: ctx.chunked.ensurer,
+            stream: ctx.chunked.stream,
+            chunkSize: ctx.chunked.chunkSize,
+            checkpointTable: ctx.chunked.checkpointTable,
+            reason,
+            syncCurrent: ctx.syncCurrent,
+          }
+        : undefined
+
     const result = await dispatchRollback({
       store: ctx.store,
       introspector: ctx.introspector,
@@ -490,6 +1005,7 @@ export async function runManagedRollback(
       safeCursor,
       queryParams: target.params,
       logger: ctx.logger,
+      chunked: chunkedCfg,
     })
     ctx.logger?.debug?.(
       { event: `rollback.${result.kind}`, reason, safeCursor, table: qualifiedTable },

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -337,15 +337,20 @@ export class RollbackSemaphore {
       this.#inFlight++
       return () => this.#release()
     }
+    // The slot is handed off to us by `#release()` without decrementing
+    // `#inFlight` — otherwise a fast-path `acquire()` arriving during the
+    // jittered wake-up delay could steal the slot and push in-flight past
+    // the cap.
     await new Promise<void>((resolve) => this.#waiters.push(resolve))
-    this.#inFlight++
     return () => this.#release()
   }
 
   #release() {
-    this.#inFlight--
     const next = this.#waiters.shift()
-    if (!next) return
+    if (!next) {
+      this.#inFlight--
+      return
+    }
     const delay = jitteredBackoff(this.#baseMs, this.#jitter, this.#rng)
     setTimeout(next, Math.max(0, delay))
   }
@@ -1044,7 +1049,7 @@ export async function dispatchRollback(params: {
     stream,
   } = params
 
-  const probeKind: 'exists' | 'none' = cursorColumn != null ? 'exists' : 'none'
+  const probeKind: 'exists' | 'none' = cursorColumn != null && safeCursor != null ? 'exists' : 'none'
   const startEvent: RollbackStartEvent = {
     event: 'rollback.start',
     stream: stream ?? null,

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -39,6 +39,45 @@ export type RollbackResult =
       resumed: boolean
     }
 
+/** Structured log event emitted at the start of every rollback invocation (Phase 5 Step 1). */
+export type RollbackStartEvent = {
+  event: 'rollback.start'
+  stream: string | null
+  table: string
+  reason: RollbackReason | null
+  cursorColumn: string | null
+  safeCursor: number | null
+  probeKind: 'exists' | 'none'
+}
+
+/** Structured log event emitted per chunk. Only produced when `kind === 'chunked'`. */
+export type RollbackChunkEvent = {
+  event: 'rollback.chunk'
+  stream: string | null
+  table: string
+  chunkIndex: number
+  chunkFrom: number
+  chunkTo: number
+  durationMs: number
+}
+
+/** Structured log event emitted at the end of every rollback invocation, discriminated on `RollbackResult.kind`. */
+export type RollbackEndEvent =
+  | { event: 'rollback.end'; kind: 'short_circuit'; stream: string | null; table: string; totalDurationMs: number }
+  | { event: 'rollback.end'; kind: 'monolithic'; stream: string | null; table: string; totalDurationMs: number }
+  | {
+      event: 'rollback.end'
+      kind: 'chunked'
+      stream: string | null
+      table: string
+      chunksPlanned: number
+      chunksCompleted: number
+      resumed: boolean
+      totalDurationMs: number
+    }
+
+export type RollbackLogEvent = RollbackStartEvent | RollbackChunkEvent | RollbackEndEvent
+
 export const DEFAULT_ROLLBACK_CONCURRENCY = 2
 export const DEFAULT_ROLLBACK_CHUNK_SIZE = 500_000
 export const DEFAULT_ROLLBACK_BACKOFF_BASE_MS = 250
@@ -807,10 +846,6 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
     chunk_size = existing.chunk_size
     last_completed_chunk = existing.last_completed_chunk
     startedAtUnix = existing.started_at_unix
-    logger?.debug?.(
-      { event: 'rollback.chunked.resume', table, last_completed_chunk, max_cursor },
-      'resumed chunked rollback from checkpoint',
-    )
   } else {
     // Fresh rollback: derive max_cursor per reason.
     if (reason === 'blockchain_fork') {
@@ -864,6 +899,7 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
     for (let n = nextChunkIndex; n < totalChunks; n++) {
       const { chunkFrom, chunkTo } = chunks[n]!
       const release = semaphore ? await semaphore.acquire() : undefined
+      const chunkStartedAtMs = Date.now()
       try {
         await store.command({
           query: chunkSql,
@@ -891,6 +927,16 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
         prev: last_completed_chunk,
         next: n,
       })
+      const chunkEvent: RollbackChunkEvent = {
+        event: 'rollback.chunk',
+        stream,
+        table,
+        chunkIndex: n,
+        chunkFrom,
+        chunkTo,
+        durationMs: Date.now() - chunkStartedAtMs,
+      }
+      logger?.info?.(chunkEvent, 'rollback chunk')
       last_completed_chunk = n
       chunksCompleted++
     }
@@ -909,11 +955,6 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
     },
     startedAtUnix,
   })
-
-  logger?.debug?.(
-    { event: 'rollback.chunked.end', table, chunksPlanned: totalChunks, chunksCompleted, resumed },
-    'chunked rollback complete',
-  )
 
   return {
     kind: 'chunked',
@@ -963,6 +1004,10 @@ export async function dispatchRollback(params: {
   logger?: Logger
   chunked?: ChunkedDispatchConfig
   semaphore?: RollbackSemaphore
+  /** Optional `reason` for structured logs. Populated by the managed path; undefined for direct `removeAllRows`. */
+  reason?: RollbackReason
+  /** Optional stream identifier for structured logs. Populated by the managed path. */
+  stream?: string
 }): Promise<RollbackResult> {
   const {
     store,
@@ -977,7 +1022,46 @@ export async function dispatchRollback(params: {
     logger,
     chunked,
     semaphore,
+    reason,
+    stream,
   } = params
+
+  const probeKind: 'exists' | 'none' = cursorColumn != null ? 'exists' : 'none'
+  const startEvent: RollbackStartEvent = {
+    event: 'rollback.start',
+    stream: stream ?? null,
+    table,
+    reason: reason ?? null,
+    cursorColumn: cursorColumn ?? null,
+    safeCursor: safeCursor?.number ?? null,
+    probeKind,
+  }
+  logger?.info?.(startEvent, 'rollback start')
+  const startedAtMs = Date.now()
+
+  const emitEnd = (result: RollbackResult) => {
+    const totalDurationMs = Date.now() - startedAtMs
+    const end: RollbackEndEvent =
+      result.kind === 'chunked'
+        ? {
+            event: 'rollback.end',
+            kind: 'chunked',
+            stream: stream ?? null,
+            table,
+            chunksPlanned: result.chunksPlanned,
+            chunksCompleted: result.chunksCompleted,
+            resumed: result.resumed,
+            totalDurationMs,
+          }
+        : {
+            event: 'rollback.end',
+            kind: result.kind,
+            stream: stream ?? null,
+            table,
+            totalDurationMs,
+          }
+    logger?.info?.(end, 'rollback end')
+  }
 
   if (cursorColumn && safeCursor) {
     const hasWork = await probeHasWorkToDo({
@@ -989,16 +1073,13 @@ export async function dispatchRollback(params: {
       queryParams,
     })
     if (!hasWork) {
-      logger?.debug?.(
-        { event: 'rollback.short_circuit', table, safeCursor: safeCursor.number },
-        'managed rollback short-circuited; probe found no rows past safeCursor',
-      )
-      return { kind: 'short_circuit', table }
+      const result: RollbackResult = { kind: 'short_circuit', table }
+      emitEnd(result)
+      return result
     }
 
-    // Probe returned true — choose chunked path if configured, else monolithic.
     if (chunked) {
-      return runChunkedRollback({
+      const result = await runChunkedRollback({
         store,
         introspector,
         ensurer: chunked.ensurer,
@@ -1017,10 +1098,12 @@ export async function dispatchRollback(params: {
         logger,
         semaphore,
       })
+      emitEnd(result)
+      return result
     }
   }
 
-  return runMonolithicCleanup({
+  const result = await runMonolithicCleanup({
     store,
     introspector,
     db,
@@ -1030,6 +1113,8 @@ export async function dispatchRollback(params: {
     queryParams,
     semaphore,
   })
+  emitEnd(result)
+  return result
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1119,11 +1204,9 @@ export async function runManagedRollback(
       logger: ctx.logger,
       chunked: chunkedCfg,
       semaphore: ctx.semaphore,
+      reason,
+      stream: ctx.chunked?.stream,
     })
-    ctx.logger?.debug?.(
-      { event: `rollback.${result.kind}`, reason, safeCursor, table: qualifiedTable },
-      `managed rollback ${result.kind} path complete`,
-    )
     skippedTables.push(qualifiedTable)
     results.push(result)
   }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -235,6 +235,55 @@ export class ColumnIntrospector {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// EXISTS probe (Phase 2 Step 1)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the single-row probe SQL:
+ *   `SELECT 1 FROM <table> WHERE (<scopeWhere>) AND {cursorColumn:Identifier} > {safeCursor:UInt64} LIMIT 1`
+ *
+ * No `FINAL`, no `SETTINGS max_rows_to_read` — relies on sort-key pruning.
+ * Unmerged tombstones may cause the probe to return `true` even when the
+ * logical state is empty; the monolithic INSERT SELECT FINAL that runs next
+ * is idempotent on already-cancelled keys, so this is not a soundness defect.
+ */
+export function buildProbeSql(params: { table: string; scopeWhere: string }): string {
+  const { table, scopeWhere } = params
+  return `SELECT 1
+FROM ${table}
+WHERE (${scopeWhere})
+  AND {cursorColumn:Identifier} > {safeCursor:UInt64}
+LIMIT 1`
+}
+
+/**
+ * Runs the EXISTS probe. Returns `true` when at least one physical row past
+ * `safeCursor` matches the scope.
+ */
+export async function probeHasWorkToDo(params: {
+  store: ClickhouseStore
+  table: string
+  scopeWhere: string
+  cursorColumn: string
+  safeCursor: BlockCursor
+  queryParams?: Record<string, unknown>
+}): Promise<boolean> {
+  const { store, table, scopeWhere, cursorColumn, safeCursor, queryParams } = params
+  const sql = buildProbeSql({ table, scopeWhere })
+  const res = await store.query({
+    query: sql,
+    format: 'JSONEachRow',
+    query_params: {
+      ...(queryParams ?? {}),
+      cursorColumn,
+      safeCursor: safeCursor.number,
+    },
+  })
+  const rows = await res.json<unknown>()
+  return rows.length > 0
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Monolithic cleanup (Phase 1 Step 3)
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -312,6 +361,72 @@ export async function runMonolithicCleanup(params: {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Dispatch: probe → short-circuit | monolithic (Phase 2 Step 2)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * For a single target: if `cursorColumn` and `safeCursor` are both present,
+ * run the EXISTS probe. Empty probe → `{ kind: 'short_circuit' }` and skip
+ * the INSERT SELECT. Otherwise fall through to the monolithic path.
+ *
+ * Phase 3 will replace the monolithic fallthrough with the chunked/resumable
+ * path when both inputs are present.
+ */
+export async function dispatchRollback(params: {
+  store: ClickhouseStore
+  introspector: ColumnIntrospector
+  db: string
+  table: string
+  unqualifiedTable: string
+  scopeWhere: string
+  cursorColumn?: string
+  safeCursor?: BlockCursor
+  queryParams?: Record<string, unknown>
+  logger?: Logger
+}): Promise<RollbackResult> {
+  const {
+    store,
+    introspector,
+    db,
+    table,
+    unqualifiedTable,
+    scopeWhere,
+    cursorColumn,
+    safeCursor,
+    queryParams,
+    logger,
+  } = params
+
+  if (cursorColumn && safeCursor) {
+    const hasWork = await probeHasWorkToDo({
+      store,
+      table,
+      scopeWhere,
+      cursorColumn,
+      safeCursor,
+      queryParams,
+    })
+    if (!hasWork) {
+      logger?.debug?.(
+        { event: 'rollback.short_circuit', table, safeCursor: safeCursor.number },
+        'managed rollback short-circuited; probe found no rows past safeCursor',
+      )
+      return { kind: 'short_circuit', table }
+    }
+  }
+
+  return runMonolithicCleanup({
+    store,
+    introspector,
+    db,
+    table,
+    unqualifiedTable,
+    scopeWhere,
+    queryParams,
+  })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Managed rollback (Phase 1 Step 6)
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -364,18 +479,21 @@ export async function runManagedRollback(
   const results: RollbackResult[] = []
   for (const target of targets) {
     const { db, unqualifiedTable, qualifiedTable } = resolveTargetTable(target.table, ctx.defaultDb)
-    const result = await runMonolithicCleanup({
+    const result = await dispatchRollback({
       store: ctx.store,
       introspector: ctx.introspector,
       db,
       table: qualifiedTable,
       unqualifiedTable,
       scopeWhere: target.scopeWhere,
+      cursorColumn: target.cursorColumn,
+      safeCursor,
       queryParams: target.params,
+      logger: ctx.logger,
     })
     ctx.logger?.debug?.(
-      { event: 'rollback.monolithic', reason, safeCursor, table: qualifiedTable },
-      'managed rollback monolithic path complete',
+      { event: `rollback.${result.kind}`, reason, safeCursor, table: qualifiedTable },
+      `managed rollback ${result.kind} path complete`,
     )
     skippedTables.push(qualifiedTable)
     results.push(result)

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -235,6 +235,98 @@ export class ColumnIntrospector {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Concurrency gate + jittered backoff (Phase 4 Step 1)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute a jittered delay `base * (0.5 + random * jitter * 2)`. For the
+ * default `jitter = 0.5`, the output falls in `[0.5×base, 1.5×base]`.
+ */
+export function jitteredBackoff(baseMs: number, jitter: number, rng: () => number = Math.random): number {
+  return baseMs * (0.5 + rng() * jitter * 2)
+}
+
+/**
+ * Async semaphore with jittered post-release wake-up. `acquire()` returns a
+ * release function; the contract is strictly one release per acquire.
+ *
+ * When a slot frees, the oldest waiter is scheduled to resume after a random
+ * jittered delay — this prevents the thundering-herd on release, distinct
+ * from the concurrency cap which prevents the in-flight stampede.
+ */
+export class RollbackSemaphore {
+  #inFlight = 0
+  #waiters: Array<() => void> = []
+  readonly #concurrency: number
+  readonly #baseMs: number
+  readonly #jitter: number
+  readonly #rng: () => number
+
+  constructor(params: { concurrency: number; baseMs: number; jitter: number; rng?: () => number }) {
+    if (params.concurrency < 1) throw new Error('RollbackSemaphore concurrency must be >= 1')
+    this.#concurrency = params.concurrency
+    this.#baseMs = params.baseMs
+    this.#jitter = params.jitter
+    this.#rng = params.rng ?? Math.random
+  }
+
+  /** Test-only: current in-flight count. */
+  get inFlight(): number {
+    return this.#inFlight
+  }
+
+  async acquire(): Promise<() => void> {
+    if (this.#inFlight < this.#concurrency) {
+      this.#inFlight++
+      return () => this.#release()
+    }
+    await new Promise<void>((resolve) => this.#waiters.push(resolve))
+    this.#inFlight++
+    return () => this.#release()
+  }
+
+  #release() {
+    this.#inFlight--
+    const next = this.#waiters.shift()
+    if (!next) return
+    const delay = jitteredBackoff(this.#baseMs, this.#jitter, this.#rng)
+    setTimeout(next, Math.max(0, delay))
+  }
+}
+
+/**
+ * Module-level registry of semaphores keyed by the `(client, database)`
+ * identity tuple.
+ */
+const semaphoreRegistry = new WeakMap<object, Map<string, RollbackSemaphore>>()
+
+export function getRollbackSemaphore(params: {
+  client: object
+  db: string
+  concurrency: number
+  baseMs: number
+  jitter: number
+}): RollbackSemaphore {
+  const { client, db, concurrency, baseMs, jitter } = params
+  let perClient = semaphoreRegistry.get(client)
+  if (!perClient) {
+    perClient = new Map()
+    semaphoreRegistry.set(client, perClient)
+  }
+  const existing = perClient.get(db)
+  if (existing) return existing
+  const s = new RollbackSemaphore({ concurrency, baseMs, jitter })
+  perClient.set(db, s)
+  return s
+}
+
+/** Test-only: clear the semaphore registry. */
+export function resetRollbackSemaphoreRegistry() {
+  // WeakMap has no clear; replace by creating a new one would break references.
+  // Tests instead construct a fresh RollbackSemaphore directly.
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // EXISTS probe (Phase 2 Step 1)
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -340,13 +432,19 @@ export async function runMonolithicCleanup(params: {
   unqualifiedTable: string
   scopeWhere: string
   queryParams?: Record<string, unknown>
+  semaphore?: RollbackSemaphore
 }): Promise<RollbackResult> {
-  const { store, introspector, db, table, unqualifiedTable, scopeWhere, queryParams } = params
+  const { store, introspector, db, table, unqualifiedTable, scopeWhere, queryParams, semaphore } = params
 
   const attempt = async () => {
     const columns = await introspector.columnsFor(db, unqualifiedTable)
     const sql = buildMonolithicInsertSelectSql({ table, columns, scopeWhere })
-    await store.command({ query: sql, query_params: queryParams })
+    const release = semaphore ? await semaphore.acquire() : undefined
+    try {
+      await store.command({ query: sql, query_params: queryParams })
+    } finally {
+      release?.()
+    }
   }
 
   try {
@@ -649,6 +747,8 @@ export type ChunkedRollbackContext = {
   /** Only used when `reason === 'blockchain_fork'`. */
   syncCurrent?: BlockCursor
   logger?: Logger
+  /** Optional Phase-4 in-process concurrency gate for each chunk INSERT SELECT. */
+  semaphore?: RollbackSemaphore
 }
 
 /**
@@ -681,6 +781,7 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
     reason,
     syncCurrent,
     logger,
+    semaphore,
   } = ctx
 
   const qualifiedCheckpointTable = await ensurer.ensure({ store, db, checkpointTable })
@@ -762,15 +863,20 @@ export async function runChunkedRollback(ctx: ChunkedRollbackContext): Promise<R
   if (nextChunkIndex < totalChunks) {
     for (let n = nextChunkIndex; n < totalChunks; n++) {
       const { chunkFrom, chunkTo } = chunks[n]!
-      await store.command({
-        query: chunkSql,
-        query_params: {
-          ...(queryParams ?? {}),
-          cursorColumn,
-          chunkFrom,
-          chunkTo,
-        },
-      })
+      const release = semaphore ? await semaphore.acquire() : undefined
+      try {
+        await store.command({
+          query: chunkSql,
+          query_params: {
+            ...(queryParams ?? {}),
+            cursorColumn,
+            chunkFrom,
+            chunkTo,
+          },
+        })
+      } finally {
+        release?.()
+      }
       await advanceCheckpoint({
         store,
         qualifiedCheckpointTable,
@@ -856,6 +962,7 @@ export async function dispatchRollback(params: {
   queryParams?: Record<string, unknown>
   logger?: Logger
   chunked?: ChunkedDispatchConfig
+  semaphore?: RollbackSemaphore
 }): Promise<RollbackResult> {
   const {
     store,
@@ -869,6 +976,7 @@ export async function dispatchRollback(params: {
     queryParams,
     logger,
     chunked,
+    semaphore,
   } = params
 
   if (cursorColumn && safeCursor) {
@@ -907,6 +1015,7 @@ export async function dispatchRollback(params: {
         reason: chunked.reason,
         syncCurrent: chunked.syncCurrent,
         logger,
+        semaphore,
       })
     }
   }
@@ -919,6 +1028,7 @@ export async function dispatchRollback(params: {
     unqualifiedTable,
     scopeWhere,
     queryParams,
+    semaphore,
   })
 }
 
@@ -960,6 +1070,8 @@ export type ManagedRollbackContext = {
     chunkSize: number
     checkpointTable: string
   }
+  /** Phase 4: in-process concurrency gate. */
+  semaphore?: RollbackSemaphore
 }
 
 /**
@@ -1006,6 +1118,7 @@ export async function runManagedRollback(
       queryParams: target.params,
       logger: ctx.logger,
       chunked: chunkedCfg,
+      semaphore: ctx.semaphore,
     })
     ctx.logger?.debug?.(
       { event: `rollback.${result.kind}`, reason, safeCursor, table: qualifiedTable },

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -1,0 +1,472 @@
+import type { BlockCursor, Logger } from '~/core/index.js'
+
+import type { ClickhouseStore } from './clickhouse-store.js'
+
+export type RollbackReason = 'offset_check' | 'blockchain_fork'
+
+/**
+ * A user table the SDK should roll back on `offset_check` and `blockchain_fork`.
+ * Pinned config shape per rev-2 B1 in the implementation plan.
+ */
+export type RollbackTarget = {
+  /** Fully-qualified `<db>.<tbl>` or unqualified `<tbl>` (resolved against the client's connection database). */
+  table: string
+  /** Parameterized SQL fragment inlined verbatim into every probe/chunk/monolithic WHERE. */
+  scopeWhere: string
+  /** Query parameters referenced by `scopeWhere`. */
+  params?: Record<string, unknown>
+  /** Optional sort-key column enabling the EXISTS short-circuit and chunked rollback. */
+  cursorColumn?: string
+}
+
+export type RollbackSettings = {
+  targets?: RollbackTarget[]
+  concurrency?: number
+  chunkSize?: number
+  retryBackoff?: { baseMs?: number; jitter?: number }
+  checkpointTable?: string
+}
+
+/** Discriminated result of a managed rollback invocation. */
+export type RollbackResult =
+  | { kind: 'short_circuit'; table: string }
+  | { kind: 'monolithic'; table: string; rowsCanceled: null }
+  | {
+      kind: 'chunked'
+      table: string
+      chunksPlanned: number
+      chunksCompleted: number
+      resumed: boolean
+    }
+
+export const DEFAULT_ROLLBACK_CONCURRENCY = 2
+export const DEFAULT_ROLLBACK_CHUNK_SIZE = 500_000
+export const DEFAULT_ROLLBACK_BACKOFF_BASE_MS = 250
+export const DEFAULT_ROLLBACK_BACKOFF_JITTER = 0.5
+export const DEFAULT_ROLLBACK_CHECKPOINT_TABLE = '_sqd_rollback_checkpoint'
+
+/** Resolved settings with defaults applied. */
+export type ResolvedRollbackSettings = {
+  targets: RollbackTarget[]
+  concurrency: number
+  chunkSize: number
+  retryBackoff: { baseMs: number; jitter: number }
+  checkpointTable: string
+}
+
+export function resolveRollbackSettings(s?: RollbackSettings): ResolvedRollbackSettings {
+  return {
+    targets: s?.targets ?? [],
+    concurrency: s?.concurrency ?? DEFAULT_ROLLBACK_CONCURRENCY,
+    chunkSize: s?.chunkSize ?? DEFAULT_ROLLBACK_CHUNK_SIZE,
+    retryBackoff: {
+      baseMs: s?.retryBackoff?.baseMs ?? DEFAULT_ROLLBACK_BACKOFF_BASE_MS,
+      jitter: s?.retryBackoff?.jitter ?? DEFAULT_ROLLBACK_BACKOFF_JITTER,
+    },
+    checkpointTable: s?.checkpointTable ?? DEFAULT_ROLLBACK_CHECKPOINT_TABLE,
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Sort-key parser (NB5)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Split the CH `sorting_key` DDL form into top-level entries, respecting
+ * parenthesis depth and backtick-quoted identifiers.
+ */
+export function splitSortKeyEntries(sortingKey: string): string[] {
+  let s = sortingKey.trim()
+  // Strip a single balanced outer paren pair if present.
+  if (s.startsWith('(') && s.endsWith(')')) {
+    let depth = 0
+    let balancedAtTail = true
+    for (let i = 0; i < s.length; i++) {
+      const ch = s[i]
+      if (ch === '(') depth++
+      else if (ch === ')') {
+        depth--
+        if (depth === 0 && i < s.length - 1) {
+          balancedAtTail = false
+          break
+        }
+      }
+    }
+    if (balancedAtTail && depth === 0) s = s.slice(1, -1).trim()
+  }
+
+  const entries: string[] = []
+  let depth = 0
+  let inBacktick = false
+  let buf = ''
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === '`') {
+      inBacktick = !inBacktick
+      buf += ch
+      continue
+    }
+    if (!inBacktick) {
+      if (ch === '(') depth++
+      else if (ch === ')') depth--
+      else if (ch === ',' && depth === 0) {
+        entries.push(buf.trim())
+        buf = ''
+        continue
+      }
+    }
+    buf += ch
+  }
+  if (buf.trim().length > 0) entries.push(buf.trim())
+  return entries
+}
+
+/** Extract the set of bare identifiers referenced by a single sort-key entry. */
+export function extractIdentifiers(entry: string): Set<string> {
+  const ids = new Set<string>()
+  let i = 0
+  while (i < entry.length) {
+    const ch = entry[i]
+    if (ch === '`') {
+      let j = i + 1
+      while (j < entry.length && entry[j] !== '`') j++
+      if (j > i + 1) ids.add(entry.slice(i + 1, j))
+      i = j + 1
+      continue
+    }
+    if (/[A-Za-z_]/.test(ch)) {
+      let j = i
+      while (j < entry.length && /[A-Za-z0-9_]/.test(entry[j]!)) j++
+      const token = entry.slice(i, j)
+      // Skip token if immediately followed by `(` — it's a function name.
+      let k = j
+      while (k < entry.length && /\s/.test(entry[k]!)) k++
+      const isFunctionName = entry[k] === '('
+      if (!isFunctionName) ids.add(token)
+      i = j
+      continue
+    }
+    i++
+  }
+  return ids
+}
+
+/** Returns the set of identifiers referenced anywhere in the ORDER BY. */
+export function sortKeyIdentifiers(sortingKey: string): Set<string> {
+  const all = new Set<string>()
+  for (const entry of splitSortKeyEntries(sortingKey)) {
+    for (const id of extractIdentifiers(entry)) all.add(id)
+  }
+  return all
+}
+
+/** True if `cursorColumn` appears anywhere in the ORDER BY expression. */
+export function cursorColumnIsInSortKey(sortingKey: string, cursorColumn: string): boolean {
+  return sortKeyIdentifiers(sortingKey).has(cursorColumn)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Column introspection (M-1 + DDL-churn cache key)
+// ────────────────────────────────────────────────────────────────────────────
+
+type ColumnCacheEntry = { schemaVersion: string; columns: string[] }
+
+export class ColumnIntrospector {
+  #cache = new Map<string, ColumnCacheEntry>()
+
+  constructor(private store: ClickhouseStore) {}
+
+  /** Resets the cache entry for a single `(db, table)` key. */
+  invalidate(db: string, table: string) {
+    this.#cache.delete(`${db}.${table}`)
+  }
+
+  /** Clears the entire cache. */
+  clear() {
+    this.#cache.clear()
+  }
+
+  /**
+   * Returns the list of insertable (non-ALIAS, non-MATERIALIZED) columns for a
+   * table, cached by `(db, table, metadata_modification_time)`.
+   */
+  async columnsFor(db: string, table: string): Promise<string[]> {
+    const cacheKey = `${db}.${table}`
+    const currentVersion = await this.#schemaVersion(db, table)
+    const hit = this.#cache.get(cacheKey)
+    if (hit && hit.schemaVersion === currentVersion) return hit.columns
+    const columns = await this.#fetchColumns(db, table)
+    this.#cache.set(cacheKey, { schemaVersion: currentVersion, columns })
+    return columns
+  }
+
+  async #schemaVersion(db: string, table: string): Promise<string> {
+    const res = await this.store.query({
+      query: `
+        SELECT toUnixTimestamp(metadata_modification_time) AS v
+        FROM system.tables
+        WHERE database = {db:String} AND name = {tbl:String}
+      `,
+      format: 'JSONEachRow',
+      query_params: { db, tbl: table },
+    })
+    const rows = await res.json<{ v: string | number }>()
+    if (rows.length === 0) {
+      throw new Error(`clickhouseTarget: table ${db}.${table} not found in system.tables`)
+    }
+    return String(rows[0]!.v)
+  }
+
+  async #fetchColumns(db: string, table: string): Promise<string[]> {
+    const res = await this.store.query({
+      query: `
+        SELECT name
+        FROM system.columns
+        WHERE database = {db:String} AND table = {tbl:String}
+          AND default_kind NOT IN ('ALIAS', 'MATERIALIZED')
+        ORDER BY position
+      `,
+      format: 'JSONEachRow',
+      query_params: { db, tbl: table },
+    })
+    const rows = await res.json<{ name: string }>()
+    return rows.map((r) => r.name)
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Monolithic cleanup (Phase 1 Step 3)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the monolithic `INSERT INTO t (cols, sign) SELECT cols, -1 FROM t FINAL WHERE <scope>`
+ * statement. `scopeWhere` is inlined verbatim; identifier quoting in the table
+ * name and column list is the caller's responsibility to produce safe input.
+ */
+export function buildMonolithicInsertSelectSql(params: {
+  table: string
+  columns: string[]
+  scopeWhere: string
+}): string {
+  const { table, columns, scopeWhere } = params
+  if (columns.length === 0) {
+    throw new Error(`clickhouseTarget: no insertable columns resolved for table ${table}`)
+  }
+  const nonSignCols = columns.filter((c) => c !== 'sign')
+  const colList = nonSignCols.join(', ')
+  return `INSERT INTO ${table} (${colList}, sign)
+SELECT ${colList}, -1 AS sign
+FROM ${table} FINAL
+WHERE (${scopeWhere})`
+}
+
+/** Error-class set used by Phase 1 Step 4 cache-invalidation retry. */
+export const SCHEMA_DRIFT_ERROR_TYPES = new Set([
+  'UNKNOWN_IDENTIFIER',
+  'THERE_IS_NO_COLUMN',
+  'NOT_FOUND_COLUMN_IN_BLOCK',
+])
+
+function isSchemaDriftError(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'type' in err) {
+    const t = (err as { type?: unknown }).type
+    if (typeof t === 'string' && SCHEMA_DRIFT_ERROR_TYPES.has(t)) return true
+  }
+  if (err instanceof Error) {
+    for (const t of SCHEMA_DRIFT_ERROR_TYPES) if (err.message.includes(t)) return true
+  }
+  return false
+}
+
+/**
+ * Run the monolithic server-side INSERT SELECT with error-code-driven cache
+ * invalidation (Phase 1 Step 4). One retry on schema-drift errors; a second
+ * consecutive schema-drift is rethrown.
+ */
+export async function runMonolithicCleanup(params: {
+  store: ClickhouseStore
+  introspector: ColumnIntrospector
+  db: string
+  table: string
+  unqualifiedTable: string
+  scopeWhere: string
+  queryParams?: Record<string, unknown>
+}): Promise<RollbackResult> {
+  const { store, introspector, db, table, unqualifiedTable, scopeWhere, queryParams } = params
+
+  const attempt = async () => {
+    const columns = await introspector.columnsFor(db, unqualifiedTable)
+    const sql = buildMonolithicInsertSelectSql({ table, columns, scopeWhere })
+    await store.command({ query: sql, query_params: queryParams })
+  }
+
+  try {
+    await attempt()
+  } catch (err) {
+    if (!isSchemaDriftError(err)) throw err
+    introspector.invalidate(db, unqualifiedTable)
+    await attempt()
+  }
+
+  return { kind: 'monolithic', table, rowsCanceled: null }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Managed rollback (Phase 1 Step 6)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a `RollbackTarget.table` into `{db, unqualifiedTable, qualifiedTable}`
+ * where `db` falls back to `defaultDb`.
+ */
+export function resolveTargetTable(
+  targetTable: string,
+  defaultDb: string,
+): { db: string; unqualifiedTable: string; qualifiedTable: string } {
+  if (targetTable.includes('.')) {
+    const [db, ...rest] = targetTable.split('.')
+    const unqualifiedTable = rest.join('.')
+    return { db: db!, unqualifiedTable, qualifiedTable: `"${db}"."${unqualifiedTable}"` }
+  }
+  return {
+    db: defaultDb,
+    unqualifiedTable: targetTable,
+    qualifiedTable: `"${defaultDb}"."${targetTable}"`,
+  }
+}
+
+export type ManagedRollbackContext = {
+  store: ClickhouseStore
+  introspector: ColumnIntrospector
+  defaultDb: string
+  logger?: Logger
+  /** Phase 3 consumer: the in-memory cursor captured before `state.fork()` ran. */
+  syncCurrent?: BlockCursor
+}
+
+/**
+ * Walks the declared `RollbackTarget[]`, invokes `runMonolithicCleanup` for
+ * each (Phase 1), and returns the list of tables handled so callers can thread
+ * `skippedTables` into the user's `onRollback` hook.
+ *
+ * In Phase 1 the probe (Phase 2) and chunking (Phase 3) are not yet wired — a
+ * target with `cursorColumn` is still handled via the monolithic path. Later
+ * phases extend this function to pick the chunked path when `cursorColumn` is
+ * present and the Phase-0 gate is passed.
+ */
+export async function runManagedRollback(
+  targets: RollbackTarget[],
+  reason: RollbackReason,
+  safeCursor: BlockCursor | undefined,
+  ctx: ManagedRollbackContext,
+): Promise<{ skippedTables: string[]; results: RollbackResult[] }> {
+  const skippedTables: string[] = []
+  const results: RollbackResult[] = []
+  for (const target of targets) {
+    const { db, unqualifiedTable, qualifiedTable } = resolveTargetTable(target.table, ctx.defaultDb)
+    const result = await runMonolithicCleanup({
+      store: ctx.store,
+      introspector: ctx.introspector,
+      db,
+      table: qualifiedTable,
+      unqualifiedTable,
+      scopeWhere: target.scopeWhere,
+      queryParams: target.params,
+    })
+    ctx.logger?.debug?.(
+      { event: 'rollback.monolithic', reason, safeCursor, table: qualifiedTable },
+      'managed rollback monolithic path complete',
+    )
+    skippedTables.push(qualifiedTable)
+    results.push(result)
+  }
+  return { skippedTables, results }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Init-time validation (Phase 1 Step 5 + Phase 3 Step 11 — scope isolation)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the DDL `sorting_key` for a table and asserts `cursorColumn` appears
+ * anywhere in it. Throws a user-actionable error otherwise (R-E fail-loud).
+ */
+export async function assertCursorColumnInSortKey(params: {
+  store: ClickhouseStore
+  db: string
+  unqualifiedTable: string
+  cursorColumn: string
+}): Promise<void> {
+  const { store, db, unqualifiedTable, cursorColumn } = params
+  const res = await store.query({
+    query: `
+      SELECT sorting_key
+      FROM system.tables
+      WHERE database = {db:String} AND name = {tbl:String}
+    `,
+    format: 'JSONEachRow',
+    query_params: { db, tbl: unqualifiedTable },
+  })
+  const rows = await res.json<{ sorting_key: string }>()
+  if (rows.length === 0) {
+    throw new Error(
+      `clickhouseTarget: table ${db}.${unqualifiedTable} not found in system.tables (cannot validate cursorColumn='${cursorColumn}').`,
+    )
+  }
+  const sortingKey = rows[0]!.sorting_key
+  if (!cursorColumnIsInSortKey(sortingKey, cursorColumn)) {
+    throw new Error(
+      `clickhouseTarget: cursorColumn '${cursorColumn}' is not referenced anywhere in the ORDER BY of ${db}.${unqualifiedTable} (ORDER BY: ${sortingKey}). Either add '${cursorColumn}' to ORDER BY (or to an ORDER BY expression's operands) or omit cursorColumn to use the monolithic-cleanup path.`,
+    )
+  }
+}
+
+/**
+ * PC-4 multi-writer scope enforcement (Phase 3 Step 11 / B10). When multiple
+ * rollback targets share the same `table`, every target for that table MUST
+ * have a non-empty `scopeWhere` — otherwise cross-writer tombstoning is
+ * possible. Single-writer case (one target on a table) allows empty scope.
+ */
+export function assertScopeIsolation(targets: RollbackTarget[]): void {
+  const byTable = new Map<string, RollbackTarget[]>()
+  for (const t of targets) {
+    const list = byTable.get(t.table) ?? []
+    list.push(t)
+    byTable.set(t.table, list)
+  }
+  for (const [table, list] of byTable) {
+    if (list.length > 1) {
+      for (const t of list) {
+        if (t.scopeWhere.trim().length === 0) {
+          throw new Error(
+            `clickhouseTarget: table '${table}' is declared by multiple rollback targets; scopeWhere is required on each to isolate writers. Empty scope would cause cross-writer tombstoning.`,
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Runs the full init-time validation: scope isolation + (per-target) sort-key
+ * check where `cursorColumn` is declared.
+ */
+export async function validateRollbackTargets(params: {
+  store: ClickhouseStore
+  defaultDb: string
+  targets: RollbackTarget[]
+}): Promise<void> {
+  const { store, defaultDb, targets } = params
+  if (targets.length === 0) return
+  assertScopeIsolation(targets)
+  for (const target of targets) {
+    if (!target.cursorColumn) continue
+    const { db, unqualifiedTable } = resolveTargetTable(target.table, defaultDb)
+    await assertCursorColumnInSortKey({
+      store,
+      db,
+      unqualifiedTable,
+      cursorColumn: target.cursorColumn,
+    })
+  }
+}

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-rollback.ts
@@ -19,11 +19,29 @@ export type RollbackTarget = {
   cursorColumn?: string
 }
 
+/**
+ * Declarative rollback config. When `targets` is non-empty, the SDK runs a
+ * managed rollback path for each target on `offset_check` and `blockchain_fork`
+ * and `onRollback` receives the list of tables the SDK already handled via
+ * `skippedTables` so user code can skip them.
+ */
 export type RollbackSettings = {
+  /** Tables to manage. Each target with `cursorColumn` opts into chunked + resumable rollback. */
   targets?: RollbackTarget[]
+  /**
+   * Max in-flight tombstone INSERTs per (client, database). Default `2`. The
+   * semaphore bounds parallelism regardless of how many pipes share the client.
+   */
   concurrency?: number
+  /** Row-window size for the chunked path. Default `500_000`. Ignored for monolithic and short-circuit paths. */
   chunkSize?: number
+  /**
+   * Jittered backoff for (a) the semaphore wake-up on release and (b) the
+   * optional `PortalSource.forkRetryBackoff` knob. Actual delay
+   * `baseMs * (0.5 + Math.random() * jitter * 2)`; default `baseMs=250, jitter=0.5`.
+   */
   retryBackoff?: { baseMs?: number; jitter?: number }
+  /** Name of the per-database checkpoint table used by the chunked path. Default `_sqd_rollback_checkpoint`. */
   checkpointTable?: string
 }
 

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
@@ -51,6 +51,7 @@ export class ClickhouseState {
 
   readonly #qualifiedName: string
   #saves = 0
+  #currentCursor: BlockCursor | undefined
 
   constructor(
     private store: ClickhouseStore,
@@ -112,6 +113,7 @@ export class ClickhouseState {
       })
     })
 
+    this.#currentCursor = { ...current }
     this.#saves++
 
     // Debounce cleanup for large retention windows, but enforce small limits
@@ -149,7 +151,9 @@ export class ClickhouseState {
 
       const [row] = await res.json<{ current: string; initial: string }>()
       if (row) {
-        return this.decodeCursor(row.current)
+        const cursor = this.decodeCursor(row.current)
+        this.#currentCursor = { ...cursor }
+        return cursor
       }
 
       return
@@ -162,6 +166,18 @@ export class ClickhouseState {
 
       throw e
     }
+  }
+
+  /**
+   * Returns a by-value copy of the in-memory current cursor (R-B freeze), or
+   * `undefined` if no cursor has been observed yet. Synchronous — reads the
+   * memoized cursor last written via `saveCursor()` or loaded via
+   * `getCursor()`. Used by the managed rollback helper to bound chunked
+   * `max_cursor` derivation at fork-handler entry, before `state.fork()`
+   * mutates the cursor to the fork-resolved value.
+   */
+  snapshotCurrent(): BlockCursor | undefined {
+    return this.#currentCursor ? { ...this.#currentCursor } : undefined
   }
 
   async fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null> {

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@clickhouse/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ClickhouseStore } from '~/targets/clickhouse/clickhouse-store.js'
 
@@ -68,5 +68,42 @@ describe('Clickhouse store', () => {
     })
     const rows = await select.json()
     expect(rows.data).toHaveLength(0)
+  })
+})
+
+describe('ClickhouseStore.removeAllRows (unit)', () => {
+  it('forwards reason from structured args to the rollback.start log event', async () => {
+    const events: Array<{ payload: any; msg: string }> = []
+    const logger = {
+      info: (payload: any, msg: string) => events.push({ payload, msg }),
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+    } as any
+
+    // Mock ClickHouse client: schema version, columns, then the monolithic
+    // INSERT SELECT command. No real connection is opened.
+    const query = vi
+      .fn()
+      // ColumnIntrospector#schemaVersion
+      .mockResolvedValueOnce({ json: async () => [{ v: '0' }] })
+      // ColumnIntrospector#fetchColumns
+      .mockResolvedValueOnce({ json: async () => [{ name: 'id' }, { name: 'value' }, { name: 'sign' }] })
+    const command = vi.fn().mockResolvedValue({ query_id: 'cmd' })
+    const mockClient = {
+      connectionParams: { database: 'default' },
+      query,
+      command,
+    } as any
+
+    const store = new ClickhouseStore(mockClient)
+    await store.removeAllRows(
+      { tables: 't', scopeWhere: '1', reason: 'blockchain_fork' },
+      { logger },
+    )
+
+    const start = events.find((e) => e.payload?.event === 'rollback.start')
+    expect(start).toBeDefined()
+    expect(start!.payload.reason).toBe('blockchain_fork')
   })
 })

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@clickhouse/client'
 import { afterEach, describe, expect, it } from 'vitest'
+
 import { ClickhouseStore } from '~/targets/clickhouse/clickhouse-store.js'
 
 const client = createClient({

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.test.ts
@@ -55,8 +55,9 @@ describe('Clickhouse store', () => {
     expect(res).toMatchInlineSnapshot(`
       [
         {
-          "count": 1,
-          "table": "big_numbers",
+          "kind": "monolithic",
+          "rowsCanceled": null,
+          "table": ""default"."big_numbers"",
         },
       ]
     `)

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
@@ -134,6 +134,7 @@ export class ClickhouseStore {
         cursorColumn: args.cursorColumn,
         safeCursor: args.safeCursor,
         queryParams: args.params,
+        reason: args.reason,
         logger: opts?.logger,
       })
       results.push(result)

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
@@ -15,8 +15,8 @@ import {
   ColumnIntrospector,
   type RollbackReason,
   type RollbackResult,
+  dispatchRollback,
   resolveTargetTable,
-  runMonolithicCleanup,
 } from './clickhouse-rollback.js'
 import { loadSqlFiles } from './fs.js'
 
@@ -103,16 +103,19 @@ export class ClickhouseStore {
           'removeAllRows({ where }) is deprecated; pass { scopeWhere, cursorColumn, safeCursor, reason } to get EXISTS short-circuit and chunked+resumable rollback.',
         )
       }
-      return this.#runStructured({
-        tables: args.tables,
-        scopeWhere: args.where,
-        params: args.params,
-      })
+      return this.#runStructured(
+        {
+          tables: args.tables,
+          scopeWhere: args.where,
+          params: args.params,
+        },
+        opts,
+      )
     }
-    return this.#runStructured(args)
+    return this.#runStructured(args, opts)
   }
 
-  async #runStructured(args: StructuredRemoveAllRowsArgs): Promise<RollbackResult[]> {
+  async #runStructured(args: StructuredRemoveAllRowsArgs, opts?: { logger?: Logger }): Promise<RollbackResult[]> {
     const tables = typeof args.tables === 'string' ? [args.tables] : args.tables
     const introspector = this.#getIntrospector()
     const defaultDb = this.#getDefaultDb()
@@ -121,14 +124,17 @@ export class ClickhouseStore {
     const results: RollbackResult[] = []
     for (const rawTable of tables) {
       const { db, unqualifiedTable, qualifiedTable } = resolveTargetTable(rawTable, defaultDb)
-      const result = await runMonolithicCleanup({
+      const result = await dispatchRollback({
         store: this,
         introspector,
         db,
         table: qualifiedTable,
         unqualifiedTable,
         scopeWhere,
+        cursorColumn: args.cursorColumn,
+        safeCursor: args.safeCursor,
         queryParams: args.params,
+        logger: opts?.logger,
       })
       results.push(result)
     }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
@@ -8,13 +8,50 @@ import type {
   QueryParams,
   QueryResult,
 } from '@clickhouse/client'
+
+import type { BlockCursor, Logger } from '~/core/index.js'
+
+import {
+  ColumnIntrospector,
+  type RollbackReason,
+  type RollbackResult,
+  resolveTargetTable,
+  runMonolithicCleanup,
+} from './clickhouse-rollback.js'
 import { loadSqlFiles } from './fs.js'
 
 export type QueryParamsWithFormat<Format extends DataFormat> = Omit<QueryParams, 'format'> & {
   format?: Format
 }
 
+/** Legacy `removeAllRows` shape, preserved as a shim with a deprecation warning. */
+export type LegacyRemoveAllRowsArgs = {
+  tables: string | string[]
+  where: string
+  params?: Record<string, unknown>
+}
+
+/** Structured `removeAllRows` shape introduced by Phase 1 of SDKTL-52. */
+export type StructuredRemoveAllRowsArgs = {
+  tables: string | string[]
+  scopeWhere?: string
+  params?: Record<string, unknown>
+  cursorColumn?: string
+  safeCursor?: BlockCursor
+  reason?: RollbackReason
+}
+
+export type RemoveAllRowsArgs = LegacyRemoveAllRowsArgs | StructuredRemoveAllRowsArgs
+
+function isLegacy(args: RemoveAllRowsArgs): args is LegacyRemoveAllRowsArgs {
+  return 'where' in args && typeof (args as LegacyRemoveAllRowsArgs).where === 'string'
+}
+
 export class ClickhouseStore {
+  #shimWarned = false
+  #introspector?: ColumnIntrospector
+  #defaultDb?: string
+
   constructor(public client: ClickHouseClient) {}
 
   insert<T>(params: InsertParams<T>): Promise<InsertResult> {
@@ -48,30 +85,54 @@ export class ClickhouseStore {
     }
   }
 
-  async removeAllRows({
-    tables,
-    params,
-    where,
-  }: {
-    tables: string | string[]
-    where: string
-    params?: Record<string, unknown>
-  }) {
-    tables = typeof tables === 'string' ? [tables] : tables
+  /**
+   * Removes all rows matching a scope via CollapsingMergeTree tombstone
+   * insertion. Two call shapes:
+   *
+   * - **Legacy**: `{ tables, where, params? }`. Preserved for back-compat;
+   *   emits a one-time deprecation warning per store instance.
+   * - **Structured** (recommended): `{ tables, scopeWhere?, params?, cursorColumn?, safeCursor?, reason? }`.
+   *   Runs a single server-side `INSERT INTO t (cols, sign) SELECT cols, -1 FROM t FINAL WHERE <scope>`.
+   *   No rows stream through Node.
+   */
+  async removeAllRows(args: RemoveAllRowsArgs, opts?: { logger?: Logger }): Promise<RollbackResult[]> {
+    if (isLegacy(args)) {
+      if (!this.#shimWarned) {
+        this.#shimWarned = true
+        opts?.logger?.warn?.(
+          'removeAllRows({ where }) is deprecated; pass { scopeWhere, cursorColumn, safeCursor, reason } to get EXISTS short-circuit and chunked+resumable rollback.',
+        )
+      }
+      return this.#runStructured({
+        tables: args.tables,
+        scopeWhere: args.where,
+        params: args.params,
+      })
+    }
+    return this.#runStructured(args)
+  }
 
-    return Promise.all(
-      tables.map(async (table) => {
-        // TODO check engine
+  async #runStructured(args: StructuredRemoveAllRowsArgs): Promise<RollbackResult[]> {
+    const tables = typeof args.tables === 'string' ? [args.tables] : args.tables
+    const introspector = this.#getIntrospector()
+    const defaultDb = this.#getDefaultDb()
+    const scopeWhere = args.scopeWhere ?? '1'
 
-        const count = await this.removeAllRowsByQuery({
-          table,
-          query: `SELECT * FROM ${table} FINAL WHERE ${where}`,
-          params,
-        })
-
-        return { table, count }
-      }),
-    )
+    const results: RollbackResult[] = []
+    for (const rawTable of tables) {
+      const { db, unqualifiedTable, qualifiedTable } = resolveTargetTable(rawTable, defaultDb)
+      const result = await runMonolithicCleanup({
+        store: this,
+        introspector,
+        db,
+        table: qualifiedTable,
+        unqualifiedTable,
+        scopeWhere,
+        queryParams: args.params,
+      })
+      results.push(result)
+    }
+    return results
   }
 
   async removeAllRowsByQuery({
@@ -115,5 +176,18 @@ export class ClickhouseStore {
     }
 
     return count
+  }
+
+  #getIntrospector(): ColumnIntrospector {
+    this.#introspector ??= new ColumnIntrospector(this)
+    return this.#introspector
+  }
+
+  #getDefaultDb(): string {
+    if (this.#defaultDb) return this.#defaultDb
+    const anyClient = this.client as any
+    const db = anyClient?.connectionParams?.database || 'default'
+    this.#defaultDb = db
+    return db
   }
 }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-target.test.ts
@@ -782,7 +782,10 @@ describe('Clickhouse state', () => {
         },
         {
           statusCode: 200,
-          data: [{ header: { number: 2, hash: '0x2a', timestamp: 2000 } }, { header: { number: 3, hash: '0x3a', timestamp: 3000 } }],
+          data: [
+            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+          ],
           head: { finalized: { number: 2, hash: '0x2a' } },
         },
         // we mock 2 responses here as the first will fail

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
@@ -64,6 +64,25 @@ export type RollbackHookContext = {
   cursor: BlockCursor
 }
 
+/**
+ * Build a ClickHouse write target for the pipe.
+ *
+ * When `settings.rollback.targets` is declared, the SDK runs a managed
+ * rollback path for each target on both `offset_check` (init-time, on resume)
+ * and `blockchain_fork`. Targets that also declare `cursorColumn` are handled
+ * via the chunked + resumable path backed by a `_sqd_rollback_checkpoint`
+ * table; targets without `cursorColumn` fall back to a single monolithic
+ * `INSERT INTO t (cols, sign) SELECT cols, -1 FROM t FINAL WHERE <scope>`.
+ *
+ * The managed path tombstones via the CollapsingMergeTree `sign` column.
+ * Tables listed in `targets` are passed to the optional `onRollback` hook via
+ * the `skippedTables` argument so user code can skip them.
+ *
+ * Every rollback invocation emits structured log events on the target's
+ * logger: `rollback.start`, optional `rollback.chunk` per chunk, and
+ * `rollback.end` discriminated on `{ short_circuit | monolithic | chunked }`.
+ * See `RollbackLogEvent` for the full event union.
+ */
 export function clickhouseTarget<T>({
   client,
   onStart,
@@ -195,4 +214,13 @@ export function clickhouseTarget<T>({
  */
 export const createClickhouseTarget = clickhouseTarget
 
-export type { RollbackReason, RollbackResult, RollbackSettings }
+export type {
+  RollbackChunkEvent,
+  RollbackEndEvent,
+  RollbackLogEvent,
+  RollbackReason,
+  RollbackResult,
+  RollbackSettings,
+  RollbackStartEvent,
+  RollbackTarget,
+} from './clickhouse-rollback.js'

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
@@ -2,6 +2,15 @@ import type { ClickHouseClient } from '@clickhouse/client'
 
 import { BlockCursor, Ctx, Logger, createTarget } from '~/core/index.js'
 
+import {
+  ColumnIntrospector,
+  type RollbackReason,
+  type RollbackResult,
+  type RollbackSettings,
+  resolveRollbackSettings,
+  runManagedRollback,
+  validateRollbackTargets,
+} from './clickhouse-rollback.js'
 import { ClickhouseState } from './clickhouse-state.js'
 import { ClickhouseStore } from './clickhouse-store.js'
 
@@ -32,6 +41,25 @@ export type Settings = {
    * Default is 10,000.
    */
   maxRows?: number
+
+  /**
+   * Declarative rollback configuration (SDKTL-52). When `targets` is declared,
+   * the SDK runs a managed rollback path for each target on `offset_check` and
+   * `blockchain_fork`, and the user's `onRollback` hook receives a
+   * `skippedTables` argument listing the tables the SDK already handled.
+   */
+  rollback?: RollbackSettings
+}
+
+export type RollbackHookContext = {
+  type: 'offset_check' | 'blockchain_fork'
+  store: ClickhouseStore
+  safeCursor: BlockCursor
+  /** Tables the SDK's managed rollback path already tombstoned. User hooks should skip them. */
+  skippedTables: string[]
+
+  /** @deprecated Use `safeCursor` from state instead */
+  cursor: BlockCursor
 }
 
 export function clickhouseTarget<T>({
@@ -45,31 +73,55 @@ export function clickhouseTarget<T>({
   settings?: Settings
   onStart?: (ctx: { store: ClickhouseStore; logger: Logger }) => unknown | Promise<unknown>
   onData: (ctx: { store: ClickhouseStore; data: T; ctx: Ctx }) => unknown | Promise<unknown>
-  onRollback?: (ctx: {
-    type: 'offset_check' | 'blockchain_fork'
-    store: ClickhouseStore
-    safeCursor: BlockCursor
-
-    /** @deprecated Use `safeCursor` from state instead */
-    cursor: BlockCursor
-  }) => unknown | Promise<unknown>
+  onRollback?: (ctx: RollbackHookContext) => unknown | Promise<unknown>
 }) {
-  // TODO Can we generate row ID based on query?
-
   const store = new ClickhouseStore(client)
   const state = new ClickhouseState(store, settings)
+  const rollbackSettings = resolveRollbackSettings(settings.rollback)
+  const rollbackTargetsDeclared = rollbackSettings.targets.length > 0
+  const introspector = new ColumnIntrospector(store)
+  let capturedLogger: Logger | undefined
+
+  const runManaged = async (
+    reason: RollbackReason,
+    safeCursor: BlockCursor,
+    logger: Logger | undefined,
+    syncCurrent?: BlockCursor,
+  ): Promise<string[]> => {
+    if (!rollbackTargetsDeclared) return []
+    const { skippedTables } = await runManagedRollback(rollbackSettings.targets, reason, safeCursor, {
+      store,
+      introspector,
+      defaultDb: state.options.database,
+      logger,
+      syncCurrent,
+    })
+    return skippedTables
+  }
 
   return createTarget<T>({
     write: async ({ read, logger }) => {
+      capturedLogger = logger
       await onStart?.({ store, logger })
+
+      if (rollbackTargetsDeclared) {
+        await validateRollbackTargets({
+          store,
+          defaultDb: state.options.database,
+          targets: rollbackSettings.targets,
+        })
+      }
+
       const cursor = await state.getCursor()
 
       if (cursor) {
+        const skippedTables = await runManaged('offset_check', cursor, logger)
         await onRollback?.({
           type: 'offset_check',
           store,
           cursor,
           safeCursor: cursor,
+          skippedTables,
         })
       }
 
@@ -97,14 +149,21 @@ export function clickhouseTarget<T>({
       await store.close()
     },
     fork: async (previousBlocks) => {
+      // R-B freeze: capture the pre-fork in-memory cursor BEFORE state.fork()
+      // touches anything. Phase 3's chunked path consumes this value as
+      // `syncCurrent` for max_cursor derivation. Phase 1 threads it but does
+      // not yet use it.
+      const syncCurrent = state.snapshotCurrent()
       const cursor = await state.fork(previousBlocks)
       if (!cursor) return cursor
 
+      const skippedTables = await runManaged('blockchain_fork', cursor, capturedLogger, syncCurrent)
       await onRollback?.({
         type: 'blockchain_fork',
         store,
         cursor,
         safeCursor: cursor,
+        skippedTables,
       })
       return cursor
     },
@@ -115,3 +174,5 @@ export function clickhouseTarget<T>({
  *  @deprecated use `clickhouseTarget` instead
  */
 export const createClickhouseTarget = clickhouseTarget
+
+export type { RollbackReason, RollbackResult, RollbackSettings }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
@@ -8,6 +8,7 @@ import {
   type RollbackReason,
   type RollbackResult,
   type RollbackSettings,
+  getRollbackSemaphore,
   resolveRollbackSettings,
   runManagedRollback,
   validateRollbackTargets,
@@ -92,6 +93,13 @@ export function clickhouseTarget<T>({
     syncCurrent?: BlockCursor,
   ): Promise<string[]> => {
     if (!rollbackTargetsDeclared) return []
+    const semaphore = getRollbackSemaphore({
+      client,
+      db: state.options.database,
+      concurrency: rollbackSettings.concurrency,
+      baseMs: rollbackSettings.retryBackoff.baseMs,
+      jitter: rollbackSettings.retryBackoff.jitter,
+    })
     const { skippedTables } = await runManagedRollback(rollbackSettings.targets, reason, safeCursor, {
       store,
       introspector,
@@ -106,6 +114,7 @@ export function clickhouseTarget<T>({
             checkpointTable: rollbackSettings.checkpointTable,
           }
         : undefined,
+      semaphore,
     })
     return skippedTables
   }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
@@ -3,6 +3,7 @@ import type { ClickHouseClient } from '@clickhouse/client'
 import { BlockCursor, Ctx, Logger, createTarget } from '~/core/index.js'
 
 import {
+  CheckpointTableEnsurer,
   ColumnIntrospector,
   type RollbackReason,
   type RollbackResult,
@@ -80,6 +81,8 @@ export function clickhouseTarget<T>({
   const rollbackSettings = resolveRollbackSettings(settings.rollback)
   const rollbackTargetsDeclared = rollbackSettings.targets.length > 0
   const introspector = new ColumnIntrospector(store)
+  const checkpointEnsurer = new CheckpointTableEnsurer()
+  const chunkedConfigured = rollbackSettings.targets.some((t) => t.cursorColumn)
   let capturedLogger: Logger | undefined
 
   const runManaged = async (
@@ -95,6 +98,14 @@ export function clickhouseTarget<T>({
       defaultDb: state.options.database,
       logger,
       syncCurrent,
+      chunked: chunkedConfigured
+        ? {
+            ensurer: checkpointEnsurer,
+            stream: state.options.id,
+            chunkSize: rollbackSettings.chunkSize,
+            checkpointTable: rollbackSettings.checkpointTable,
+          }
+        : undefined,
     })
     return skippedTables
   }

--- a/packages/subsquid-pipes/src/targets/clickhouse/index.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/index.ts
@@ -1,1 +1,8 @@
+export type {
+  ResolvedRollbackSettings,
+  RollbackReason,
+  RollbackResult,
+  RollbackSettings,
+  RollbackTarget,
+} from './clickhouse-rollback.js'
 export * from './clickouse-target.js'


### PR DESCRIPTION
## Summary
Redesigns ClickHouse rollback on `offset_check` and `blockchain_fork` around a managed path: EXISTS short-circuit → monolithic `INSERT INTO t SELECT … -1 FROM t FINAL` or chunked+resumable variant backed by a `_sqd_rollback_checkpoint` table. Adds an in-process semaphore keyed by `(client, database)` with jittered wake-up, an optional jittered `PortalSource.forkRetryBackoff` to spread multi-container reconnect storms, and a discriminated `rollback.start`/`rollback.chunk`/`rollback.end` log event union. `store.removeAllRows` gains a structured shape (`{tables, scopeWhere, cursorColumn, safeCursor, reason}`) with a one-shot deprecation shim for the legacy `{where}` form.

## Test plan
- [x] 71 unit tests pass (`pnpm vitest run src/targets/clickhouse/clickhouse-rollback.test.ts`)
- [x] `tsc --noEmit` clean from the package dir
- [x] Biome clean on changed files (pre-existing warnings only in Phase-0 experiment harness)
- [ ] Live-CH integration tests (deferred — require a CH container; not run locally per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)