### PR TITLE
fix(pipes): allow null refundAddress on suicide trace action

### DIFF
--- a/packages/subsquid-pipes/src/portal-client/query/evm.test.ts
+++ b/packages/subsquid-pipes/src/portal-client/query/evm.test.ts
@@ -80,3 +80,54 @@ describe('TransactionFields accessList validation', () => {
     expect(() => castAccessList([{ address: 'nothex', storageKeys: [] }])).toThrow()
   })
 })
+
+describe('TraceSuicideAction.refundAddress validation', () => {
+  function castSuicideTrace(refundAddress: unknown) {
+    const schema = getBlockSchema({
+      trace: {
+        type: true,
+        transactionIndex: true,
+        traceAddress: true,
+        subtraces: true,
+        error: true,
+        suicideAddress: true,
+        suicideRefundAddress: true,
+        suicideBalance: true,
+      },
+    })
+    const block = {
+      header: {},
+      traces: [
+        {
+          type: 'suicide',
+          transactionIndex: 0,
+          traceAddress: [],
+          subtraces: 0,
+          error: null,
+          action: {
+            address: '0x0000000000000000000000000000000000000001',
+            refundAddress,
+            balance: '0x0',
+          },
+        },
+      ],
+    }
+    return cast(schema, block).traces[0]
+  }
+
+  it('accepts null refundAddress (real SELFDESTRUCT edge case)', () => {
+    const trace = castSuicideTrace(null) as { action: { refundAddress: unknown } }
+    expect(trace.action.refundAddress).toBeNull()
+  })
+
+  it('accepts a valid hex refundAddress', () => {
+    const trace = castSuicideTrace('0x000000000000000000000000000000000000dead') as {
+      action: { refundAddress: unknown }
+    }
+    expect(trace.action.refundAddress).toBe('0x000000000000000000000000000000000000dead')
+  })
+
+  it('rejects a non-hex refundAddress', () => {
+    expect(() => castSuicideTrace('not-hex')).toThrow()
+  })
+})

--- a/packages/subsquid-pipes/src/portal-client/query/evm.ts
+++ b/packages/subsquid-pipes/src/portal-client/query/evm.ts
@@ -162,7 +162,7 @@ export type TraceSuicideFields = TraceBaseFields & {
 
 export type TraceSuicideActionFields = {
   address: Hex
-  refundAddress: Hex
+  refundAddress: Hex | null
   balance: bigint
 }
 
@@ -618,7 +618,7 @@ const TraceCallResultShape: ObjectValidatorShape<TraceCallResultFields> = {
 
 const TraceSuicideActionShape: ObjectValidatorShape<TraceSuicideActionFields> = {
   address: BYTES,
-  refundAddress: BYTES,
+  refundAddress: nullable(BYTES),
   balance: QTY,
 }
 


### PR DESCRIPTION
## Summary

- Fixes a production crash-loop in indexers that request `suicideRefundAddress` from `ethereum-mainnet`. Portal returns `null` for `action.refundAddress` on some real SELFDESTRUCT traces (confirmed reproducer: block `23,376,469`), but the EVM block schema declared `refundAddress` as a non-nullable hex string. The validator inside `evmPortalStream` rejected the payload with `DataValidationError` before any user `.pipe()` callback could intercept it, leaving the stream unrecoverable from the user side.
- `packages/subsquid-pipes/src/portal-client/query/evm.ts`: change `TraceSuicideActionShape.refundAddress` from `BYTES` to `nullable(BYTES)` and widen `TraceSuicideActionFields.refundAddress` to `Hex | null`. Mirrors the existing `nullable(STRING)` precedent on `TraceBaseFields.error`.
- Scope intentionally narrow: only `refundAddress` has a confirmed null repro from Portal; `suicideAddress` and `balance` are unchanged.

## Why `nullable` (not `option`)

`option(BYTES)` would coerce `null` → `undefined`, conflating "field not requested" with "field requested but chain returned null." `nullable(BYTES)` preserves the distinction and lets downstream targets (BigQuery `action_refund_address`, ClickHouse `Nullable(String)`) map to a proper `NULL` column rather than dropping the row or crashing.

## Test coverage

New describe block `TraceSuicideAction.refundAddress validation` in `packages/subsquid-pipes/src/portal-client/query/evm.test.ts`:

1. `accepts null refundAddress (real SELFDESTRUCT edge case)` — regression test reproducing the exact production error against the unfixed schema
2. `accepts a valid hex refundAddress` — guards against the fix accidentally rejecting normal addresses
3. `rejects a non-hex refundAddress` — guards against `nullable(BYTES)` being overly permissive

Tests use the project's standard `cast(schema, block)` + `getBlockSchema` pattern (no ad-hoc HTTP mocks), matching CLAUDE.md's testing rules.

### Coverage diff (`packages/subsquid-pipes/src/portal-client/query/evm.ts`)

Coverage measured by running `pnpm vitest run src/portal-client/query/evm.test.ts --coverage --coverage.include='src/portal-client/query/evm.ts'`:

| Metric    | Base (design/sdk1) | Head    | Δ            |
|-----------|--------------------|---------|--------------|
| Statements| 99.21%             | 99.21%  | —            |
| Branches  | 13.79%             | 89.65%  | **+75.86%**  |
| Functions | 100%               | 100%    | —            |
| Lines     | 99.21%             | 99.21%  | —            |

The big branch-coverage jump comes from the new tests exercising the suicide trace path of the validator (previously only the nonce path was covered by direct unit tests in this file).

## Test plan

- [x] Targeted failing test reproduces the production `DataValidationError` against the unfixed schema
- [x] All 3 new tests pass after the fix
- [x] Full offline suite passes: `pnpm vitest run --exclude '**/clickhouse/**' --exclude '**/postgres/**' --exclude '**/bigquery/**' --exclude '**/drizzle/**'` → 268/268
- [x] `tsc --noEmit` clean for changed files (only pre-existing unrelated BigQuery dep errors remain)
- [x] `biome check` clean on changed files
- [ ] Reviewer: confirm `nullable` (preserves null) over `option` (coerces to undefined) is the desired semantic for downstream targets
- [ ] Post-merge: cut a new `@subsquid/pipes` release so the `evm-traces` indexer can bump and resume from cursor `23,376,469`

🤖 Generated with [Claude Code](https://claude.com/claude-code)