### PR TITLE
Guard against missing result in newHeads subscription

### DIFF
--- a/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.ts
@@ -21,10 +21,11 @@ class EvmRpcLatencyWatcher extends RpcLatencyWatcher {
       payload,
       (message: {
         method: string
-        params: { result: { number: string; hash: string; timestamp: string } }
+        params?: { result?: { number: string; hash: string; timestamp: string } }
       }) => {
         if (message.method !== 'eth_subscription') return
-        const head = message.params.result
+        const head = message.params?.result
+        if (!head) return
 
         this.addBlock(url, {
           number: parseInt(head.number),


### PR DESCRIPTION
## Problem

Missing `message.params.result` throwed `TypeError: undefined is not an object`. The throw is uncaught in the WebSocket callback and kills the `freshness-monitor` pod.

## Fix

Skip notifications with no `result`, matching the Solana watcher's guard.