### PR TITLE
feat(pipes): expose RPC block hash in LatencySample

### DIFF
--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@subsquid/pipes",
   "type": "module",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "sideEffects": false,
   "author": "Subsquid Team",
   "files": [

--- a/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
+++ b/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
@@ -35,6 +35,9 @@ describe('BitcoinRpcLatencyWatcher', () => {
         expect(lookup).toHaveLength(1)
         expect(lookup[0].url).toBe(mock!.url)
         expect(lookup[0].timestamp).toEqual(new Date(time * 1000))
+        // Hash must round-trip through addBlock → lookup() so reorg-aware downstream
+        // consumers (e.g. the BigQuery freshness probe) can match (number, hash).
+        expect(lookup[0].hash).toBe(`hash-${800_000}`)
       },
       { timeout: 1_000, interval: 20 },
     )

--- a/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
+++ b/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
@@ -78,6 +78,7 @@ export class BitcoinRpcLatencyWatcher extends RpcLatencyWatcher {
       // when iterating `this.rpcUrl`).
       this.addBlock(url, {
         number: header.height,
+        hash,
         timestamp: new Date(header.time * 1000),
         receivedAt: new Date(),
       })

--- a/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.ts
@@ -19,12 +19,16 @@ class EvmRpcLatencyWatcher extends RpcLatencyWatcher {
 
     listener.subscribe(
       payload,
-      (message: { method: string; params: { result: { number: string; timestamp: string } } }) => {
+      (message: {
+        method: string
+        params: { result: { number: string; hash: string; timestamp: string } }
+      }) => {
         if (message.method !== 'eth_subscription') return
         const head = message.params.result
 
         this.addBlock(url, {
           number: parseInt(head.number),
+          hash: head.hash,
           timestamp: new Date(parseInt(head.timestamp) * 1000),
           receivedAt: new Date(),
         })

--- a/packages/subsquid-pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
+++ b/packages/subsquid-pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BatchContext } from '~/core/portal-source.js'
+
+import { RpcLatencyWatcher, type RpcLatencyListener, rpcLatencyWatcher } from './rpc-latency-watcher.js'
+
+class StubWatcher extends RpcLatencyWatcher {
+  watch(): RpcLatencyListener {
+    return { stop: () => {} }
+  }
+  /** Skip subscribing — tests populate `nodes` directly via addBlock. */
+  preregister(url: string): void {
+    this.nodes.set(url, new Map())
+  }
+}
+
+const profilerStub: Record<string, unknown> = {
+  start: () => profilerStub,
+  measure: async (_: unknown, fn: () => unknown) => fn(),
+  end: () => {},
+  data: undefined,
+}
+
+function makeBatchContext(receivedAt: Date): BatchContext {
+  return {
+    profiler: profilerStub,
+    batch: {
+      blocksCount: 1,
+      bytesSize: 0,
+      requests: {},
+      lastBlockReceivedAt: receivedAt,
+    },
+  } as unknown as BatchContext
+}
+
+describe('rpcLatencyWatcher transformer', () => {
+  it('propagates the RPC-observed hash from lookup() into LatencySample.rpc[].hash', async () => {
+    // Reorg-safe joining downstream (BigQuery freshness probe) requires the hash to flow
+    // end-to-end: addBlock → lookup → LatencySample. A regression dropping the field would
+    // silently break (number, hash) matching, leaving the probe pairing observations across
+    // chain forks. This pins the wire-up.
+    const watcher = new StubWatcher(['ws://rpc-1', 'ws://rpc-2'])
+    watcher.preregister('ws://rpc-1')
+    watcher.preregister('ws://rpc-2')
+
+    const blockTimestamp = new Date('2026-05-09T00:00:00Z')
+    const rpc1ReceivedAt = new Date('2026-05-09T00:00:01Z')
+    const rpc2ReceivedAt = new Date('2026-05-09T00:00:02Z')
+    watcher.addBlock('ws://rpc-1', {
+      number: 100,
+      hash: '0xCANONICAL',
+      timestamp: blockTimestamp,
+      receivedAt: rpc1ReceivedAt,
+    })
+    watcher.addBlock('ws://rpc-2', {
+      number: 100,
+      hash: '0xCANONICAL',
+      timestamp: blockTimestamp,
+      receivedAt: rpc2ReceivedAt,
+    })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const portalReceivedAt = new Date('2026-05-09T00:00:03Z')
+    const result = await transformer.run(
+      [{ header: { number: 100, timestamp: blockTimestamp.getTime() / 1000 } }],
+      makeBatchContext(portalReceivedAt),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result?.number).toBe(100)
+    expect(result?.rpc).toEqual([
+      { url: 'ws://rpc-1', hash: '0xCANONICAL', receivedAt: rpc1ReceivedAt, portalDelayMs: 2000 },
+      { url: 'ws://rpc-2', hash: '0xCANONICAL', receivedAt: rpc2ReceivedAt, portalDelayMs: 1000 },
+    ])
+  })
+
+  it('emits hash=undefined for sources that do not carry one (e.g. Solana)', async () => {
+    // Solana's slot updates carry no hash; the field stays undefined end-to-end. Downstream
+    // consumers degrade to number-only matching — this test pins that the pipeline doesn't
+    // accidentally fabricate a value (e.g. empty string) on the way through.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.preregister('ws://rpc')
+
+    watcher.addBlock('ws://rpc', {
+      number: 42,
+      timestamp: new Date('2026-05-09T00:00:00Z'),
+      receivedAt: new Date('2026-05-09T00:00:01Z'),
+    })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const result = await transformer.run(
+      [{ header: { number: 42, timestamp: new Date('2026-05-09T00:00:00Z').getTime() / 1000 } }],
+      makeBatchContext(new Date('2026-05-09T00:00:02Z')),
+    )
+
+    expect(result?.rpc[0]?.hash).toBeUndefined()
+  })
+
+  it('returns null when no RPC has seen the block (lookup empty)', async () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.preregister('ws://rpc')
+    // No addBlock calls — lookup returns [].
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const result = await transformer.run(
+      [{ header: { number: 999, timestamp: 0 } }],
+      makeBatchContext(new Date()),
+    )
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/subsquid-pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
+++ b/packages/subsquid-pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
@@ -1,7 +1,10 @@
 import { createTransformer } from '~/core/index.js'
 import { arrayify, last } from '~/internal/array.js'
 
-type RpcHead = { number: number; timestamp: Date; receivedAt: Date }
+// `hash` is optional because Solana's `slotsUpdatesSubscribe` ships only `{ slot, timestamp }`
+// — the hash would require a follow-up `getBlock(slot)` round-trip we don't want on the
+// hot path. EVM (`eth_subscribe newHeads`) and Bitcoin (`getbestblockhash`) both populate it.
+type RpcHead = { number: number; hash?: string; timestamp: Date; receivedAt: Date }
 
 export interface RpcLatencyListener {
   stop(): void
@@ -47,7 +50,7 @@ export abstract class RpcLatencyWatcher {
   }
 
   lookup(number: number) {
-    const res: { url: string; timestamp: Date; receivedAt: Date }[] = []
+    const res: { url: string; hash?: string; timestamp: Date; receivedAt: Date }[] = []
 
     for (const [url, blocks] of this.nodes) {
       const block = blocks.get(number)
@@ -55,6 +58,7 @@ export abstract class RpcLatencyWatcher {
       if (block) {
         res.push({
           url,
+          hash: block.hash,
           timestamp: block.timestamp,
           receivedAt: block.receivedAt,
         })
@@ -82,6 +86,8 @@ type Latency = {
   }
   rpc: {
     url: string
+    /** Block hash as observed by this RPC. Omitted on Solana (no hash on slot updates). */
+    hash?: string
     portalDelayMs: number
     receivedAt?: Date
   }[]
@@ -111,6 +117,7 @@ export function rpcLatencyWatcher({ watcher }: { watcher: RpcLatencyWatcher }) {
         rpc: lookup.map((r) => {
           return {
             url: r.url,
+            hash: r.hash,
             receivedAt: r.receivedAt,
             portalDelayMs: receivedAt.getTime() - r.receivedAt.getTime(),
           }


### PR DESCRIPTION
## Summary

Adds `hash?: string` to `RpcHead` → watcher `lookup()` → `LatencySample.rpc[]`. Populated on EVM (`eth_subscribe newHeads` carries `hash`) and Bitcoin (already had it from `getbestblockhash`); Solana stays without it (slot updates don't carry hash, and a follow-up `getBlock(slot)` would put a network round-trip on the hot path).

Unblocks downstream consumers — specifically the BigQuery freshness probe (Track 3) — to join observations against BQ cursors by `(number, hash)` so a reorged-but-not-yet-canonical block produces a clean cache miss instead of a best-effort lag sample.

Bumps `@subsquid/pipes` to `1.0.0-alpha.12`.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run src/monitoring src/evm src/bitcoin` — 120/120

🤖 Generated with [Claude Code](https://claude.com/claude-code)