### PR TITLE
feat(bigquery): add commit-stage metrics for data freshness

### DIFF
--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subsquid/pipes",
   "type": "module",
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "sideEffects": false,
   "author": "Subsquid Team",
   "files": [

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target-fork.integration.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target-fork.integration.test.ts
@@ -1,0 +1,682 @@
+import type { BigQuery } from '@google-cloud/bigquery'
+import type { managedwriter } from '@google-cloud/bigquery-storage'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import type { BlockCursor } from '~/core/index.js'
+import { evmPortalStream } from '~/evm/evm-portal-source.js'
+import {
+  type MockPortal,
+  type MockResponse,
+  blockDecoder,
+  createMockPortal,
+  createTestLogger,
+} from '~/testing/index.js'
+
+import { type BigQueryStore } from './bigquery-store.js'
+import { bigqueryTarget } from './bigquery-target.js'
+import {
+  DATASET,
+  PREFIX,
+  RUN,
+  makeBatchContext,
+  partitioning,
+  projectId,
+  setupIntegrationClients,
+  trackedTable,
+} from './integration-helpers.js'
+import { ensureTrackedTable } from './tables.js'
+
+/**
+ * Fork-lifecycle integration tests for the BigQuery target — gated by `BIGQUERY_TEST_PROJECT`.
+ *
+ * Run:
+ *   BIGQUERY_TEST_PROJECT=my-gcp-project \
+ *   BIGQUERY_TEST_DATASET=pipes_target_test \
+ *   pnpm vitest run src/targets/bigquery/bigquery-target-fork.integration.test.ts
+ *
+ * Lives in its own file because:
+ *   - These tests run real `target.write()` + `target.fork()` against a live BQ table; each
+ *     case runs for tens of seconds. Splitting them off lets `bigquery-target.integration.test`
+ *     finish DDL/visibility/type-mapping checks fast without waiting on the fork suite.
+ *   - The fork suite has its own helpers (`uniqueTables`, `buildTarget`, `readEvents`,
+ *     `readSyncCommittedCursors`) that don't belong in the broader integration file.
+ *
+ * Shared scaffolding (env vars, dataset bootstrap, `makeBatchContext`) lives in
+ * `./integration-helpers.ts`.
+ */
+
+describe.skipIf(!RUN)('bigquery target — fork lifecycle (integration)', () => {
+  let bigquery: BigQuery
+  let writer: managedwriter.WriterClient
+
+  beforeAll(async () => {
+    ;({ bigquery, writer } = await setupIntegrationClients())
+  }, 60_000)
+
+  describe('Storage Write API — write + fork end-to-end', () => {
+    // Each test gets its own dedicated events + sync table pair so writes from one test
+    // never contaminate another's row counts. The shared `${PREFIX}` sweep in `beforeAll`
+    // cleans them all up on the next run.
+
+    it('completes a write batch end-to-end and advances the cursor', async () => {
+      const localEvents = `${PREFIX}events_write_${Date.now()}`
+      const localSync = `${PREFIX}sync_write_${Date.now()}`
+      const target = bigqueryTarget<{ block_number: number; tx_hash: string }>({
+        client: { bigquery, writer },
+        dataset: DATASET,
+        tables: [{ ...trackedTable, table: localEvents }],
+        settings: { state: { table: localSync } },
+        onData: async ({ store, data }) => {
+          store.insert(localEvents, [data])
+        },
+      })
+
+      async function* read() {
+        yield {
+          data: { block_number: 1, tx_hash: '0x1' },
+          ctx: makeBatchContext({ number: 1, hash: '0x1' }),
+        }
+      }
+
+      await target.write({ read: read as never, logger: createTestLogger() })
+
+      const [rows] = await bigquery.query({
+        query: `SELECT block_number FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number = 1`,
+      })
+      expect(rows.length).toBe(1)
+    }, 60_000)
+
+    it('fork DELETE removes forked-block rows from a real BQ table', async () => {
+      // The central claim of this PR: DML on freshly-committed Storage Write rows works.
+      // Write blocks 1..10, fork at block 5, assert blocks 6..10 are gone and 1..5 remain.
+      const localEvents = `${PREFIX}events_fork_${Date.now()}`
+      const localSync = `${PREFIX}sync_fork_${Date.now()}`
+      const target = bigqueryTarget<{ block_number: number; tx_hash: string }>({
+        client: { bigquery, writer },
+        dataset: DATASET,
+        tables: [{ ...trackedTable, table: localEvents }],
+        settings: { state: { table: localSync } },
+        onData: async ({ store, data }) => {
+          store.insert(localEvents, [data])
+        },
+      })
+
+      async function* write1To10() {
+        for (let i = 1; i <= 10; i++) {
+          yield {
+            data: { block_number: i, tx_hash: `0x${i.toString(16)}` },
+            ctx: makeBatchContext({ number: i, hash: `0x${i.toString(16)}` }),
+          }
+        }
+      }
+
+      await target.write({ read: write1To10 as never, logger: createTestLogger() })
+
+      const [pre] = await bigquery.query({
+        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 1 AND 10`,
+      })
+      expect(Number(pre[0].n)).toBe(10)
+
+      const previousBlocks: BlockCursor[] = [
+        { number: 5, hash: '0x5' },
+        { number: 6, hash: 'BAD6' },
+        { number: 7, hash: 'BAD7' },
+        { number: 8, hash: 'BAD8' },
+        { number: 9, hash: 'BAD9' },
+        { number: 10, hash: 'BADA' },
+      ]
+      const safe = await target.fork!(previousBlocks)
+      expect(safe?.number).toBe(5)
+
+      const [post] = await bigquery.query({
+        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 6 AND 10`,
+      })
+      expect(Number(post[0].n)).toBe(0)
+
+      const [kept] = await bigquery.query({
+        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 1 AND 5`,
+      })
+      expect(Number(kept[0].n)).toBe(5)
+    }, 180_000)
+  })
+
+  describe('fork-rollback SQL', () => {
+    it('parameterised DELETE with numeric BETWEEN bounds runs cleanly', async () => {
+      const localEvents = `${PREFIX}events_dml_${Date.now()}`
+      await ensureTrackedTable({
+        bigquery,
+        projectId,
+        dataset: DATASET,
+        trackedTable: { ...trackedTable, table: localEvents },
+        partitioning,
+      })
+
+      const [job] = await bigquery.createQueryJob({
+        query: `DELETE FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN @low AND @high`,
+        params: { low: 100, high: 200 },
+      })
+      await job.getQueryResults()
+    }, 30_000)
+
+    it('keeps DELETE bytes-billed within partition width × row size (partition-pruning regression)', async () => {
+      const localEvents = `${PREFIX}events_dryrun_${Date.now()}`
+      await ensureTrackedTable({
+        bigquery,
+        projectId,
+        dataset: DATASET,
+        trackedTable: { ...trackedTable, table: localEvents },
+        partitioning,
+      })
+
+      const [job] = await bigquery.createQueryJob({
+        query: `DELETE FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number > @safe AND block_number <= @upper`,
+        params: { safe: 0, upper: 10 },
+        dryRun: true,
+      })
+      const bytesBilled = Number(job.metadata.statistics?.totalBytesProcessed ?? '0')
+      expect(bytesBilled).toBeLessThan(10 * 1024 * 1024) // <10MB scan for a 10-row range
+    })
+  })
+
+  // ---------------------------------------------------------------------------------------
+  // Fork scenarios driven through the full pipeTo() path with a mock portal.
+  //
+  // These mirror the ClickHouse / Postgres reorg suites: rather than calling target.fork()
+  // directly, we let evmPortalStream replay 409 reorg responses and observe BQ table /
+  // sync-table state after the framework drives target.fork() and re-stream automatically.
+  //
+  // Each test creates a fresh tracked + sync table pair so writes / DELETEs from one test
+  // never bleed into another. Tables are reaped on the next run by the PREFIX sweep in
+  // beforeAll — failed runs deliberately leave the inspectable state behind.
+  // ---------------------------------------------------------------------------------------
+
+  describe('forks (mock portal end-to-end)', () => {
+    let mockPortal: MockPortal | undefined
+
+    afterEach(async () => {
+      await mockPortal?.close()
+      mockPortal = undefined
+    })
+
+    /** Build a tracked-events + sync table pair with unique names for one test. */
+    function uniqueTables(slug: string) {
+      const stamp = Date.now()
+      return {
+        events: `${PREFIX}events_${slug}_${stamp}`,
+        sync: `${PREFIX}sync_${slug}_${stamp}`,
+      }
+    }
+
+    type Header = { number: number; hash: string; timestamp: number }
+
+    /**
+     * Builds a fork-test target. The generic stays explicit so hook callbacks
+     * (`onAfterRollback`, custom `onData`, etc) infer their parameter types
+     * instead of collapsing to `any` through a Parameters<…> spread.
+     */
+    function buildTarget(
+      events: string,
+      sync: string,
+      overrides: {
+        onData?: (ctx: { store: BigQueryStore; data: Header[] }) => Promise<unknown> | unknown
+        onBeforeRollback?: (ctx: { cursor: BlockCursor }) => Promise<unknown> | unknown
+        onAfterRollback?: (ctx: { cursor: BlockCursor }) => Promise<unknown> | unknown
+      } = {},
+    ) {
+      return bigqueryTarget<Header[]>({
+        client: { bigquery, writer },
+        dataset: DATASET,
+        tables: [{ ...trackedTable, table: events }],
+        settings: { state: { table: sync } },
+        onData:
+          overrides.onData ??
+          (({ store, data }) => {
+            store.insert(
+              events,
+              data.map((b) => ({ block_number: b.number, tx_hash: b.hash })),
+            )
+          }),
+        onBeforeRollback: overrides.onBeforeRollback,
+        onAfterRollback: overrides.onAfterRollback,
+      })
+    }
+
+    async function readEvents(events: string): Promise<{ block_number: number; tx_hash: string }[]> {
+      const [rows] = await bigquery.query({
+        query: `SELECT block_number, tx_hash FROM \`${projectId}.${DATASET}.${events}\` ORDER BY block_number ASC`,
+      })
+      return rows.map((r: { block_number: number | string; tx_hash: string }) => ({
+        block_number: Number(r.block_number),
+        tx_hash: r.tx_hash,
+      }))
+    }
+
+    async function readSyncCommittedCursors(
+      sync: string,
+    ): Promise<{ current: { number: number; hash: string }; finalized: { number: number; hash: string } | null }[]> {
+      // Project the same shape the ClickHouse suite asserts on: `current` (committed cursor),
+      // `finalized`, ordered by write time. `op='commit'` filters out IN_FLIGHT_ROLLBACK rows
+      // since those carry no meaningful cursor.
+      const [rows] = await bigquery.query({
+        query: `SELECT \`current\`, finalized FROM \`${projectId}.${DATASET}.${sync}\`
+                WHERE op = 'commit' AND committed = TRUE
+                ORDER BY \`timestamp\` ASC`,
+      })
+      return rows.map((r: { current: string | null; finalized: string | null }) => ({
+        current: JSON.parse(r.current ?? 'null'),
+        finalized: r.finalized ? JSON.parse(r.finalized) : null,
+      }))
+    }
+
+    it('handles a simple fork: re-streams forked tail and DELETE removes superseded rows', async () => {
+      const { events, sync } = uniqueTables('simple')
+
+      mockPortal = await createMockPortal([
+        // First batch: blocks 1..5 on the original chain.
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
+          ],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+        // 409 reorg: blocks 4 and 5 forked off the canonical chain.
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 2, hash: '0x2' },
+              { number: 3, hash: '0x3' },
+              { number: 4, hash: '0x4-1' },
+              { number: 5, hash: '0x5-1' },
+            ],
+          },
+        },
+        // Re-stream after the framework drives target.fork() — blocks 4..7 on the new chain.
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+          ],
+        },
+      ])
+
+      let beforeRollbacks = 0
+      let afterRollbacks = 0
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 7 }),
+      }).pipeTo(
+        buildTarget(events, sync, {
+          onBeforeRollback: ({ cursor }) => {
+            beforeRollbacks++
+            expect(cursor).toMatchObject({ number: 3, hash: '0x3' })
+          },
+          onAfterRollback: ({ cursor }) => {
+            afterRollbacks++
+            expect(cursor).toMatchObject({ number: 3, hash: '0x3' })
+          },
+        }),
+      )
+
+      expect(beforeRollbacks).toBe(1)
+      expect(afterRollbacks).toBe(1)
+
+      // Rows 1..3 from the original stream survive; 4-5 (orig) are gone; 4a-7a are present.
+      // The unique block_hash per row also proves we didn't accidentally double-insert
+      // (the WAL recovery range is [previousCursor+1, next] — a stale recovery would re-run
+      // a DELETE that wipes the rows we just inserted).
+      expect(await readEvents(events)).toEqual([
+        { block_number: 1, tx_hash: '0x1' },
+        { block_number: 2, tx_hash: '0x2' },
+        { block_number: 3, tx_hash: '0x3' },
+        { block_number: 4, tx_hash: '0x4a' },
+        { block_number: 5, tx_hash: '0x5a' },
+        { block_number: 6, tx_hash: '0x6a' },
+        { block_number: 7, tx_hash: '0x7a' },
+      ])
+    }, 240_000)
+
+    it('handles a fork whose finalized block is missing from the in-flight batch (multi-step rollback)', async () => {
+      const { events, sync } = uniqueTables('missing_finalized')
+
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
+          ],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+        // First reorg: only blocks 4..5 visible — common ancestor not yet found in this slice.
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 4, hash: '0x4a' },
+              { number: 5, hash: '0x5a' },
+            ],
+          },
+        },
+        // Second reorg: deeper slice surfaces ancestor at block 1.
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 1, hash: '0x1' },
+              { number: 2, hash: '0x2a' },
+              { number: 3, hash: '0x3a' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+          ],
+          head: { finalized: { number: 4, hash: '0x4a' } },
+        },
+      ])
+
+      const rollbackCursors: BlockCursor[] = []
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 7 }),
+      }).pipeTo(
+        buildTarget(events, sync, {
+          onAfterRollback: ({ cursor }) => {
+            rollbackCursors.push(cursor)
+          },
+        }),
+      )
+
+      // First fork resolves to block 3, second resolves all the way to block 1.
+      expect(rollbackCursors).toEqual([
+        expect.objectContaining({ number: 3, hash: '0x3' }),
+        expect.objectContaining({ number: 1, hash: '0x1' }),
+      ])
+
+      expect(await readEvents(events)).toEqual([
+        { block_number: 2, tx_hash: '0x2a' },
+        { block_number: 3, tx_hash: '0x3a' },
+        { block_number: 4, tx_hash: '0x4a' },
+        { block_number: 5, tx_hash: '0x5a' },
+        { block_number: 6, tx_hash: '0x6a' },
+        { block_number: 7, tx_hash: '0x7a' },
+      ])
+    }, 240_000)
+
+    it('handles a deep fork that rolls back to the last finalized block, including a mid-stream crash', async () => {
+      const { events, sync } = uniqueTables('deep_finalized')
+
+      // Two responses for the post-fork range: the first attempt crashes mid-batch (we throw
+      // inside onData), the second is consumed by the resumed pipeTo loop. Both must agree
+      // on parentBlockHash='0x3a' — proving recovery resumed from the persisted cursor.
+      const postForkBatch: MockResponse = {
+        statusCode: 200,
+        data: [
+          { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+          { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+          { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+          { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+        ],
+        head: { finalized: { number: 4, hash: '0x4a' } },
+      }
+
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
+          ],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 1, hash: '0x1' },
+              { number: 2, hash: '0x2a' },
+              { number: 3, hash: '0x3a' },
+              { number: 4, hash: '0x4a' },
+              { number: 5, hash: '0x5a' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+          ],
+          head: { finalized: { number: 2, hash: '0x2a' } },
+        },
+        postForkBatch,
+        postForkBatch,
+      ])
+
+      let crashes = 0
+      let finished = false
+      while (!finished) {
+        try {
+          await evmPortalStream({
+            id: 'test',
+            portal: mockPortal.url,
+            outputs: blockDecoder({ from: 0, to: 7 }),
+          }).pipeTo(
+            buildTarget(events, sync, {
+              onData: async ({ store, data }) => {
+                if (data[0]?.hash === '0x4a' && crashes === 0) {
+                  crashes++
+                  throw new Error('process failed')
+                }
+                store.insert(
+                  events,
+                  data.map((b: { number: number; hash: string }) => ({
+                    block_number: b.number,
+                    tx_hash: b.hash,
+                  })),
+                )
+                if (data.some((b: { hash: string }) => b.hash === '0x7a')) finished = true
+              },
+            }),
+          )
+          // Stream ended cleanly — done either way.
+          finished = true
+        } catch (e) {
+          if (!(e instanceof Error) || e.message !== 'process failed') throw e
+        }
+      }
+
+      expect(crashes).toBe(1)
+
+      // After recovery + replay, all canonical-chain blocks landed exactly once. Forked
+      // blocks 0x4 and 0x5 must have been DELETEd by tracker.fork(); the crash must NOT
+      // have left a stale 0x4a row that doubles up after restart.
+      expect(await readEvents(events)).toEqual([
+        { block_number: 1, tx_hash: '0x1' },
+        { block_number: 2, tx_hash: '0x2a' },
+        { block_number: 3, tx_hash: '0x3a' },
+        { block_number: 4, tx_hash: '0x4a' },
+        { block_number: 5, tx_hash: '0x5a' },
+        { block_number: 6, tx_hash: '0x6a' },
+        { block_number: 7, tx_hash: '0x7a' },
+      ])
+    }, 300_000)
+
+    it('handles a deep fork via two cascading rollbacks (no crash)', async () => {
+      const { events, sync } = uniqueTables('deep')
+
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
+          ],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+        // Shallow slice — only blocks 4-5 visible, no common ancestor here.
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 4, hash: '0x4a' },
+              { number: 5, hash: '0x5a' },
+            ],
+          },
+        },
+        // Deeper slice — ancestor at block 1.
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 1, hash: '0x1' },
+              { number: 2, hash: '0x2a' },
+              { number: 3, hash: '0x3a' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+          ],
+        },
+      ])
+
+      const rollbackCursors: BlockCursor[] = []
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 7 }),
+      }).pipeTo(
+        buildTarget(events, sync, {
+          onAfterRollback: ({ cursor }) => {
+            rollbackCursors.push(cursor)
+          },
+        }),
+      )
+
+      expect(rollbackCursors.map((c) => c.number)).toEqual([3, 1])
+
+      expect(await readEvents(events)).toEqual([
+        { block_number: 1, tx_hash: '0x1' },
+        { block_number: 2, tx_hash: '0x2a' },
+        { block_number: 3, tx_hash: '0x3a' },
+        { block_number: 4, tx_hash: '0x4a' },
+        { block_number: 5, tx_hash: '0x5a' },
+        { block_number: 6, tx_hash: '0x6a' },
+        { block_number: 7, tx_hash: '0x7a' },
+      ])
+    }, 240_000)
+
+    it('resumes from the last persisted cursor after a clean stop (parentBlockHash threaded through)', async () => {
+      const { events, sync } = uniqueTables('resume')
+
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [{ header: { number: 1, hash: '0x1', timestamp: 1000 } }],
+        },
+        {
+          statusCode: 200,
+          data: [{ header: { number: 2, hash: '0x2', timestamp: 2000 } }],
+          // The portal contract: after restart, the request must include the parentBlockHash
+          // of the previously persisted cursor so the portal can detect any fork that happened
+          // while we were down.
+          validateRequest: (req) => {
+            expect(req).toMatchObject({
+              type: 'evm',
+              fromBlock: 2,
+              parentBlockHash: '0x1',
+            })
+          },
+        },
+      ])
+
+      // First run: ingest block 1 and stop cleanly.
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 1 }),
+      }).pipeTo(buildTarget(events, sync))
+
+      // Second run with a fresh stream: the BigQuery sync table holds the previous cursor,
+      // so getCursor() must read it back and the new stream must request block 2 with the
+      // expected parentBlockHash. validateRequest in the mock asserts that.
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 1, to: 2 }),
+      }).pipeTo(buildTarget(events, sync))
+
+      expect(await readEvents(events)).toEqual([
+        { block_number: 1, tx_hash: '0x1' },
+        { block_number: 2, tx_hash: '0x2' },
+      ])
+    }, 240_000)
+
+    it('records cursor + finalized for every committed batch in the sync table', async () => {
+      const { events, sync } = uniqueTables('sync_state')
+
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
+          ],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+      ])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(buildTarget(events, sync))
+
+      // `evmPortalStream` may split a single portal response into multiple per-batch
+      // emissions; assert on the FINAL committed cursor rather than counting rows. What
+      // matters for resumption correctness is that the latest commit reflects the last
+      // block we processed, with the finalized pointer the portal advertised.
+      const rows = await readSyncCommittedCursors(sync)
+      expect(rows.length).toBeGreaterThan(0)
+      expect(rows[rows.length - 1]).toMatchObject({
+        current: { number: 3, hash: '0x3' },
+        finalized: { number: 1, hash: '0x1' },
+      })
+    }, 180_000)
+  })
+})

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.integration.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.integration.test.ts
@@ -1,27 +1,24 @@
-import { BigQuery } from '@google-cloud/bigquery'
-import { managedwriter } from '@google-cloud/bigquery-storage'
-import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import type { BigQuery, TableField } from '@google-cloud/bigquery'
+import type { managedwriter } from '@google-cloud/bigquery-storage'
+import { beforeAll, describe, expect, it } from 'vitest'
 
-import type { BatchContext, BlockCursor } from '~/core/index.js'
-import { evmPortalStream } from '~/evm/evm-portal-source.js'
-import {
-  type MockPortal,
-  type MockResponse,
-  blockDecoder,
-  createMockPortal,
-  createTestLogger,
-} from '~/testing/index.js'
+import { createTestLogger } from '~/testing/index.js'
 
 import { BigQueryState } from './bigquery-state.js'
 import { BigQueryStore } from './bigquery-store.js'
 import { bigqueryTarget } from './bigquery-target.js'
 import {
-  type TrackedTable,
-  ensureTrackedTable,
-  partitioningWithDefaults,
-  syncTableDdl,
-  trackedTableDdl,
-} from './tables.js'
+  DATASET,
+  PREFIX,
+  PROJECT,
+  RUN,
+  makeBatchContext,
+  partitioning,
+  projectId,
+  setupIntegrationClients,
+  trackedTable,
+} from './integration-helpers.js'
+import { type TrackedTable, ensureTrackedTable, syncTableDdl, trackedTableDdl } from './tables.js'
 
 /**
  * Integration tests for the BigQuery target — gated by `BIGQUERY_TEST_PROJECT`.
@@ -35,84 +32,18 @@ import {
  *   BIGQUERY_TEST_DATASET=pipes_target_test \
  *   pnpm vitest run src/targets/bigquery/bigquery-target.integration.test.ts
  *
- * What this suite verifies that unit tests cannot:
- *   - Generated DDL is accepted by the live SQL parser (catches reserved-keyword bugs and
- *     clause-ordering mistakes that mocked tests can't surface).
- *   - `BigQueryState.getCursor` round-trips through real REST (Not Found error → CREATE
- *     TABLE → returns undefined).
- *   - Real Storage Write API Pending mode end-to-end (CreateWriteStream → AppendRows →
- *     FinalizeWriteStream → BatchCommitWriteStreams over actual gRPC).
- *   - GA DML on freshly streamed rows: DELETE within seconds of the Pending commit
- *     succeeds — the central correctness claim of this target.
- *   - Partition pruning: `dryRun` bytes-billed for a fork DELETE stays within
- *     partition_width × row_size, proving both bounds in the predicate fire static
- *     partition pruning at the planner.
+ * Scope of this file: schema management, Storage Write API visibility, type-mapping
+ * round-trip. Fork lifecycle lives in `bigquery-target-fork.integration.test.ts`. Shared
+ * scaffolding (env vars, dataset bootstrap, BatchContext stub) lives in `./integration-helpers`.
  */
 
-const PROJECT = process.env['BIGQUERY_TEST_PROJECT']
-const DATASET = process.env['BIGQUERY_TEST_DATASET'] ?? 'pipes_target_test'
-const RUN = !!PROJECT
-
 describe.skipIf(!RUN)('bigquery target — integration', () => {
-  // `describe.skipIf(!RUN)` gates on PROJECT being set, so inside the suite we narrow once.
-  const projectId = PROJECT as string
-
   let bigquery: BigQuery
   let writer: managedwriter.WriterClient
 
-  // Every table this suite creates uses this prefix. Two reasons:
-  //   1. The leftover-sweep in `beforeAll` matches exactly these tables — never the user's
-  //      own data sharing the same dataset.
-  //   2. Easy to spot test artefacts in the BigQuery console.
-  // Each test then appends its own `<purpose>_<timestamp>` so failures leave inspectable
-  // state behind without contaminating sibling tests.
-  const PREFIX = 'e2e_test_'
-  const partitioning = partitioningWithDefaults()
-
-  // Schema template — copied per-test with an overridden `table` name.
-  const trackedTable: TrackedTable = {
-    table: 'unused', // overridden per-test
-    blockNumberColumn: 'block_number',
-    schema: [
-      { name: 'block_number', type: 'INT64', mode: 'REQUIRED' },
-      { name: 'tx_hash', type: 'STRING' },
-    ],
-  }
-
   beforeAll(async () => {
-    bigquery = new BigQuery({ projectId })
-    writer = new managedwriter.WriterClient({ projectId })
-
-    const [exists] = await bigquery.dataset(DATASET).exists()
-    if (!exists) await bigquery.createDataset(DATASET)
-
-    // Drop leftover tables from previous runs. Tests do NOT clean up after themselves on
-    // purpose — we want failed runs to leave their state behind for inspection. The next
-    // run wipes via this prefix-scoped sweep, so leftovers never accumulate beyond one run.
-    const [allTables] = await bigquery.dataset(DATASET).getTables()
-    await Promise.all(
-      allTables
-        .filter((t) => (t.id ?? '').startsWith(PREFIX))
-        .map((t) => t.delete({ ignoreNotFound: true }).catch(() => {})),
-    )
+    ;({ bigquery, writer } = await setupIntegrationClients())
   }, 60_000)
-
-  /** Helper: produce a synthetic BatchContext for direct target.write loops. */
-  function makeBatchContext(current: BlockCursor): BatchContext {
-    const profilerStub: Record<string, unknown> = {
-      start: () => profilerStub,
-      measure: async (_: unknown, fn: () => unknown) => fn(),
-      end: () => {},
-    }
-    return {
-      logger: createTestLogger(),
-      profiler: profilerStub,
-      stream: {
-        state: { current, rollbackChain: [current] },
-        head: { finalized: undefined, latest: current },
-      },
-    } as unknown as BatchContext
-  }
 
   describe('DDL parse — generated SQL is accepted by the live BigQuery parser', () => {
     it('sync-table DDL: backtick-quoted reserved keywords + DEFAULT ordering', async () => {
@@ -213,630 +144,324 @@ describe.skipIf(!RUN)('bigquery target — integration', () => {
     }, 30_000)
   })
 
-  describe('Storage Write API — write + fork end-to-end', () => {
-    // Each test gets its own dedicated events + sync table pair so writes from one test
-    // never contaminate another's row counts. The shared `${PREFIX}` sweep in `beforeAll`
-    // cleans them all up on the next run.
+  // ---------------------------------------------------------------------------------------
+  // Type-mapping coverage — Storage Write API round-trip.
+  //
+  // Verifies what JS shapes the BigQueryStore accepts per BQ column type, and that the value
+  // SQL reads back equals what we wrote. Each column owns one bullet of the matrix (no hidden
+  // coupling) so a regression on, say, NUMERIC fails its own assertion line and not the rest.
+  //
+  // Specifically targets the NUMERIC/BIGNUMERIC claim in the docs example: SDK 5.x maps both
+  // to proto TYPE_STRING (see @google-cloud/bigquery-storage/.../adapt/proto_mappings.js), and
+  // the proto-row encoder turns number/bigint into base-10 strings while passing JS strings
+  // through verbatim. If the older "string hangs silently on AppendRows" still bites, this
+  // suite is where it surfaces — and the docs comment can be retired.
+  // ---------------------------------------------------------------------------------------
 
-    it('completes a write batch end-to-end and advances the cursor', async () => {
-      const localEvents = `${PREFIX}events_write_${Date.now()}`
-      const localSync = `${PREFIX}sync_write_${Date.now()}`
-      const target = bigqueryTarget<{ block_number: number; tx_hash: string }>({
+  describe('type mappings (Storage Write API round-trip)', () => {
+    // Shared values across the auto-DDL and manual-DDL tests so a regression that only affects
+    // one path (e.g. encoder vs DDL emission) is easy to spot — same input, different setup.
+
+    // BIGNUMERIC range is ±5.79e38 — i.e. up to 38 digits before the decimal point, plus 38
+    // after. 38 before is comfortably outside INT64 (~19 digits), so a regression that
+    // quietly truncates to INT64 still surfaces; going past 38 before would overflow the
+    // type itself ("Invalid BIGNUMERIC value" from AppendRows).
+    const bigNumericString = '12345678901234567890123456789012345678.1234567890'
+    // NUMERIC range: ~38 digits, scale 9 — keep well within bounds, with a non-zero fractional
+    // part so a "lost the fraction" bug fails the equality check.
+    const numericFromString = '12345.6789'
+    const dateValue = new Date(Date.UTC(2026, 4, 9)) // 2026-05-09
+    const timestampValue = new Date(Date.UTC(2026, 4, 9, 12, 34, 56, 789))
+
+    const SCALAR_FIELDS = [
+      { name: 'block_number', type: 'INT64', mode: 'REQUIRED' },
+      { name: 'col_int64', type: 'INT64' },
+      { name: 'col_int64_str', type: 'INT64' }, // INT64 written as JS string (max-safe-integer fix)
+      { name: 'col_float64', type: 'FLOAT64' },
+      { name: 'col_bool', type: 'BOOL' },
+      { name: 'col_string', type: 'STRING' },
+      { name: 'col_bytes', type: 'BYTES' },
+      // The whole point of the suite — if these fail, the docs example's STRING workaround is
+      // justified. If they pass, we update the example.
+      { name: 'col_numeric_from_number', type: 'NUMERIC' },
+      { name: 'col_numeric_from_bigint', type: 'NUMERIC' },
+      { name: 'col_numeric_from_string', type: 'NUMERIC' },
+      { name: 'col_bignumeric_from_string', type: 'BIGNUMERIC' },
+      { name: 'col_date', type: 'DATE' }, // expects JS Date per encoder.js:140-145
+      { name: 'col_timestamp', type: 'TIMESTAMP' }, // expects JS Date per encoder.js:140-153
+      { name: 'col_json', type: 'JSON' }, // BQ JSON type — encoder treats as STRING in proto
+    ] as const satisfies readonly TableField[]
+
+    const scalarRow: Record<string, unknown> = {
+      block_number: 1,
+      col_int64: 42,
+      // Numbers above 2^53 must travel as a string-typed field — JS number loses precision
+      // around 9.007e15 and the encoder would silently round.
+      col_int64_str: '9007199254740993',
+      col_float64: 3.14,
+      col_bool: true,
+      col_string: 'hello, мир',
+      col_bytes: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+      col_numeric_from_number: 1234,
+      col_numeric_from_bigint: 1234567890123456789n,
+      col_numeric_from_string: numericFromString,
+      col_bignumeric_from_string: bigNumericString,
+      col_date: dateValue,
+      col_timestamp: timestampValue,
+      col_json: '{"a":1,"b":[2,3]}',
+    }
+
+    type ScalarReadRow = {
+      col_int64: string
+      col_int64_str: string
+      col_float64: number
+      col_bool: boolean
+      col_string: string
+      col_bytes_hex: string
+      num_number: string
+      num_bigint: string
+      num_string: string
+      bignum_string: string
+      d: string
+      ts: string
+      j: string
+    }
+
+    /**
+     * Cast every non-trivial type to STRING BQ-side so the JS client doesn't surface
+     * Big.js / PreciseDate / Buffer-with-quirks — and so INT64 values past 2^53 round-trip
+     * intact. The default `bigquery.query` returns INT64 as a JS Number, which truncates
+     * `9007199254740993` to `9007199254740992` on the read path even though the stored
+     * value is correct. CAST(... AS STRING) forces lossless transit.
+     */
+    const SCALAR_SELECT = `
+      CAST(col_int64 AS STRING) AS col_int64,
+      CAST(col_int64_str AS STRING) AS col_int64_str,
+      col_float64,
+      col_bool,
+      col_string,
+      TO_HEX(col_bytes) AS col_bytes_hex,
+      CAST(col_numeric_from_number AS STRING) AS num_number,
+      CAST(col_numeric_from_bigint AS STRING) AS num_bigint,
+      CAST(col_numeric_from_string AS STRING) AS num_string,
+      CAST(col_bignumeric_from_string AS STRING) AS bignum_string,
+      CAST(col_date AS STRING) AS d,
+      FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', col_timestamp, 'UTC') AS ts,
+      TO_JSON_STRING(col_json) AS j
+    `
+
+    function assertScalarRow(r: ScalarReadRow): void {
+      expect(Number(r.col_int64)).toBe(42)
+      expect(String(r.col_int64_str)).toBe('9007199254740993')
+      expect(Number(r.col_float64)).toBeCloseTo(3.14, 6)
+      expect(r.col_bool).toBe(true)
+      expect(r.col_string).toBe('hello, мир')
+      expect(r.col_bytes_hex).toBe('deadbeef')
+      // BQ NUMERIC normalizes scale on read — '12345.6789' may come back as '12345.678900000'.
+      // Use Number-equality instead of string-equality so we test the value, not the format.
+      expect(Number(r.num_number)).toBe(1234)
+      expect(String(r.num_bigint)).toBe('1234567890123456789')
+      expect(Number(r.num_string)).toBe(12345.6789)
+      // BIGNUMERIC has 76-digit precision; can't compare via JS Number. Strip trailing zeros
+      // to compare meaningful digits only.
+      expect(r.bignum_string.replace(/0+$/, '')).toBe(bigNumericString.replace(/0+$/, ''))
+      expect(r.d).toBe('2026-05-09')
+      expect(r.ts).toBe('2026-05-09T12:34:56.789Z')
+      // BQ JSON normalizes whitespace; assert structural equality, not byte-equality.
+      expect(JSON.parse(r.j)).toEqual({ a: 1, b: [2, 3] })
+    }
+
+    it('auto-DDL: round-trips every flat scalar type the SDK auto-creates', async () => {
+      // Pure auto-create path. No REPEATED, no RECORD — those are the auto-DDL guard's
+      // responsibility (see assertFlatSchema). Anything in here MUST work end-to-end via
+      // ensureTrackedTable + Storage Write API + SQL read-back.
+      const localEvents = `${PREFIX}types_auto_${Date.now()}`
+      const trackedTableScalars: TrackedTable = {
+        table: localEvents,
+        blockNumberColumn: 'block_number',
+        schema: [...SCALAR_FIELDS],
+      }
+
+      const target = bigqueryTarget<Record<string, unknown>>({
         client: { bigquery, writer },
         dataset: DATASET,
-        tables: [{ ...trackedTable, table: localEvents }],
-        settings: { state: { table: localSync } },
+        tables: [trackedTableScalars],
+        settings: { state: { table: `${PREFIX}types_auto_sync_${Date.now()}` } },
         onData: async ({ store, data }) => {
           store.insert(localEvents, [data])
         },
       })
 
       async function* read() {
-        yield {
-          data: { block_number: 1, tx_hash: '0x1' },
-          ctx: makeBatchContext({ number: 1, hash: '0x1' }),
-        }
+        yield { data: scalarRow, ctx: makeBatchContext({ number: 1, hash: '0x1' }) }
       }
-
       await target.write({ read: read as never, logger: createTestLogger() })
 
       const [rows] = await bigquery.query({
-        query: `SELECT block_number FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number = 1`,
+        query: `SELECT ${SCALAR_SELECT} FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number = 1`,
       })
       expect(rows.length).toBe(1)
-    }, 60_000)
+      assertScalarRow(rows[0] as ScalarReadRow)
+    }, 120_000)
 
-    it('fork DELETE removes forked-block rows from a real BQ table', async () => {
-      // The central claim of this PR: DML on freshly-committed Storage Write rows works.
-      // Write blocks 1..10, fork at block 5, assert blocks 6..10 are gone and 1..5 remain.
-      const localEvents = `${PREFIX}events_fork_${Date.now()}`
-      const localSync = `${PREFIX}sync_fork_${Date.now()}`
-      const target = bigqueryTarget<{ block_number: number; tx_hash: string }>({
+    it('manual DDL: scalar matrix + REPEATED INT64 + nested RECORD round-trip', async () => {
+      // Pre-create the table manually so the schema can carry REPEATED / RECORD — those modes
+      // are blocked by `assertFlatSchema` in the auto-DDL path. The SDK's documented escape
+      // hatch is "create the table yourself and re-run; the target will validate". This test
+      // exercises that path. Partition clause matches `partitioningWithDefaults()` so the
+      // validator accepts.
+      const localEvents = `${PREFIX}types_manual_${Date.now()}`
+
+      if (!partitioning) throw new Error('integration suite assumes default partitioning is enabled')
+      await bigquery.query({
+        query: `
+          CREATE TABLE \`${projectId}.${DATASET}.${localEvents}\` (
+            block_number INT64 NOT NULL,
+            col_int64 INT64,
+            col_int64_str INT64,
+            col_float64 FLOAT64,
+            col_bool BOOL,
+            col_string STRING,
+            col_bytes BYTES,
+            col_numeric_from_number NUMERIC,
+            col_numeric_from_bigint NUMERIC,
+            col_numeric_from_string NUMERIC,
+            col_bignumeric_from_string BIGNUMERIC,
+            col_date DATE,
+            col_timestamp TIMESTAMP,
+            col_json JSON,
+            col_array_int64 ARRAY<INT64>,
+            col_record STRUCT<inner_int INT64, inner_string STRING>
+          )
+          PARTITION BY RANGE_BUCKET(block_number, GENERATE_ARRAY(0, ${partitioning.maxBlocks}, ${partitioning.bucketSize}))
+        `,
+      })
+
+      const trackedTableNested: TrackedTable = {
+        table: localEvents,
+        blockNumberColumn: 'block_number',
+        schema: [
+          ...SCALAR_FIELDS,
+          { name: 'col_array_int64', type: 'INT64', mode: 'REPEATED' },
+          {
+            name: 'col_record',
+            type: 'RECORD',
+            fields: [
+              { name: 'inner_int', type: 'INT64' },
+              { name: 'inner_string', type: 'STRING' },
+            ],
+          },
+        ],
+      }
+
+      const target = bigqueryTarget<Record<string, unknown>>({
         client: { bigquery, writer },
         dataset: DATASET,
-        tables: [{ ...trackedTable, table: localEvents }],
-        settings: { state: { table: localSync } },
+        tables: [trackedTableNested],
+        settings: { state: { table: `${PREFIX}types_manual_sync_${Date.now()}` } },
         onData: async ({ store, data }) => {
           store.insert(localEvents, [data])
         },
       })
 
-      async function* write1To10() {
-        for (let i = 1; i <= 10; i++) {
-          yield {
-            data: { block_number: i, tx_hash: `0x${i.toString(16)}` },
-            ctx: makeBatchContext({ number: i, hash: `0x${i.toString(16)}` }),
-          }
-        }
+      const row: Record<string, unknown> = {
+        ...scalarRow,
+        col_array_int64: [10, 20, 30],
+        col_record: { inner_int: 7, inner_string: 'inside' },
       }
 
-      await target.write({ read: write1To10 as never, logger: createTestLogger() })
+      async function* read() {
+        yield { data: row, ctx: makeBatchContext({ number: 1, hash: '0x1' }) }
+      }
+      await target.write({ read: read as never, logger: createTestLogger() })
 
-      const [pre] = await bigquery.query({
-        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 1 AND 10`,
+      const [rows] = await bigquery.query({
+        query: `
+          SELECT
+            ${SCALAR_SELECT},
+            col_array_int64,
+            col_record.inner_int AS rec_int,
+            col_record.inner_string AS rec_string
+          FROM \`${projectId}.${DATASET}.${localEvents}\`
+          WHERE block_number = 1
+        `,
       })
-      expect(Number(pre[0].n)).toBe(10)
+      expect(rows.length).toBe(1)
+      type NestedRow = ScalarReadRow & {
+        col_array_int64: unknown[]
+        rec_int: number | string
+        rec_string: string
+      }
+      const r = rows[0] as NestedRow
 
-      const previousBlocks: BlockCursor[] = [
-        { number: 5, hash: '0x5' },
-        { number: 6, hash: 'BAD6' },
-        { number: 7, hash: 'BAD7' },
-        { number: 8, hash: 'BAD8' },
-        { number: 9, hash: 'BAD9' },
-        { number: 10, hash: 'BADA' },
-      ]
-      const safe = await target.fork!(previousBlocks)
-      expect(safe?.number).toBe(5)
+      assertScalarRow(r)
+      expect(r.col_array_int64.map((v) => Number(v))).toEqual([10, 20, 30])
+      expect(Number(r.rec_int)).toBe(7)
+      expect(r.rec_string).toBe('inside')
+    }, 120_000)
 
-      const [post] = await bigquery.query({
-        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 6 AND 10`,
-      })
-      expect(Number(post[0].n)).toBe(0)
+    it('writes NULL for omitted fields and explicit nulls', async () => {
+      // The encoder skips keys whose value is null/undefined (encoder.js convertRow). For
+      // NULLABLE columns BQ writes NULL — the same behavior whether the key is omitted or
+      // present-and-null. This pins both paths so a future encoder change that, say, writes
+      // empty-string for missing STRING is caught immediately.
+      const localEvents = `${PREFIX}types_null_${Date.now()}`
+      const trackedTableNulls: TrackedTable = {
+        table: localEvents,
+        blockNumberColumn: 'block_number',
+        schema: [
+          { name: 'block_number', type: 'INT64', mode: 'REQUIRED' },
+          { name: 'col_string_nullable', type: 'STRING' },
+          { name: 'col_int64_nullable', type: 'INT64' },
+          { name: 'col_numeric_nullable', type: 'NUMERIC' },
+        ],
+      }
 
-      const [kept] = await bigquery.query({
-        query: `SELECT COUNT(*) AS n FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN 1 AND 5`,
-      })
-      expect(Number(kept[0].n)).toBe(5)
-    }, 180_000)
-  })
-
-  describe('fork-rollback SQL', () => {
-    it('parameterised DELETE with numeric BETWEEN bounds runs cleanly', async () => {
-      const localEvents = `${PREFIX}events_dml_${Date.now()}`
       await ensureTrackedTable({
         bigquery,
         projectId,
         dataset: DATASET,
-        trackedTable: { ...trackedTable, table: localEvents },
+        trackedTable: trackedTableNulls,
         partitioning,
       })
 
-      const [job] = await bigquery.createQueryJob({
-        query: `DELETE FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number BETWEEN @low AND @high`,
-        params: { low: 100, high: 200 },
-      })
-      await job.getQueryResults()
-    }, 30_000)
-
-    it('keeps DELETE bytes-billed within partition width × row size (partition-pruning regression)', async () => {
-      const localEvents = `${PREFIX}events_dryrun_${Date.now()}`
-      await ensureTrackedTable({
-        bigquery,
-        projectId,
-        dataset: DATASET,
-        trackedTable: { ...trackedTable, table: localEvents },
-        partitioning,
-      })
-
-      const [job] = await bigquery.createQueryJob({
-        query: `DELETE FROM \`${projectId}.${DATASET}.${localEvents}\` WHERE block_number > @safe AND block_number <= @upper`,
-        params: { safe: 0, upper: 10 },
-        dryRun: true,
-      })
-      const bytesBilled = Number(job.metadata.statistics?.totalBytesProcessed ?? '0')
-      expect(bytesBilled).toBeLessThan(10 * 1024 * 1024) // <10MB scan for a 10-row range
-    })
-  })
-
-  // ---------------------------------------------------------------------------------------
-  // Fork scenarios driven through the full pipeTo() path with a mock portal.
-  //
-  // These mirror the ClickHouse / Postgres reorg suites: rather than calling target.fork()
-  // directly, we let evmPortalStream replay 409 reorg responses and observe BQ table /
-  // sync-table state after the framework drives target.fork() and re-stream automatically.
-  //
-  // Each test creates a fresh tracked + sync table pair so writes / DELETEs from one test
-  // never bleed into another. Tables are reaped on the next run by the PREFIX sweep in
-  // beforeAll — failed runs deliberately leave the inspectable state behind.
-  // ---------------------------------------------------------------------------------------
-
-  describe('forks (mock portal end-to-end)', () => {
-    let mockPortal: MockPortal | undefined
-
-    afterEach(async () => {
-      await mockPortal?.close()
-      mockPortal = undefined
-    })
-
-    /** Build a tracked-events + sync table pair with unique names for one test. */
-    function uniqueTables(slug: string) {
-      const stamp = Date.now()
-      return {
-        events: `${PREFIX}events_${slug}_${stamp}`,
-        sync: `${PREFIX}sync_${slug}_${stamp}`,
-      }
-    }
-
-    type Header = { number: number; hash: string; timestamp: number }
-
-    /**
-     * Builds a fork-test target. The generic stays explicit so hook callbacks
-     * (`onAfterRollback`, custom `onData`, etc) infer their parameter types
-     * instead of collapsing to `any` through a Parameters<…> spread.
-     */
-    function buildTarget(
-      events: string,
-      sync: string,
-      overrides: {
-        onData?: (ctx: { store: BigQueryStore; data: Header[] }) => Promise<unknown> | unknown
-        onBeforeRollback?: (ctx: { cursor: BlockCursor }) => Promise<unknown> | unknown
-        onAfterRollback?: (ctx: { cursor: BlockCursor }) => Promise<unknown> | unknown
-      } = {},
-    ) {
-      return bigqueryTarget<Header[]>({
+      const target = bigqueryTarget<Record<string, unknown>>({
         client: { bigquery, writer },
         dataset: DATASET,
-        tables: [{ ...trackedTable, table: events }],
-        settings: { state: { table: sync } },
-        onData:
-          overrides.onData ??
-          (({ store, data }) => {
-            store.insert(
-              events,
-              data.map((b) => ({ block_number: b.number, tx_hash: b.hash })),
-            )
-          }),
-        onBeforeRollback: overrides.onBeforeRollback,
-        onAfterRollback: overrides.onAfterRollback,
+        tables: [trackedTableNulls],
+        settings: { state: { table: `${PREFIX}types_null_sync_${Date.now()}` } },
+        onData: async ({ store, data }) => {
+          store.insert(localEvents, [data])
+        },
       })
-    }
 
-    async function readEvents(events: string): Promise<{ block_number: number; tx_hash: string }[]> {
-      const [rows] = await bigquery.query({
-        query: `SELECT block_number, tx_hash FROM \`${projectId}.${DATASET}.${events}\` ORDER BY block_number ASC`,
-      })
-      return rows.map((r: { block_number: number | string; tx_hash: string }) => ({
-        block_number: Number(r.block_number),
-        tx_hash: r.tx_hash,
-      }))
-    }
-
-    async function readSyncCommittedCursors(
-      sync: string,
-    ): Promise<{ current: { number: number; hash: string }; finalized: { number: number; hash: string } | null }[]> {
-      // Project the same shape the ClickHouse suite asserts on: `current` (committed cursor),
-      // `finalized`, ordered by write time. `op='commit'` filters out IN_FLIGHT_ROLLBACK rows
-      // since those carry no meaningful cursor.
-      const [rows] = await bigquery.query({
-        query: `SELECT \`current\`, finalized FROM \`${projectId}.${DATASET}.${sync}\`
-                WHERE op = 'commit' AND committed = TRUE
-                ORDER BY \`timestamp\` ASC`,
-      })
-      return rows.map((r: { current: string | null; finalized: string | null }) => ({
-        current: JSON.parse(r.current ?? 'null'),
-        finalized: r.finalized ? JSON.parse(r.finalized) : null,
-      }))
-    }
-
-    it('handles a simple fork: re-streams forked tail and DELETE removes superseded rows', async () => {
-      const { events, sync } = uniqueTables('simple')
-
-      mockPortal = await createMockPortal([
-        // First batch: blocks 1..5 on the original chain.
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
-            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
-          ],
-          head: { finalized: { number: 1, hash: '0x1' } },
-        },
-        // 409 reorg: blocks 4 and 5 forked off the canonical chain.
-        {
-          statusCode: 409,
+      async function* read() {
+        // block 1 omits keys; block 2 sets them to null. Both should land as SQL NULL.
+        yield { data: { block_number: 1 }, ctx: makeBatchContext({ number: 1, hash: '0x1' }) }
+        yield {
           data: {
-            previousBlocks: [
-              { number: 2, hash: '0x2' },
-              { number: 3, hash: '0x3' },
-              { number: 4, hash: '0x4-1' },
-              { number: 5, hash: '0x5-1' },
-            ],
+            block_number: 2,
+            col_string_nullable: null,
+            col_int64_nullable: null,
+            col_numeric_nullable: null,
           },
-        },
-        // Re-stream after the framework drives target.fork() — blocks 4..7 on the new chain.
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
-            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
-            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
-          ],
-        },
-      ])
-
-      let beforeRollbacks = 0
-      let afterRollbacks = 0
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 0, to: 7 }),
-      }).pipeTo(
-        buildTarget(events, sync, {
-          onBeforeRollback: ({ cursor }) => {
-            beforeRollbacks++
-            expect(cursor).toMatchObject({ number: 3, hash: '0x3' })
-          },
-          onAfterRollback: ({ cursor }) => {
-            afterRollbacks++
-            expect(cursor).toMatchObject({ number: 3, hash: '0x3' })
-          },
-        }),
-      )
-
-      expect(beforeRollbacks).toBe(1)
-      expect(afterRollbacks).toBe(1)
-
-      // Rows 1..3 from the original stream survive; 4-5 (orig) are gone; 4a-7a are present.
-      // The unique block_hash per row also proves we didn't accidentally double-insert
-      // (the WAL recovery range is [previousCursor+1, next] — a stale recovery would re-run
-      // a DELETE that wipes the rows we just inserted).
-      expect(await readEvents(events)).toEqual([
-        { block_number: 1, tx_hash: '0x1' },
-        { block_number: 2, tx_hash: '0x2' },
-        { block_number: 3, tx_hash: '0x3' },
-        { block_number: 4, tx_hash: '0x4a' },
-        { block_number: 5, tx_hash: '0x5a' },
-        { block_number: 6, tx_hash: '0x6a' },
-        { block_number: 7, tx_hash: '0x7a' },
-      ])
-    }, 240_000)
-
-    it('handles a fork whose finalized block is missing from the in-flight batch (multi-step rollback)', async () => {
-      const { events, sync } = uniqueTables('missing_finalized')
-
-      mockPortal = await createMockPortal([
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
-          ],
-          head: { finalized: { number: 1, hash: '0x1' } },
-        },
-        // First reorg: only blocks 4..5 visible — common ancestor not yet found in this slice.
-        {
-          statusCode: 409,
-          data: {
-            previousBlocks: [
-              { number: 4, hash: '0x4a' },
-              { number: 5, hash: '0x5a' },
-            ],
-          },
-        },
-        // Second reorg: deeper slice surfaces ancestor at block 1.
-        {
-          statusCode: 409,
-          data: {
-            previousBlocks: [
-              { number: 1, hash: '0x1' },
-              { number: 2, hash: '0x2a' },
-              { number: 3, hash: '0x3a' },
-            ],
-          },
-        },
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
-            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
-            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
-          ],
-          head: { finalized: { number: 4, hash: '0x4a' } },
-        },
-      ])
-
-      const rollbackCursors: BlockCursor[] = []
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 0, to: 7 }),
-      }).pipeTo(
-        buildTarget(events, sync, {
-          onAfterRollback: ({ cursor }) => {
-            rollbackCursors.push(cursor)
-          },
-        }),
-      )
-
-      // First fork resolves to block 3, second resolves all the way to block 1.
-      expect(rollbackCursors).toEqual([
-        expect.objectContaining({ number: 3, hash: '0x3' }),
-        expect.objectContaining({ number: 1, hash: '0x1' }),
-      ])
-
-      expect(await readEvents(events)).toEqual([
-        { block_number: 2, tx_hash: '0x2a' },
-        { block_number: 3, tx_hash: '0x3a' },
-        { block_number: 4, tx_hash: '0x4a' },
-        { block_number: 5, tx_hash: '0x5a' },
-        { block_number: 6, tx_hash: '0x6a' },
-        { block_number: 7, tx_hash: '0x7a' },
-      ])
-    }, 240_000)
-
-    it('handles a deep fork that rolls back to the last finalized block, including a mid-stream crash', async () => {
-      const { events, sync } = uniqueTables('deep_finalized')
-
-      // Two responses for the post-fork range: the first attempt crashes mid-batch (we throw
-      // inside onData), the second is consumed by the resumed pipeTo loop. Both must agree
-      // on parentBlockHash='0x3a' — proving recovery resumed from the persisted cursor.
-      const postForkBatch: MockResponse = {
-        statusCode: 200,
-        data: [
-          { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
-          { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
-          { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
-          { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
-        ],
-        head: { finalized: { number: 4, hash: '0x4a' } },
-      }
-
-      mockPortal = await createMockPortal([
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
-            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
-          ],
-          head: { finalized: { number: 1, hash: '0x1' } },
-        },
-        {
-          statusCode: 409,
-          data: {
-            previousBlocks: [
-              { number: 1, hash: '0x1' },
-              { number: 2, hash: '0x2a' },
-              { number: 3, hash: '0x3a' },
-              { number: 4, hash: '0x4a' },
-              { number: 5, hash: '0x5a' },
-            ],
-          },
-        },
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
-          ],
-          head: { finalized: { number: 2, hash: '0x2a' } },
-        },
-        postForkBatch,
-        postForkBatch,
-      ])
-
-      let crashes = 0
-      let finished = false
-      while (!finished) {
-        try {
-          await evmPortalStream({
-            id: 'test',
-            portal: mockPortal.url,
-            outputs: blockDecoder({ from: 0, to: 7 }),
-          }).pipeTo(
-            buildTarget(events, sync, {
-              onData: async ({ store, data }) => {
-                if (data[0]?.hash === '0x4a' && crashes === 0) {
-                  crashes++
-                  throw new Error('process failed')
-                }
-                store.insert(
-                  events,
-                  data.map((b: { number: number; hash: string }) => ({
-                    block_number: b.number,
-                    tx_hash: b.hash,
-                  })),
-                )
-                if (data.some((b: { hash: string }) => b.hash === '0x7a')) finished = true
-              },
-            }),
-          )
-          // Stream ended cleanly — done either way.
-          finished = true
-        } catch (e) {
-          if (!(e instanceof Error) || e.message !== 'process failed') throw e
+          ctx: makeBatchContext({ number: 2, hash: '0x2' }),
         }
       }
+      await target.write({ read: read as never, logger: createTestLogger() })
 
-      expect(crashes).toBe(1)
-
-      // After recovery + replay, all canonical-chain blocks landed exactly once. Forked
-      // blocks 0x4 and 0x5 must have been DELETEd by tracker.fork(); the crash must NOT
-      // have left a stale 0x4a row that doubles up after restart.
-      expect(await readEvents(events)).toEqual([
-        { block_number: 1, tx_hash: '0x1' },
-        { block_number: 2, tx_hash: '0x2a' },
-        { block_number: 3, tx_hash: '0x3a' },
-        { block_number: 4, tx_hash: '0x4a' },
-        { block_number: 5, tx_hash: '0x5a' },
-        { block_number: 6, tx_hash: '0x6a' },
-        { block_number: 7, tx_hash: '0x7a' },
-      ])
-    }, 300_000)
-
-    it('handles a deep fork via two cascading rollbacks (no crash)', async () => {
-      const { events, sync } = uniqueTables('deep')
-
-      mockPortal = await createMockPortal([
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
-            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5', timestamp: 5000 } },
-          ],
-          head: { finalized: { number: 1, hash: '0x1' } },
-        },
-        // Shallow slice — only blocks 4-5 visible, no common ancestor here.
-        {
-          statusCode: 409,
-          data: {
-            previousBlocks: [
-              { number: 4, hash: '0x4a' },
-              { number: 5, hash: '0x5a' },
-            ],
-          },
-        },
-        // Deeper slice — ancestor at block 1.
-        {
-          statusCode: 409,
-          data: {
-            previousBlocks: [
-              { number: 1, hash: '0x1' },
-              { number: 2, hash: '0x2a' },
-              { number: 3, hash: '0x3a' },
-            ],
-          },
-        },
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
-            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
-            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
-            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
-            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
-          ],
-        },
-      ])
-
-      const rollbackCursors: BlockCursor[] = []
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 0, to: 7 }),
-      }).pipeTo(
-        buildTarget(events, sync, {
-          onAfterRollback: ({ cursor }) => {
-            rollbackCursors.push(cursor)
-          },
-        }),
-      )
-
-      expect(rollbackCursors.map((c) => c.number)).toEqual([3, 1])
-
-      expect(await readEvents(events)).toEqual([
-        { block_number: 1, tx_hash: '0x1' },
-        { block_number: 2, tx_hash: '0x2a' },
-        { block_number: 3, tx_hash: '0x3a' },
-        { block_number: 4, tx_hash: '0x4a' },
-        { block_number: 5, tx_hash: '0x5a' },
-        { block_number: 6, tx_hash: '0x6a' },
-        { block_number: 7, tx_hash: '0x7a' },
-      ])
-    }, 240_000)
-
-    it('resumes from the last persisted cursor after a clean stop (parentBlockHash threaded through)', async () => {
-      const { events, sync } = uniqueTables('resume')
-
-      mockPortal = await createMockPortal([
-        {
-          statusCode: 200,
-          data: [{ header: { number: 1, hash: '0x1', timestamp: 1000 } }],
-        },
-        {
-          statusCode: 200,
-          data: [{ header: { number: 2, hash: '0x2', timestamp: 2000 } }],
-          // The portal contract: after restart, the request must include the parentBlockHash
-          // of the previously persisted cursor so the portal can detect any fork that happened
-          // while we were down.
-          validateRequest: (req) => {
-            expect(req).toMatchObject({
-              type: 'evm',
-              fromBlock: 2,
-              parentBlockHash: '0x1',
-            })
-          },
-        },
-      ])
-
-      // First run: ingest block 1 and stop cleanly.
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 0, to: 1 }),
-      }).pipeTo(buildTarget(events, sync))
-
-      // Second run with a fresh stream: the BigQuery sync table holds the previous cursor,
-      // so getCursor() must read it back and the new stream must request block 2 with the
-      // expected parentBlockHash. validateRequest in the mock asserts that.
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 1, to: 2 }),
-      }).pipeTo(buildTarget(events, sync))
-
-      expect(await readEvents(events)).toEqual([
-        { block_number: 1, tx_hash: '0x1' },
-        { block_number: 2, tx_hash: '0x2' },
-      ])
-    }, 240_000)
-
-    it('records cursor + finalized for every committed batch in the sync table', async () => {
-      const { events, sync } = uniqueTables('sync_state')
-
-      mockPortal = await createMockPortal([
-        {
-          statusCode: 200,
-          data: [
-            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
-            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
-            { header: { number: 3, hash: '0x3', timestamp: 3000 } },
-          ],
-          head: { finalized: { number: 1, hash: '0x1' } },
-        },
-      ])
-
-      await evmPortalStream({
-        id: 'test',
-        portal: mockPortal.url,
-        outputs: blockDecoder({ from: 0, to: 3 }),
-      }).pipeTo(buildTarget(events, sync))
-
-      // `evmPortalStream` may split a single portal response into multiple per-batch
-      // emissions; assert on the FINAL committed cursor rather than counting rows. What
-      // matters for resumption correctness is that the latest commit reflects the last
-      // block we processed, with the finalized pointer the portal advertised.
-      const rows = await readSyncCommittedCursors(sync)
-      expect(rows.length).toBeGreaterThan(0)
-      expect(rows[rows.length - 1]).toMatchObject({
-        current: { number: 3, hash: '0x3' },
-        finalized: { number: 1, hash: '0x1' },
+      const [rows] = await bigquery.query({
+        query: `SELECT block_number, col_string_nullable, col_int64_nullable, CAST(col_numeric_nullable AS STRING) AS num
+                FROM \`${projectId}.${DATASET}.${localEvents}\`
+                ORDER BY block_number`,
       })
-    }, 180_000)
+      expect(rows.length).toBe(2)
+      type NullRow = { col_string_nullable: string | null; col_int64_nullable: number | null; num: string | null }
+      for (const r of rows as NullRow[]) {
+        expect(r.col_string_nullable).toBeNull()
+        expect(r.col_int64_nullable).toBeNull()
+        expect(r.num).toBeNull()
+      }
+    }, 60_000)
   })
 })

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
@@ -4,7 +4,7 @@ import * as protobuf from 'protobufjs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BatchContext, BlockCursor } from '~/core/index.js'
-import { createTestLogger } from '~/testing/index.js'
+import { createMockMetricServer, createTestLogger } from '~/testing/index.js'
 
 import { BigQueryState } from './bigquery-state.js'
 import { BigQueryStore, type ProtoWriterFactory } from './bigquery-store.js'
@@ -147,15 +147,22 @@ const TABLES: TrackedTable[] = [
 
 const cursor = (number: number, hash = `0x${number}`): BlockCursor => ({ number, hash })
 
-function makeBatchContext(current: BlockCursor, rollbackChain: BlockCursor[] = [], initial = 0): BatchContext {
+function makeBatchContext(
+  current: BlockCursor,
+  rollbackChain: BlockCursor[] = [],
+  initial = 0,
+  metrics?: ReturnType<typeof createMockMetricServer>,
+): BatchContext {
   const profilerStub: Record<string, unknown> = {
     start: () => profilerStub,
     measure: async (_: unknown, fn: () => unknown) => fn(),
     end: () => {},
   }
   return {
+    id: 'test-pipe',
     logger: createTestLogger(),
     profiler: profilerStub,
+    metrics: (metrics ?? createMockMetricServer()).server.metrics,
     stream: {
       state: { current, rollbackChain, initial },
       head: { finalized: undefined, latest: current },
@@ -685,6 +692,237 @@ describe('bigqueryTarget — write lifecycle', () => {
     } finally {
       Object.defineProperty(managedwriter, 'WriterClient', desc)
     }
+  })
+})
+
+// -----------------------------------------------------------------------------
+// bigqueryTarget — Track 2 metrics (commit lag / commit duration / append errors)
+// -----------------------------------------------------------------------------
+
+describe('bigqueryTarget — commit metrics', () => {
+  let writerSetup: ReturnType<typeof makeWriter>
+  let bqSetup: ReturnType<typeof makeBigQuery>
+
+  beforeEach(() => {
+    writerSetup = makeWriter()
+    bqSetup = makeBigQuery()
+  })
+
+  afterEach(() => {
+    // Restore real timers BEFORE clearing other mocks — `vi.restoreAllMocks` doesn't undo
+    // `vi.useFakeTimers()`. Without this, the lag test below leaves frozen Date.now() in
+    // place and any subsequent test that relies on real wallclock (e.g. the duration test
+    // asserting `>= 0` only by accident) silently degrades.
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function buildTarget(opts?: {
+    onData?: (ctx: { store: BigQueryStore; data: unknown; ctx: unknown }) => void | Promise<void>
+    protoWriterFactory?: ProtoWriterFactory
+  }) {
+    return bigqueryTarget<unknown>({
+      client: { bigquery: bqSetup.bq, writer: writerSetup.writer },
+      dataset: 'd',
+      tables: TABLES,
+      settings: { protoWriterFactory: opts?.protoWriterFactory ?? fakeProtoWriterFactory },
+      onData: opts?.onData ?? (() => {}),
+    })
+  }
+
+  it('observes block_to_commit_lag using commit-ack wallclock minus block.timestamp (seconds)', async () => {
+    // Pin wallclock so commit_end_ms is deterministic; the lag observation is
+    // commit_end_seconds - cursor.timestamp_seconds. Setting commit_end at epoch 1_700_000_005 and
+    // the block timestamp at 1_700_000_000 should yield exactly 5s of lag.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(1_700_000_005 * 1000))
+
+    const metrics = createMockMetricServer()
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+    })
+
+    async function* read() {
+      yield {
+        data: { block_number: 10, tx_hash: '0xa' },
+        ctx: makeBatchContext({ number: 10, hash: '0xa', timestamp: 1_700_000_000 }, [], 0, metrics),
+      }
+    }
+    await target.write({ read: read as never, logger: createTestLogger() })
+
+    const histogram = metrics.histogram('sqd_bigquery_block_to_commit_lag_seconds')
+    expect(histogram.observations).toEqual([5])
+  })
+
+  it('skips block_to_commit_lag observation when cursor.timestamp is missing', async () => {
+    // Cursor timestamp is optional — emitting `now − 0` would put a 50+ year lag into the
+    // histogram and ruin the rate(...) bucket counts. Better to skip the observation.
+    const metrics = createMockMetricServer()
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+    })
+
+    async function* read() {
+      // cursor() helper returns { number, hash } — no timestamp by design.
+      yield { data: { block_number: 10, tx_hash: '0xa' }, ctx: makeBatchContext(cursor(10), [], 0, metrics) }
+    }
+    await target.write({ read: read as never, logger: createTestLogger() })
+
+    const histogram = metrics.histogram('sqd_bigquery_block_to_commit_lag_seconds')
+    expect(histogram.observations).toEqual([])
+  })
+
+  it('observes commit_duration once per batch', async () => {
+    // Two batches → two observations on the same registered histogram. We don't pin values
+    // (that's wallclock-dependent and brittle); we just assert count and non-negativity.
+    const metrics = createMockMetricServer()
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+    })
+
+    async function* read() {
+      yield { data: { block_number: 10, tx_hash: '0xa' }, ctx: makeBatchContext(cursor(10), [], 0, metrics) }
+      yield { data: { block_number: 11, tx_hash: '0xb' }, ctx: makeBatchContext(cursor(11), [], 0, metrics) }
+    }
+    await target.write({ read: read as never, logger: createTestLogger() })
+
+    const histogram = metrics.histogram('sqd_bigquery_commit_duration_seconds')
+    expect(histogram.observations).toHaveLength(2)
+    for (const v of histogram.observations) expect(v).toBeGreaterThanOrEqual(0)
+  })
+
+  it('classifies AppendRows failures into append_errors_total{kind}', async () => {
+    // Inject a fake writer that rejects with a gRPC RESOURCE_EXHAUSTED (code 8). The
+    // classifier must label this as "resource_exhausted" and the counter must increment by 1.
+    // Using doWithRetry's transient retry: code 8 is retried up to 8 times before bubbling —
+    // we want a NON-transient code here so the failure surfaces immediately to the metric path.
+    // Use code 3 (INVALID_ARGUMENT) which is non-retried and maps to "invalid_argument".
+    const metrics = createMockMetricServer()
+    const failingFactory: ProtoWriterFactory = () => ({
+      appendRows: () => ({
+        getResult: async () => {
+          const err = new Error('schema mismatch') as Error & { code: number }
+          err.code = 3
+          throw err
+        },
+      }),
+      close: () => {},
+    })
+
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+      protoWriterFactory: failingFactory,
+    })
+
+    async function* read() {
+      yield {
+        data: { block_number: 10, tx_hash: '0xa' },
+        ctx: makeBatchContext({ number: 10, hash: '0xa', timestamp: 1_700_000_000 }, [], 0, metrics),
+      }
+    }
+    await expect(target.write({ read: read as never, logger: createTestLogger() })).rejects.toThrow(/schema mismatch/)
+
+    const counter = metrics.counter('sqd_bigquery_append_errors_total')
+    // Exactly one increment, labeled with the pipe id and the classified kind.
+    expect(counter.calls).toHaveLength(1)
+    expect(counter.calls[0]).toEqual({ labels: { id: 'test-pipe', kind: 'invalid_argument' }, value: 1 })
+
+    // The success-path observations must NOT fire when the commit threw.
+    expect(metrics.histogram('sqd_bigquery_commit_duration_seconds').observations).toEqual([])
+    expect(metrics.histogram('sqd_bigquery_block_to_commit_lag_seconds').observations).toEqual([])
+  })
+
+  it('reuses the same Histogram/Counter handles across batches (lazy registration cached)', async () => {
+    // The metrics-server interface returns the same registered metric on duplicate names; we
+    // also cache the handles in a closure variable so we don't re-resolve on every batch. Two
+    // batches → exactly one registered histogram with two observations on it.
+    const metrics = createMockMetricServer()
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+    })
+
+    async function* read() {
+      yield {
+        data: { block_number: 10, tx_hash: '0xa' },
+        ctx: makeBatchContext({ number: 10, hash: '0xa', timestamp: 1_700_000_000 }, [], 0, metrics),
+      }
+      yield {
+        data: { block_number: 11, tx_hash: '0xb' },
+        ctx: makeBatchContext({ number: 11, hash: '0xb', timestamp: 1_700_000_001 }, [], 0, metrics),
+      }
+    }
+    await target.write({ read: read as never, logger: createTestLogger() })
+
+    const lag = metrics.histogram('sqd_bigquery_block_to_commit_lag_seconds')
+    expect(lag.observations).toHaveLength(2)
+    // Single registered histogram for the metric name (no duplicates from re-registration).
+    expect(metrics.keys().filter((k) => k === 'sqd_bigquery_block_to_commit_lag_seconds')).toHaveLength(1)
+  })
+
+  it('does not observe duration/lag when WAL post-commit fails (no phantom success)', async () => {
+    // Per-batch AppendRows order:
+    //   1. saveCommitPre  → IN_FLIGHT_COMMIT row on /sync   (call 1)
+    //   2. commitBatch    → data row on /events             (call 2)
+    //   3. saveCommitPost → COMMITTED row on /sync          (call 3)
+    // Failing call 3 leaves the batch uncommitted from the recovery POV (next getCursor()
+    // re-runs the bounded DELETE for the in-flight range). The success metrics MUST NOT
+    // observe — otherwise the dashboard shows a happy commit lag for a batch that wasn't.
+    const metrics = createMockMetricServer()
+    let appendCalls = 0
+    // Use a NON-transient code so doWithRetry doesn't retry past the failure — code 3
+    // (INVALID_ARGUMENT) is fatal in `isTransientError`, so the first throw on call 3
+    // propagates immediately.
+    const failOnPostCommit: ProtoWriterFactory = () => ({
+      appendRows: () => ({
+        getResult: async () => {
+          appendCalls++
+          if (appendCalls === 3) {
+            const err = new Error('post-commit broke') as Error & { code: number }
+            err.code = 3
+            throw err
+          }
+          return { acked: true }
+        },
+      }),
+      close: () => {},
+    })
+
+    const target = buildTarget({
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+      protoWriterFactory: failOnPostCommit,
+    })
+
+    async function* read() {
+      yield {
+        data: { block_number: 10, tx_hash: '0xa' },
+        ctx: makeBatchContext({ number: 10, hash: '0xa', timestamp: 1_700_000_000 }, [], 0, metrics),
+      }
+    }
+    await expect(target.write({ read: read as never, logger: createTestLogger() })).rejects.toThrow(
+      /post-commit broke/,
+    )
+
+    // Error counter increments — trackBqErrors classifies the post-commit gRPC failure.
+    const counter = metrics.counter('sqd_bigquery_append_errors_total')
+    expect(counter.calls).toEqual([{ labels: { id: 'test-pipe', kind: 'invalid_argument' }, value: 1 }])
+
+    // Success-path histograms stay empty: post-commit never returned, so we never reached
+    // the observe() calls. This is the central regression check — moving observe() before
+    // saveCommitPost would silently fail this test.
+    expect(metrics.histogram('sqd_bigquery_commit_duration_seconds').observations).toEqual([])
+    expect(metrics.histogram('sqd_bigquery_block_to_commit_lag_seconds').observations).toEqual([])
   })
 })
 

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.test.ts
@@ -10,7 +10,7 @@ import {
   syncTableDdl,
   trackedTableDdl,
 } from './tables.js'
-import { assertInt64NotNull, assertRangePartitionedOn, isNotFoundError, isTransientError } from './utils.js'
+import { assertInt64NotNull, assertRangePartitionedOn, classifyBqError, isNotFoundError, isTransientError } from './utils.js'
 
 /**
  * This file holds ONLY pure-function unit tests:
@@ -192,14 +192,27 @@ describe('BigQueryTargetError', () => {
 })
 
 describe('isNotFoundError', () => {
-  it('detects code: 404', () => {
+  it('detects HTTP 404 (REST client)', () => {
     expect(isNotFoundError({ code: 404 })).toBe(true)
     expect(isNotFoundError({ code: '404' })).toBe(true)
   })
 
-  it('detects "not found" in message (case-insensitive)', () => {
+  it('detects gRPC NOT_FOUND (Storage Write API code 5)', () => {
+    expect(isNotFoundError({ code: 5 })).toBe(true)
+    expect(isNotFoundError({ code: '5' })).toBe(true)
+  })
+
+  it('detects "not found" in message ONLY when no numeric code present', () => {
     expect(isNotFoundError({ message: 'Not found: Table p.d.foo' })).toBe(true)
     expect(isNotFoundError({ message: 'NOT FOUND' })).toBe(true)
+  })
+
+  it('numeric code is authoritative — "not found" in message must not override 5xx', () => {
+    // A 500 with an unfortunate message must NOT classify as not-found, otherwise the
+    // schema validator's NotFound branch would mis-handle a real internal error as
+    // "table missing" and quietly auto-create on top of a real outage.
+    expect(isNotFoundError({ code: 500, message: 'Internal: not found in cache' })).toBe(false)
+    expect(isNotFoundError({ code: 503, message: 'service not found' })).toBe(false)
   })
 
   it('detects errors[].reason === "notFound"', () => {
@@ -207,10 +220,12 @@ describe('isNotFoundError', () => {
     expect(isNotFoundError({ errors: [{ reason: 'invalid' }] })).toBe(false)
   })
 
-  it('walks the cause chain', () => {
+  it('walks the cause chain even past a non-not-found outer code', () => {
     const inner = { code: 404 }
     const outer = { cause: { cause: inner } }
     expect(isNotFoundError(outer)).toBe(true)
+    // Outer 500 wrapping inner 404 — inner wins via cause walk.
+    expect(isNotFoundError({ code: 500, cause: { code: 404 } })).toBe(true)
   })
 
   it('returns false for unrelated errors', () => {
@@ -246,6 +261,45 @@ describe('isTransientError', () => {
     expect(isTransientError({ code: 3 })).toBe(false) // INVALID_ARGUMENT
     expect(isTransientError({ code: 5 })).toBe(false) // NOT_FOUND
     expect(isTransientError({ code: 404 })).toBe(false)
+  })
+})
+
+describe('classifyBqError', () => {
+  it('returns not_found for 404 / gRPC NOT_FOUND / "not found" message', () => {
+    expect(classifyBqError({ code: 404 })).toBe('not_found')
+    expect(classifyBqError({ code: 5 })).toBe('not_found')
+    expect(classifyBqError({ message: 'Not found: Table p.d.foo' })).toBe('not_found')
+  })
+
+  it('returns invalid_argument for gRPC INVALID_ARGUMENT (3) / HTTP 400', () => {
+    expect(classifyBqError({ code: 3 })).toBe('invalid_argument')
+    expect(classifyBqError({ code: 400 })).toBe('invalid_argument')
+  })
+
+  it('returns resource_exhausted for gRPC RESOURCE_EXHAUSTED (8) / HTTP 429', () => {
+    expect(classifyBqError({ code: 8 })).toBe('resource_exhausted')
+    expect(classifyBqError({ code: 429 })).toBe('resource_exhausted')
+  })
+
+  it('returns transient for the remaining retryable family', () => {
+    expect(classifyBqError({ code: 4 })).toBe('transient') // DEADLINE_EXCEEDED
+    expect(classifyBqError({ code: 10 })).toBe('transient') // ABORTED
+    expect(classifyBqError({ code: 13 })).toBe('transient') // INTERNAL
+    expect(classifyBqError({ code: 14 })).toBe('transient') // UNAVAILABLE
+    expect(classifyBqError({ code: 503 })).toBe('transient')
+  })
+
+  it('returns unknown for anything else (and never throws on weird input)', () => {
+    expect(classifyBqError(new Error('boom'))).toBe('unknown')
+    expect(classifyBqError({})).toBe('unknown')
+    expect(classifyBqError(null)).toBe('unknown')
+    expect(classifyBqError(undefined)).toBe('unknown')
+    expect(classifyBqError('string')).toBe('unknown')
+  })
+
+  it('walks the cause chain', () => {
+    expect(classifyBqError({ cause: { code: 8 } })).toBe('resource_exhausted')
+    expect(classifyBqError({ cause: { cause: { code: 404 } } })).toBe('not_found')
   })
 })
 
@@ -585,6 +639,26 @@ describe('assertSchemaMatches', () => {
         [{ name: 'bn', type: 'INTEGER', mode: 'REQUIRED' }],
         fqn,
       ),
+    ).not.toThrow()
+  })
+
+  it('treats FLOAT and FLOAT64 as the same type (BQ reports FLOAT in REST metadata)', () => {
+    // BQ accepts `FLOAT64` in DDL but reports `FLOAT` in REST metadata. Without alias support
+    // a freshly created `FLOAT64` column would falsely fail validation on every restart.
+    expect(() =>
+      assertSchemaMatches(md([{ name: 'price', type: 'FLOAT' }]), [{ name: 'price', type: 'FLOAT64' }], fqn),
+    ).not.toThrow()
+    expect(() =>
+      assertSchemaMatches(md([{ name: 'price', type: 'FLOAT64' }]), [{ name: 'price', type: 'FLOAT' }], fqn),
+    ).not.toThrow()
+  })
+
+  it('treats BOOL and BOOLEAN as the same type (BQ reports BOOLEAN in REST metadata)', () => {
+    expect(() =>
+      assertSchemaMatches(md([{ name: 'active', type: 'BOOLEAN' }]), [{ name: 'active', type: 'BOOL' }], fqn),
+    ).not.toThrow()
+    expect(() =>
+      assertSchemaMatches(md([{ name: 'active', type: 'BOOL' }]), [{ name: 'active', type: 'BOOLEAN' }], fqn),
     ).not.toThrow()
   })
 })

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
@@ -3,8 +3,11 @@ import { managedwriter } from '@google-cloud/bigquery-storage'
 
 import {
   type BlockCursor,
+  type Counter,
   type Ctx,
+  type Histogram,
   type Logger,
+  type Metrics,
   createTarget,
   formatBlock,
   formatNumber,
@@ -16,6 +19,7 @@ import { BigQueryStore } from './bigquery-store.js'
 import { BigQueryTracker, type TrackedTableLocation } from './bigquery-tracker.js'
 import { BQ_ERR, BigQueryTargetError } from './errors.js'
 import { type PartitioningSetting, type TrackedTable, ensureTrackedTable, partitioningWithDefaults } from './tables.js'
+import { classifyBqError } from './utils.js'
 
 export type BigQuerySettings = {
   state?: Omit<BigQueryStateOptions, 'projectId' | 'dataset'>
@@ -131,6 +135,12 @@ export function bigqueryTarget<T>(options: {
 
   return createTarget<T>({
     write: async ({ read, logger }) => {
+      // Lazy: registered on the first batch from `ctx.metrics`. The slot is local to
+      // `write()`, but the metrics-server registry caches by name — every call to `write()`
+      // (including re-entries after a crash) resolves to the same Histogram/Counter handles
+      // for a given pipe id, so the in-process state stays consistent across restarts.
+      let metrics: BqTargetMetrics | undefined
+
       // The try/finally wraps the ENTIRE write() body — including ensureTrackedTable,
       // onStart, and getCursor — so the internally-constructed WriterClient is closed
       // even if startup throws. fork() runs inside read()'s generator while this
@@ -160,6 +170,7 @@ export function bigqueryTarget<T>(options: {
         // Recovery: getCursor re-executes any outstanding IN_FLIGHT operation before returning.
         let previousCursor = await state.getCursor({ logger })
         for await (const { data, ctx } of read(previousCursor)) {
+          if (!metrics) metrics = registerBqTargetMetrics(ctx.metrics)
           const span = ctx.profiler.start({ name: 'bigquery', labels: 'db' })
           try {
             const next = ctx.stream.state.current
@@ -174,8 +185,10 @@ export function bigqueryTarget<T>(options: {
             const low = previousCursor ? previousCursor.number + 1 : ctx.stream.state.initial
             const high = next.number
 
-            await span.measure('wal pre-commit', () =>
-              state.saveCommitPre({ cursor: previousCursor, finalized, rollbackChain, range: { low, high } }),
+            await trackBqErrors(metrics, ctx.id, () =>
+              span.measure('wal pre-commit', () =>
+                state.saveCommitPre({ cursor: previousCursor, finalized, rollbackChain, range: { low, high } }),
+              ),
             )
 
             await span.measure('user onData', () =>
@@ -195,11 +208,30 @@ export function bigqueryTarget<T>(options: {
               tables: tableStats,
             })
 
-            await span.measure('commit data tables', () => store.commitBatch())
+            // `commit_duration` measures only the parallel AppendRows phase, not the WAL
+            // bracket — the help text claims this scope, and a wider timer would conflate
+            // commit latency with WAL/onData latency on the dashboard.
+            const commitStartMs = Date.now()
+            await trackBqErrors(metrics, ctx.id, () => span.measure('commit data tables', () => store.commitBatch()))
+            const commitEndMs = Date.now()
 
-            await span.measure('wal post-commit', () =>
-              state.saveCommitPost({ logger, cursor: next, finalized, rollbackChain }),
+            await trackBqErrors(metrics, ctx.id, () =>
+              span.measure('wal post-commit', () =>
+                state.saveCommitPost({ logger, cursor: next, finalized, rollbackChain }),
+              ),
             )
+
+            // Observe AFTER post-commit so a failed WAL post-commit (which leaves the batch
+            // uncommitted from the recovery POV) doesn't emit phantom success observations.
+            // commitEndMs was captured before post-commit so the duration / lag still reflect
+            // the AppendRows ack moment, not the post-commit delay.
+            metrics.commitDuration.observe({ id: ctx.id }, (commitEndMs - commitStartMs) / 1000)
+            if (typeof next.timestamp === 'number') {
+              // Block timestamps are epoch seconds (see cursorFromHeader). Skip the lag
+              // observation when timestamp is missing rather than emit a wildly wrong value
+              // derived from `0`.
+              metrics.blockToCommitLag.observe({ id: ctx.id }, commitEndMs / 1000 - next.timestamp)
+            }
 
             logger.info({
               message: `committed batch: ${formatNumber(totalRows)} rows / ${humanBytes(totalBytes)} across ${Object.keys(tableStats).length} tables, ${range}`,
@@ -241,4 +273,50 @@ export function bigqueryTarget<T>(options: {
       return safeCursor
     },
   })
+}
+
+type BqTargetMetrics = {
+  blockToCommitLag: Histogram<'id'>
+  commitDuration: Histogram<'id'>
+  appendErrors: Counter<'id' | 'kind'>
+}
+
+function registerBqTargetMetrics(metrics: Metrics): BqTargetMetrics {
+  // Buckets cover the operational range per stage — sub-second commits on a healthy pipeline
+  // up to a 10-minute lag where an alert should already be firing. Long tail beyond 10m goes
+  // into the +Inf bucket; count/sum still capture SLO violations.
+  const blockToCommitLagBuckets = [0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600]
+  const commitDurationBuckets = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30]
+
+  return {
+    blockToCommitLag: metrics.histogram({
+      name: 'sqd_bigquery_block_to_commit_lag_seconds',
+      help: 'Per-batch lag (seconds) between the last block timestamp and the BQ AppendRows ack. PRIMARY commit-stage SLO.',
+      labelNames: ['id'] as const,
+      buckets: blockToCommitLagBuckets,
+    }),
+    commitDuration: metrics.histogram({
+      name: 'sqd_bigquery_commit_duration_seconds',
+      help: 'Wallclock duration (seconds) of one batch commit (parallel AppendRows across tracked tables).',
+      labelNames: ['id'] as const,
+      buckets: commitDurationBuckets,
+    }),
+    appendErrors: metrics.counter({
+      name: 'sqd_bigquery_append_errors_total',
+      help: 'AppendRows failures classified by kind. Kind ∈ {not_found, invalid_argument, resource_exhausted, transient, unknown}.',
+      labelNames: ['id', 'kind'] as const,
+    }),
+  }
+}
+
+// BQ errors from any of pre/data/post AppendRows go through this classifier so
+// `append_errors_total{kind}` represents end-to-end commit-stage failures, not just the
+// data-table phase. `onData` is excluded — those are user-code throws, not BQ.
+async function trackBqErrors<R>(metrics: BqTargetMetrics, id: string, op: () => Promise<R>): Promise<R> {
+  try {
+    return await op()
+  } catch (error) {
+    metrics.appendErrors.inc({ id, kind: classifyBqError(error) }, 1)
+    throw error
+  }
 }

--- a/packages/subsquid-pipes/src/targets/bigquery/integration-helpers.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/integration-helpers.ts
@@ -1,0 +1,92 @@
+import { BigQuery } from '@google-cloud/bigquery'
+import { managedwriter } from '@google-cloud/bigquery-storage'
+
+import type { BatchContext, BlockCursor } from '~/core/index.js'
+import { createMockMetricServer, createTestLogger } from '~/testing/index.js'
+
+import { type TrackedTable, partitioningWithDefaults } from './tables.js'
+
+/**
+ * Shared scaffolding for the BigQuery integration test files. The integration suite is split
+ * across multiple files (basic + type-mappings here, fork lifecycle in
+ * `bigquery-target-fork.integration.test.ts`); this module owns the env-vars, prefix, and
+ * fixture builders so each file stays focused on its own assertions.
+ *
+ * Gating: every file does `describe.skipIf(!RUN)`. With `BIGQUERY_TEST_PROJECT` unset the
+ * suite is skipped wholesale and nothing here ever runs against a real GCP project.
+ */
+
+export const PROJECT = process.env['BIGQUERY_TEST_PROJECT']
+export const DATASET = process.env['BIGQUERY_TEST_DATASET'] ?? 'pipes_target_test'
+export const RUN = !!PROJECT
+// Narrowed at module top-level: only ever read inside `describe.skipIf(!RUN)` bodies, so by
+// the time a test executes PROJECT was non-empty (the gate is the same `RUN` flag).
+export const projectId = PROJECT as string
+
+// Every table the integration suites create uses this prefix. The `setupIntegrationDataset`
+// sweep matches it exactly so leftover tables from a failed run get cleaned up on the next
+// run, while never touching the user's own data sharing the dataset.
+export const PREFIX = 'e2e_test_'
+
+export const partitioning = partitioningWithDefaults()
+
+/** A two-column tracked-table template; copy and override `table` per test. */
+export const trackedTable: TrackedTable = {
+  table: 'unused', // overridden per-test
+  blockNumberColumn: 'block_number',
+  schema: [
+    { name: 'block_number', type: 'INT64', mode: 'REQUIRED' },
+    { name: 'tx_hash', type: 'STRING' },
+  ],
+}
+
+/**
+ * Creates a fresh BigQuery REST client + Storage Write API client for the suite, ensures the
+ * dataset exists, and sweeps any leftover `${PREFIX}*` tables from previous runs. Tests
+ * deliberately do NOT clean up after themselves — failures leave inspectable state behind,
+ * and this sweep makes sure those leftovers don't accumulate beyond one run.
+ */
+export async function setupIntegrationClients(): Promise<{
+  bigquery: BigQuery
+  writer: managedwriter.WriterClient
+}> {
+  const bigquery = new BigQuery({ projectId })
+  const writer = new managedwriter.WriterClient({ projectId })
+
+  const [exists] = await bigquery.dataset(DATASET).exists()
+  if (!exists) await bigquery.createDataset(DATASET)
+
+  const [allTables] = await bigquery.dataset(DATASET).getTables()
+  await Promise.all(
+    allTables
+      .filter((t) => (t.id ?? '').startsWith(PREFIX))
+      .map((t) => t.delete({ ignoreNotFound: true }).catch(() => {})),
+  )
+
+  return { bigquery, writer }
+}
+
+/**
+ * Builds a synthetic `BatchContext` for tests that drive `target.write()` directly (i.e.
+ * without `evmPortalStream`). Includes the `id` + `metrics` slots the BigQuery target reads
+ * for Track-2 commit-stage metrics — without them, the first batch crashes on
+ * `registerBqTargetMetrics(ctx.metrics)`.
+ */
+export function makeBatchContext(current: BlockCursor): BatchContext {
+  const profilerStub: Record<string, unknown> = {
+    start: () => profilerStub,
+    measure: async (_: unknown, fn: () => unknown) => fn(),
+    end: () => {},
+  }
+
+  return {
+    id: 'integration-test',
+    logger: createTestLogger(),
+    profiler: profilerStub,
+    metrics: createMockMetricServer().server.metrics,
+    stream: {
+      state: { current, rollbackChain: [current] },
+      head: { finalized: undefined, latest: current },
+    },
+  } as unknown as BatchContext
+}

--- a/packages/subsquid-pipes/src/targets/bigquery/tables.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/tables.ts
@@ -279,14 +279,14 @@ export function assertSchemaMatches(metadata: TableMetadata, declared: TableFiel
         `Table ${tableFqn} is missing declared column '${decl.name}' of type ${decl.type}.`,
       )
     }
-    if ((live.type || '').toUpperCase() !== (decl.type || '').toUpperCase()) {
-      // INTEGER ↔ INT64 alias: BigQuery legacy SQL used INTEGER, GoogleSQL uses INT64. They're identical.
-      if (!isIntegerAlias(live.type, decl.type)) {
-        throw new BigQueryTargetError(
-          BQ_ERR.SCHEMA_TYPE_MISMATCH,
-          `Table ${tableFqn} column '${decl.name}' has type ${live.type}, but declared as ${decl.type}.`,
-        )
-      }
+    // Legacy-SQL ↔ GoogleSQL aliases: BQ accepts the modern name in DDL but reports the
+    // legacy name in REST metadata, so a `FLOAT64` column comes back as `FLOAT` and a fresh
+    // round-trip would falsely fail validation. Canonicalize both sides before comparing.
+    if (canonicalType(live.type) !== canonicalType(decl.type)) {
+      throw new BigQueryTargetError(
+        BQ_ERR.SCHEMA_TYPE_MISMATCH,
+        `Table ${tableFqn} column '${decl.name}' has type ${live.type}, but declared as ${decl.type}.`,
+      )
     }
     // Compare mode too (NULLABLE / REQUIRED / REPEATED). Without this, a live `tags STRING
     // REPEATED` passes when declared as a scalar `tags STRING` and the first AppendRows
@@ -303,7 +303,19 @@ export function assertSchemaMatches(metadata: TableMetadata, declared: TableFiel
   }
 }
 
-function isIntegerAlias(a?: string, b?: string): boolean {
-  const ints = new Set(['INT64', 'INTEGER'])
-  return ints.has((a || '').toUpperCase()) && ints.has((b || '').toUpperCase())
+/**
+ * GoogleSQL type names normalised against their legacy-SQL aliases. BigQuery accepts the
+ * modern name in DDL but reports the legacy name in REST metadata, so without this
+ * canonicalisation a `FLOAT64` declaration validates against a live `FLOAT` column as a
+ * mismatch on the second startup — even though the table is exactly what the target wants.
+ */
+const LEGACY_TYPE_ALIASES: Record<string, string> = {
+  INTEGER: 'INT64',
+  FLOAT: 'FLOAT64',
+  BOOLEAN: 'BOOL',
+}
+
+function canonicalType(type?: string): string {
+  const t = (type || '').toUpperCase()
+  return LEGACY_TYPE_ALIASES[t] ?? t
 }

--- a/packages/subsquid-pipes/src/targets/bigquery/utils.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/utils.ts
@@ -3,18 +3,27 @@ import type { TableField, TableMetadata } from '@google-cloud/bigquery'
 import { BQ_ERR, BigQueryTargetError } from './errors.js'
 
 /**
- * Detects "Not Found" errors from the @google-cloud/bigquery client.
+ * Detects "Not Found" errors from the @google-cloud/bigquery client AND the Storage Write
+ * API: HTTP 404 from the REST client, gRPC NOT_FOUND (code 5) from Storage Write, or — when
+ * no machine-readable code is present — an Error whose message contains "not found". Walks
+ * the `cause` chain because both clients wrap lower-level errors at multiple layers.
  *
- * BQ surfaces missing tables/datasets/jobs as either a `code: 404` ApiError or
- * an Error whose message starts with "Not found:". We also walk the `cause`
- * chain because the client wraps lower-level errors at multiple layers.
+ * Numeric codes are authoritative: a `{ code: 500, message: "internal: not found in cache" }`
+ * must NOT classify as not-found. The message scan only kicks in when no numeric code is
+ * present anywhere in the local frame.
  */
 export function isNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
 
   const e = error as { code?: number | string; message?: string; cause?: unknown; errors?: { reason?: string }[] }
+  const code = parseLocalCode(error)
 
-  if (e.code === 404 || e.code === '404') return true
+  if (code === 404 || code === 5) return true
+  if (code !== undefined) {
+    // Some other numeric code — authoritative, don't fall through to message scan. Still
+    // walk the cause chain in case the outer is a generic wrapper around a real not-found.
+    return e.cause ? isNotFoundError(e.cause) : false
+  }
   if (typeof e.message === 'string' && /not found/i.test(e.message)) return true
   if (Array.isArray(e.errors) && e.errors.some((x) => x?.reason === 'notFound')) return true
   if (e.cause) return isNotFoundError(e.cause)
@@ -30,18 +39,66 @@ export function isNotFoundError(error: unknown): boolean {
  *
  * Storage Write API surfaces these as `code` numeric properties on the rejected promise.
  * The BigQuery REST client uses HTTP-style codes (429, 500, 502, 503, 504).
+ *
+ * Walks the cause chain — finds a transient code ANYWHERE in the chain (different from
+ * `readErrorCode`, which returns just the outermost code).
  */
 export function isTransientError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
 
-  const e = error as { code?: number | string; cause?: unknown }
-  const code = typeof e.code === 'string' ? Number.parseInt(e.code, 10) : e.code
-
+  const code = parseLocalCode(error)
   if (code === 4 || code === 8 || code === 10 || code === 13 || code === 14) return true
   if (code === 429 || code === 500 || code === 502 || code === 503 || code === 504) return true
+
+  const e = error as { cause?: unknown }
   if (e.cause) return isTransientError(e.cause)
 
   return false
+}
+
+/** Parses just the local `code` field on `error`, normalising string codes to number. */
+function parseLocalCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const e = error as { code?: number | string }
+  if (e.code === undefined) return undefined
+  const code = typeof e.code === 'string' ? Number.parseInt(e.code, 10) : e.code
+
+  return typeof code === 'number' && !Number.isNaN(code) ? code : undefined
+}
+
+export type BqErrorKind = 'not_found' | 'invalid_argument' | 'resource_exhausted' | 'transient' | 'unknown'
+
+/**
+ * Classifies a BigQuery / Storage Write API error into the small set of `kind` labels used by
+ * `sqd_bigquery_append_errors_total`. The label is bounded — gRPC error codes are stable, but
+ * we collapse them into operationally distinct buckets so a Grafana panel can split
+ * "schema mismatch" from "rate limit" from "everything else" without label cardinality blowing up.
+ *
+ * - not_found (gRPC 5 / HTTP 404):           dataset/table/stream gone — operator action needed.
+ * - invalid_argument (gRPC 3 / HTTP 400):    schema mismatch, NOT NULL violation — code/data bug.
+ * - resource_exhausted (gRPC 8 / HTTP 429):  rate/quota — back off, transient but distinct.
+ * - transient (gRPC 4/10/13/14, HTTP 5xx):   the rest of the retryable family.
+ * - unknown:                                  anything else (don't drop the observation).
+ */
+export function classifyBqError(error: unknown): BqErrorKind {
+  // `isNotFoundError` covers both REST 404 and gRPC NOT_FOUND (5).
+  if (isNotFoundError(error)) return 'not_found'
+  const code = readErrorCode(error)
+  if (code === 3 || code === 400) return 'invalid_argument'
+  if (code === 8 || code === 429) return 'resource_exhausted'
+  if (isTransientError(error)) return 'transient'
+
+  return 'unknown'
+}
+
+/** Returns the first code anywhere in the cause chain (outermost wins). */
+function readErrorCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const code = parseLocalCode(error)
+  if (code !== undefined) return code
+  const e = error as { cause?: unknown }
+
+  return e.cause ? readErrorCode(e.cause) : undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

Track 2 of the data-freshness plan — adds three Prometheus metrics on `bigqueryTarget` so the freshness-monitor dashboard can show distribution of commit lag and AppendRows error rates per pipe. Independent of Tracks 1 (Portal lag) and 3 (BQ probe).

- `sqd_bigquery_block_to_commit_lag_seconds` (histogram, label `id`) — **primary commit-stage SLO**; observed as `commit_ack_wallclock − latest_block.timestamp` on each successful AppendRows ack. Skipped when `cursor.timestamp` is missing.
- `sqd_bigquery_commit_duration_seconds` (histogram, label `id`) — wallclock of parallel AppendRows across tracked tables.
- `sqd_bigquery_append_errors_total` (counter, labels `id` + `kind`) — AppendRows failures classified by kind ∈ {`not_found`, `invalid_argument`, `resource_exhausted`, `transient`, `unknown`}. Wraps all three WAL stages (pre-commit / commitBatch / post-commit). `onData` throws are excluded.

Metrics are registered lazily on the first batch via `ctx.metrics` from `BatchContext` — **no Target API changes**. Error classifier (`classifyBqError`) added to `utils.ts`; gRPC `NOT_FOUND` (5) collapses with HTTP 404 since the operator response is identical.

## Test plan

- [x] `pnpm vitest run src/targets/bigquery/` (unit) — 93/93 passing, including 5 new metrics scenarios in `bigquery-target.lifecycle.test.ts` and 6 new classifier scenarios in `bigquery-target.test.ts`.
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] BQ integration tests (excluded locally; run on CI).

## Coverage

New code covered by unit tests via the internal testing framework (`~/testing/test-metrics-server`):
- Block-to-commit-lag observation with pinned wallclock asserting exact value (`vi.useFakeTimers`).
- Skip path when `cursor.timestamp === undefined`.
- Commit duration observed once per batch (multi-batch case asserted).
- Error classifier injected via `protoWriterFactory` rejecting with gRPC code 3; counter increments with `{id, kind:'invalid_argument'}` and success-path histograms stay empty.
- Cached registration across batches (single registration, two observations).
- Classifier unit tests cover each `kind` branch + cause-chain walking + non-error inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)