### PR TITLE
fix(pipes-cli): make published tarball consumable by any package manager

### DIFF
--- a/packages/pipes-cli/package.json
+++ b/packages/pipes-cli/package.json
@@ -46,7 +46,9 @@
     "test": "vitest run",
     "test:integration": "RUN_INTEGRATION=1 vitest run src/commands/init/init.handler.test.ts",
     "coverage": "vitest run --coverage",
-    "prepublishOnly": "pnpm build"
+    "prepublishOnly": "pnpm build",
+    "prepack": "node scripts/rewrite-workspace-deps.cjs",
+    "postpack": "node scripts/restore-package-json.cjs"
   },
   "dependencies": {
     "@inquirer/prompts": "^8.1.0",

--- a/packages/pipes-cli/scripts/restore-package-json.cjs
+++ b/packages/pipes-cli/scripts/restore-package-json.cjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+const backupPath = `${packageJsonPath}.prepack-backup`;
+
+if (fs.existsSync(backupPath)) {
+  fs.copyFileSync(backupPath, packageJsonPath);
+  fs.unlinkSync(backupPath);
+  console.log('[postpack] restored package.json');
+}

--- a/packages/pipes-cli/scripts/rewrite-workspace-deps.cjs
+++ b/packages/pipes-cli/scripts/rewrite-workspace-deps.cjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+const backupPath = `${packageJsonPath}.prepack-backup`;
+const workspaceRoot = path.resolve(__dirname, '..', '..', '..');
+const packagesDir = path.join(workspaceRoot, 'packages');
+
+if (fs.existsSync(backupPath)) {
+  fs.copyFileSync(backupPath, packageJsonPath);
+  fs.unlinkSync(backupPath);
+}
+
+const workspaceVersions = new Map();
+for (const entry of fs.readdirSync(packagesDir)) {
+  const subPkgPath = path.join(packagesDir, entry, 'package.json');
+  if (!fs.existsSync(subPkgPath)) continue;
+  const subPkg = JSON.parse(fs.readFileSync(subPkgPath, 'utf8'));
+  if (subPkg.name && subPkg.version) {
+    workspaceVersions.set(subPkg.name, subPkg.version);
+  }
+}
+
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const depFields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+const rewrites = [];
+
+for (const field of depFields) {
+  const deps = pkg[field];
+  if (!deps) continue;
+  for (const [name, range] of Object.entries(deps)) {
+    if (typeof range !== 'string' || !range.startsWith('workspace:')) continue;
+    const version = workspaceVersions.get(name);
+    if (!version) {
+      console.error(`[prepack] cannot resolve workspace version for "${name}"`);
+      process.exit(1);
+    }
+    deps[name] = version;
+    rewrites.push(`${field}.${name}: ${range} -> ${version}`);
+  }
+}
+
+if (rewrites.length === 0) {
+  process.exit(0);
+}
+
+fs.copyFileSync(packageJsonPath, backupPath);
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+for (const line of rewrites) console.log(`[prepack] ${line}`);

--- a/packages/pipes-cli/src/utils/package-root.ts
+++ b/packages/pipes-cli/src/utils/package-root.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 // Package name - must match package.json
-const PACKAGE_NAME = '@iankressin/pipes-cli'
+const PACKAGE_NAME = '@subsquid/pipes-cli'
 
 /**
  * Finds the package root directory by resolving the package location.


### PR DESCRIPTION
## Summary

- Add `prepack`/`postpack` lifecycle scripts that rewrite `workspace:*` to the resolved workspace version at pack time, so the tarball is correct regardless of which tool publishes it (`pnpm`, `npm`, etc.). Source still uses `workspace:*` so dev workflow is unchanged.
- Fix stale `PACKAGE_NAME` constant in `package-root.ts` that still referenced the pre-rename `@iankressin/pipes-cli`, causing the binary to crash with `Could not find package root` on first invocation.

## Why

`pnpx @subsquid/pipes-cli@latest` was failing with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` because both published tarballs (`1.0.0-alpha.1` and `1.0.0-alpha.2`) leaked `"@subsquid/pipes": "workspace:*"` into their `package.json`. Root cause: `workspace:*` is rewritten by `pnpm publish` but not by `npm publish`, and the manual verification step in the deploy skill was bypassed during release.

The previous fix (PR #74) updated the deploy skill with a manual verification step. This change makes the rewrite automatic at pack time so the tooling can no longer ship a broken tarball, even with `npm publish`.

After installing the fixed tarball, the CLI also crashed on first run because the `PACKAGE_NAME` constant in `src/utils/package-root.ts` was never updated when the package was renamed from `@iankressin/pipes-cli` to `@subsquid/pipes-cli`.

## How the prepack hook works

1. `prepack` runs `scripts/rewrite-workspace-deps.cjs`:
   - If a leftover backup exists from a previous interrupted run, restore it first (recovery).
   - Scan `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` for `workspace:*`.
   - For each match, look up the actual version from the corresponding workspace package's `package.json`.
   - Back up `package.json` to `package.json.prepack-backup` and write the rewritten file.
2. The pack tool produces the tarball using the rewritten `package.json`.
3. `postpack` runs `scripts/restore-package-json.cjs` and restores the source from the backup.

The `scripts/` directory is not in the `files` allowlist, so it never ships in the published tarball.

## Test plan

- [x] `pnpm pack` produces a tarball with `"@subsquid/pipes": "1.0.0-alpha.7"` (no `workspace:` reference).
- [x] `npm pack` produces the same clean tarball (verified independently).
- [x] Source `package.json` is restored to `workspace:*` after pack.
- [x] Recovery: running `prepack` twice in a row (simulating an interrupted previous pack) leaves source clean and backup correct.
- [x] Install the tarball into a clean directory via `npm install <tarball>` and run `./node_modules/.bin/pipes --help` — succeeds and prints the help text.
- [x] `pnpm link --global` from `packages/pipes-cli` and run `pipes --help` — succeeds.
- [x] `pnpm test` — 251 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)