### PR TITLE
feat(pipes): enforce a monotonic finalized high-watermark in targets

### DIFF
--- a/packages/subsquid-pipes/src/core/finalized-watermark.test.ts
+++ b/packages/subsquid-pipes/src/core/finalized-watermark.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { FinalizedWatermark, coerceFinalized, maxFinalized } from './finalized-watermark.js'
+
+function block(number: number, hash?: string) {
+  return { number, hash: hash ?? `0x${number}` }
+}
+
+describe('maxFinalized', () => {
+  it('returns the higher-numbered cursor', () => {
+    expect(maxFinalized(block(10), block(5))).toEqual(block(10))
+    expect(maxFinalized(block(5), block(10))).toEqual(block(10))
+  })
+
+  it('treats undefined as the lowest head', () => {
+    expect(maxFinalized(undefined, block(5))).toEqual(block(5))
+    expect(maxFinalized(block(5), undefined)).toEqual(block(5))
+    expect(maxFinalized(undefined, undefined)).toBeUndefined()
+  })
+
+  it('keeps the first argument on a tie', () => {
+    const a = block(7, '0xaa')
+    const b = block(7, '0xbb')
+    expect(maxFinalized(a, b)).toBe(a)
+  })
+})
+
+describe('coerceFinalized', () => {
+  it('passes through a valid cursor', () => {
+    expect(coerceFinalized(block(3))).toEqual(block(3))
+  })
+
+  it('rejects empty / partial persisted values', () => {
+    expect(coerceFinalized({})).toBeUndefined()
+    expect(coerceFinalized(undefined)).toBeUndefined()
+    expect(coerceFinalized(null)).toBeUndefined()
+    expect(coerceFinalized({ hash: '0x1' })).toBeUndefined()
+  })
+})
+
+describe('FinalizedWatermark', () => {
+  it('advances the floor monotonically across batches', () => {
+    const wm = new FinalizedWatermark()
+
+    expect(wm.clamp(block(10))).toEqual(block(10))
+    expect(wm.floor).toEqual(block(10))
+
+    expect(wm.clamp(block(25))).toEqual(block(25))
+    expect(wm.floor).toEqual(block(25))
+  })
+
+  it('never lets the floor regress (the restart-mid-fork case)', () => {
+    // Seeded from persisted state on restart: a source previously finalized 100.
+    const wm = new FinalizedWatermark(block(100))
+
+    // A different source now reports finalized 80 (deeper confirmation depth); the floor holds.
+    expect(wm.clamp(block(80))).toEqual(block(100))
+    expect(wm.floor).toEqual(block(100))
+  })
+
+  it('passes through undefined for a no-finality dataset', () => {
+    const wm = new FinalizedWatermark()
+
+    expect(wm.clamp(undefined)).toBeUndefined()
+    expect(wm.floor).toBeUndefined()
+  })
+
+  it('seed keeps the higher cursor', () => {
+    const wm = new FinalizedWatermark(block(50))
+    wm.seed(block(30))
+    expect(wm.floor).toEqual(block(50))
+    wm.seed(block(70))
+    expect(wm.floor).toEqual(block(70))
+    wm.seed(undefined)
+    expect(wm.floor).toEqual(block(70))
+  })
+})

--- a/packages/subsquid-pipes/src/core/finalized-watermark.ts
+++ b/packages/subsquid-pipes/src/core/finalized-watermark.ts
@@ -1,0 +1,74 @@
+import { BlockCursor } from './types.js'
+
+/**
+ * Returns the finalized cursor with the higher block number — the monotonic
+ * "high-watermark". `undefined` is treated as the lowest possible head, so any
+ * concrete cursor wins over it; two `undefined`s stay `undefined`.
+ */
+export function maxFinalized(a: BlockCursor | undefined, b: BlockCursor | undefined): BlockCursor | undefined {
+  if (!a) return b
+  if (!b) return a
+
+  return b.number > a.number ? b : a
+}
+
+/**
+ * Normalises a persisted finalized value (which may be `{}` / partial JSON for
+ * "no finalized head yet") into a usable cursor or `undefined`.
+ */
+export function coerceFinalized(value: unknown): BlockCursor | undefined {
+  if (value && typeof value === 'object' && typeof (value as BlockCursor).number === 'number') {
+    return value as BlockCursor
+  }
+
+  return undefined
+}
+
+/**
+ * Stateful monotonic finalized-head tracker for a pipe.
+ *
+ * Seeded from the target's own PERSISTED finalized head at startup so the
+ * watermark survives an unclean restart mid-fork, then advanced as batches
+ * commit. The floor only ever moves forward.
+ *
+ * Different data sources can disagree on how DEEP finality starts (a Portal
+ * replica swap, or a switch to an RPC source with a fixed confirmation depth),
+ * so an incoming finalized head may be LOWER than one already persisted. Acting
+ * on the lower value would "un-finalize" blocks already committed as final and
+ * corrupt fork resolution, so the effective finalized head never regresses below
+ * the floor. Clamping up is safe because finalized *history* is agreed across
+ * sources — blocks in `(incoming, floor]` are identical, just not yet re-marked
+ * final by the new source.
+ */
+export class FinalizedWatermark {
+  #floor: BlockCursor | undefined
+
+  constructor(floor?: BlockCursor) {
+    this.#floor = floor
+  }
+
+  /** Highest finalized head ever seen or persisted. */
+  get floor(): BlockCursor | undefined {
+    return this.#floor
+  }
+
+  /**
+   * Seed the floor from persisted state. Safe to call repeatedly — it keeps the
+   * higher of the existing and provided cursors.
+   */
+  seed(floor: BlockCursor | undefined): void {
+    this.#floor = maxFinalized(this.#floor, floor)
+  }
+
+  /**
+   * Clamp an incoming batch's finalized head against the floor, advancing the
+   * floor to (and returning) the clamped value — the finalized head the target
+   * should act on / persist. It can only move forward, never regress below the
+   * floor; `undefined` in with no floor stays `undefined` (no-finality passthrough).
+   */
+  clamp(finalized: BlockCursor | undefined): BlockCursor | undefined {
+    this.#floor = maxFinalized(this.#floor, finalized)
+
+    return this.#floor
+  }
+}

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,5 +1,9 @@
 export * from './errors.js'
 export * from './finalization-buffer.js'
+// Only `coerceFinalized` is consumed across module boundaries (the target state classes). The
+// watermark class is imported directly by the source, and maxFinalized is module-internal — keep
+// them out of the package's public surface.
+export { coerceFinalized } from './finalized-watermark.js'
 export * from './fork.js'
 export * from './formatters.js'
 export * from './logger.js'

--- a/packages/subsquid-pipes/src/core/portal-source.test.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.test.ts
@@ -386,6 +386,83 @@ describe('Portal abstract stream', () => {
       `)
     })
   })
+
+  describe('finalized watermark (centralized clamp)', () => {
+    it('clamps a transient missing finalized head up to the persisted floor', async () => {
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [{ header: { number: 6, hash: '0x6', timestamp: 6000 } }],
+          // finalized header dropped on this batch
+        },
+      ])
+
+      const stream = evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 6 }) })
+
+      const seen: unknown[] = []
+      const target = createTarget({
+        write: async ({ read }) => {
+          for await (const { ctx } of read({ latest: { number: 5, hash: '0x5' }, finalized: { number: 5, hash: '0x5f' } })) {
+            seen.push(ctx.stream.head.finalized)
+          }
+        },
+      })
+      await stream.pipeTo(target as any)
+
+      // The dropped header must not leak as `undefined` (which would collapse the buffer threshold
+      // to Infinity and release unfinalized rows); it clamps back up to the persisted floor (5).
+      expect(seen).toEqual([{ number: 5, hash: '0x5f' }])
+    })
+
+    it('seeds the floor from the target resume state and clamps a regression below it (restart-mid-fork)', async () => {
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [{ header: { number: 6, hash: '0x6', timestamp: 6000 } }],
+          // first batch after restart reports a finalized head (3) below the persisted floor (5)
+          head: { finalized: { number: 3, hash: '0x3f' }, latest: { number: 10 } },
+        },
+      ])
+
+      const stream = evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 6 }) })
+
+      const seen: unknown[] = []
+      const target = createTarget({
+        write: async ({ read }) => {
+          for await (const { ctx } of read({ latest: { number: 5, hash: '0x5' }, finalized: { number: 5, hash: '0x5f' } })) {
+            seen.push(ctx.stream.head.finalized)
+          }
+        },
+      })
+      await stream.pipeTo(target as any)
+
+      // The persisted floor (5) survives the restart and clamps the lower reported head (3).
+      expect(seen).toEqual([{ number: 5, hash: '0x5f' }])
+    })
+
+    it('leaves finalized undefined for a no-finality dataset (passthrough)', async () => {
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 1, hash: '0x1', timestamp: 1000 } },
+            { header: { number: 2, hash: '0x2', timestamp: 2000 } },
+          ],
+          // no head at all → no finality
+        },
+      ])
+
+      const stream = evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 2 }) })
+
+      const finalizedPerBatch = []
+      for await (const { ctx } of stream) {
+        finalizedPerBatch.push(ctx.stream.head.finalized)
+      }
+
+      // Floor is never seeded (only from a real finalized head), so it stays undefined.
+      expect(finalizedPerBatch).toEqual([undefined])
+    })
+  })
 })
 
 describe('pipe/pipeTo type guards', () => {

--- a/packages/subsquid-pipes/src/core/portal-source.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.ts
@@ -10,12 +10,13 @@ import {
 
 import { last } from '../internal/array.js'
 import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
+import { FinalizedWatermark } from './finalized-watermark.js'
 import { LogLevel, Logger, createDefaultLogger, formatWarning } from './logger.js'
 import { Metrics, MetricsServer, noopMetricsServer } from './metrics-server.js'
 import { Profiler, Span, SpanHooks } from './profiling.js'
 import { ProgressEvent, StartEvent } from './progress-tracker.js'
 import { QueryBuilder, hashQuery } from './query-builder.js'
-import { Target } from './target.js'
+import { Target, TargetState } from './target.js'
 import { QueryAwareTransformer, Transformer, TransformerArgs, TransformerOptions } from './transformer.js'
 import { BlockCursor, Ctx } from './types.js'
 
@@ -122,6 +123,12 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
   readonly #portal: PortalClient
   readonly #metricServer: MetricsServer
   readonly #transformers: Transformer<any, any>[] = []
+  // Single monotonic finalized high-watermark for the whole pipe. Owned here (not
+  // per-target) so a source-switch reporting a deeper/transiently-missing finalized
+  // head can never un-finalize already-committed data, and every consumer — the
+  // finalization buffer AND the targets' saveCursor path — gets one consistent,
+  // never-regressing finalized head. Seeded from the target's persisted floor.
+  readonly #watermark = new FinalizedWatermark()
   #started = false
 
   constructor({ portal, id, query, logger, progress, ...options }: PortalSourceOptions<Q>) {
@@ -163,7 +170,15 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
     this.#metricServer.registerPipe(this.#id)
   }
 
-  private async *read(cursor?: BlockCursor): AsyncIterable<PortalBatch<T>> {
+  private async *read(state?: TargetState): AsyncIterable<PortalBatch<T>> {
+    // Seed the monotonic finalized watermark from the target's persisted finalized
+    // head so it survives an unclean restart mid-fork. Seeding only from the
+    // dedicated `finalized` field (never from `latest`) keeps no-finality datasets
+    // correct: the floor stays undefined → Infinity-threshold passthrough.
+    this.#watermark.seed(state?.finalized ?? undefined)
+
+    const cursor = state?.latest
+
     /*
      Calculates query ranges while excluding blocks that were previously fetched to avoid duplicate processing
      */
@@ -210,11 +225,17 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
         const blocks = batch.blocks
 
         if (blocks.length > 0) {
+          // Clamp the portal's finalized head through the monotonic watermark before it
+          // reaches any consumer, so a regressed or transiently-missing finalized head can
+          // never un-finalize already-committed data. The rollback chain is derived from the
+          // CLAMPED head so the two stay consistent (clamp can only raise finalized).
+          const finalized = this.#watermark.clamp(batch.head.finalized)
+
           // TODO WTF with any?
           const lastBatchBlock = last(blocks as { header: { number: number } }[])
 
           const lastBlockNumber = Math.max(
-            Math.min(last(bounded)?.range?.to || batch.head.latest?.number || batch.head.finalized?.number || Infinity),
+            Math.min(last(bounded)?.range?.to || batch.head.latest?.number || finalized?.number || Infinity),
             lastBatchBlock.header?.number || -Infinity,
           )
 
@@ -226,7 +247,7 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
             stream: {
               dataset: datasetMetadata,
               head: {
-                finalized: batch.head.finalized,
+                finalized,
                 latest: batch.head.latest,
               },
               query: {
@@ -240,7 +261,7 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
                 last: lastBlockNumber,
                 rollbackChain: extractRollbackChain({
                   blocks: batch.blocks,
-                  head: batch.head.finalized,
+                  head: finalized,
                 }),
               },
             },
@@ -384,12 +405,12 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
 
     return target.write({
       logger: this.#logger,
-      read: async function* (cursor?: BlockCursor) {
+      read: async function* (state?: TargetState) {
         await self.configure()
 
         while (true) {
           try {
-            for await (const batch of self.read(cursor)) {
+            for await (const batch of self.read(state)) {
               yield batch as PortalBatch<T>
               self.batchEnd(batch.ctx)
             }
@@ -417,7 +438,10 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
 
             await self.forkTransformers(forkProfiler, forkedCursor)
 
-            cursor = forkedCursor
+            // Resume from the forked cursor; the finalized floor persists in the
+            // instance #watermark across read() re-invocation, so re-seeding with the
+            // same state.finalized is a harmless monotonic no-op.
+            state = { latest: forkedCursor, finalized: state?.finalized ?? null }
           } finally {
             await self.stop()
           }

--- a/packages/subsquid-pipes/src/core/target.ts
+++ b/packages/subsquid-pipes/src/core/target.ts
@@ -3,9 +3,24 @@ import { Logger } from '~/core/logger.js'
 import { PortalBatch } from './portal-source.js'
 import { BlockCursor } from './types.js'
 
+/**
+ * Resume state a target hands back to the source when it starts reading.
+ *
+ * `latest` is the cursor to resume from (the block after it is the first one
+ * fetched). `finalized` is the target's own PERSISTED finalized head; the source
+ * seeds its monotonic finalized watermark from it so the watermark survives an
+ * unclean restart mid-fork. `finalized` is a required key, explicitly `null` when
+ * there is no finalized head (no-finality datasets, the memory target, a
+ * cold-started target) — the absence must be stated, never just omitted.
+ */
+export type TargetState = {
+  latest: BlockCursor
+  finalized: BlockCursor | null
+}
+
 export type Target<In> = {
   write: (writer: {
-    read: (cursor?: BlockCursor) => AsyncIterableIterator<PortalBatch<In>>
+    read: (state?: TargetState) => AsyncIterableIterator<PortalBatch<In>>
     logger: Logger
   }) => Promise<void>
   fork?: (previousBlocks: BlockCursor[]) => Promise<BlockCursor | null>

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { createTestLogger } from '~/testing/index.js'
+
+import { BigQueryState } from './bigquery-state.js'
+
+/**
+ * Unit tests for the finalized-head wiring in BigQueryState, using a mocked store (no live
+ * BigQuery). `getCursor` hands the persisted finalized head back as resume state so the source can
+ * seed its monotonic watermark — the clamp itself now lives in the source (see portal-source and
+ * finalized-watermark tests), not in the target.
+ */
+
+function block(number: number, hash = `0x${number}`) {
+  return { number, hash }
+}
+
+function committedRow(finalized: { number: number; hash: string } | null) {
+  return {
+    id: 'stream',
+    op: 'commit',
+    current: JSON.stringify(block(50)),
+    finalized: finalized ? JSON.stringify(finalized) : null,
+    rollback_chain: '[]',
+    range_low: null,
+    range_high: null,
+    committed: true,
+    timestamp: 1,
+  }
+}
+
+function stateWith(row: ReturnType<typeof committedRow>) {
+  const store = {
+    query: async () => [row],
+  }
+
+  return new BigQueryState({
+    store: store as any,
+    bigquery: {} as any,
+    trackedTables: [],
+    options: { projectId: 'p', dataset: 'd' },
+  })
+}
+
+describe('BigQueryState — resume state', () => {
+  it('returns the persisted cursor and finalized head as TargetState', async () => {
+    const state = stateWith(committedRow(block(100)))
+
+    const resume = await state.getCursor({ logger: createTestLogger() })
+
+    expect(resume).toEqual({ latest: block(50), finalized: block(100) })
+  })
+
+  it('returns finalized: null when no finalized head was persisted', async () => {
+    const state = stateWith(committedRow(null))
+
+    const resume = await state.getCursor({ logger: createTestLogger() })
+
+    expect(resume).toEqual({ latest: block(50), finalized: null })
+  })
+})

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
@@ -1,6 +1,14 @@
 import type { BigQuery, TableField } from '@google-cloud/bigquery'
 
-import { type BlockCursor, type Logger, type RollbackRecord, formatBlock, resolveForkCursor } from '~/core/index.js'
+import {
+  type BlockCursor,
+  type Logger,
+  type RollbackRecord,
+  type TargetState,
+  coerceFinalized,
+  formatBlock,
+  resolveForkCursor,
+} from '~/core/index.js'
 
 import type { BigQueryStore } from './bigquery-store.js'
 import type { TrackedTableLocation } from './bigquery-tracker.js'
@@ -139,7 +147,7 @@ export class BigQueryState {
    *   - latest is IN_FLIGHT_ROLLBACK → re-DELETE [range_low, range_high] (idempotent), write
    *                                    rollback marker, return cursor (safe block).
    */
-  async getCursor({ logger }: { logger: Logger }): Promise<BlockCursor | undefined> {
+  async getCursor({ logger }: { logger: Logger }): Promise<TargetState | undefined> {
     let row: SyncRow | undefined
     try {
       row = await this.#fetchLatestRow()
@@ -179,9 +187,16 @@ export class BigQueryState {
 
     const cursor = decodeCursor(row.current)
 
+    // Hand the persisted finalized head back as resume state so the source can seed its
+    // monotonic watermark (survives an unclean restart mid-fork). It is the latest WAL row's
+    // floor; a higher finalized left by a pre-fix regression in an older row is not recovered
+    // — defensive max-across-rows seed is deferred (PR #88 review). Explicit `null` when no
+    // finalized head was ever stored.
+    const finalized = coerceFinalized(decodeCursor(row.finalized)) ?? null
+
     if (row.committed) {
       this.#lastCommittedCursor = cursor
-      return cursor
+      return cursor ? { latest: cursor, finalized } : undefined
     }
 
     // Recovery path — clean the in-flight range across every tracked table.
@@ -223,7 +238,7 @@ export class BigQueryState {
     })
 
     this.#lastCommittedCursor = cursor ?? undefined
-    return cursor ?? undefined
+    return cursor ? { latest: cursor, finalized } : undefined
   }
 
   /**

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
@@ -944,6 +944,7 @@ describe('BigQueryState — crash recovery on getCursor', () => {
     range_low: number | null
     range_high: number | null
     cursorBlock?: number
+    finalized?: { number: number; hash: string } | null
   }) {
     const writer = makeWriter().writer
     const { bq, dmlCalls } = makeBigQuery({
@@ -952,7 +953,7 @@ describe('BigQueryState — crash recovery on getCursor', () => {
           id: 'stream',
           op: latestRow.op,
           current: latestRow.cursorBlock != null ? JSON.stringify(cursor(latestRow.cursorBlock)) : null,
-          finalized: null,
+          finalized: latestRow.finalized != null ? JSON.stringify(latestRow.finalized) : null,
           rollback_chain: '[]',
           range_low: latestRow.range_low,
           range_high: latestRow.range_high,
@@ -1000,7 +1001,27 @@ describe('BigQueryState — crash recovery on getCursor', () => {
       expect(call.params).toMatchObject({ low: 100, high: 199 })
     }
     // Cursor returned is the PRE-batch position (99), not the in-flight high (199).
-    expect(cur?.number).toBe(99)
+    expect(cur?.latest?.number).toBe(99)
+    // No finalized head was stored on this in-flight row.
+    expect(cur?.finalized).toBeNull()
+  })
+
+  it('on (commit, false): hands the persisted finalized head back on the recovery path', async () => {
+    const { state } = makeRecoveryFixture({
+      op: 'commit',
+      committed: false,
+      range_low: 100,
+      range_high: 199,
+      cursorBlock: 99,
+      finalized: { number: 90, hash: '0x90' },
+    })
+
+    const cur = await state.getCursor({ logger: createTestLogger() })
+
+    // The recovery branch returns the same TargetState shape as the committed branch, including
+    // the persisted finalized head so the source can re-seed its watermark after the crash.
+    expect(cur?.latest?.number).toBe(99)
+    expect(cur?.finalized).toEqual({ number: 90, hash: '0x90' })
   })
 
   it('on (rollback, false): re-runs the bounded DELETEs idempotently and returns the safe cursor', async () => {
@@ -1018,7 +1039,7 @@ describe('BigQueryState — crash recovery on getCursor', () => {
     for (const call of dmlCalls) {
       expect(call.params).toMatchObject({ low: 51, high: 100 })
     }
-    expect(cur?.number).toBe(50)
+    expect(cur?.latest?.number).toBe(50)
   })
 
   it('throws CORRUPT_INFLIGHT_ROW when the in-flight row has NULL range_low / range_high', async () => {

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
@@ -168,12 +168,18 @@ export function bigqueryTarget<T>(options: {
         await onStart?.({ store, logger })
 
         // Recovery: getCursor re-executes any outstanding IN_FLIGHT operation before returning.
-        let previousCursor = await state.getCursor({ logger })
-        for await (const { data, ctx } of read(previousCursor)) {
+        const resumeState = await state.getCursor({ logger })
+        // The resume cursor doubles as the WAL pre-commit "previous cursor"; keep it as a plain
+        // BlockCursor (separate from the TargetState handed to read()) for the range arithmetic.
+        let previousCursor = resumeState?.latest
+        for await (const { data, ctx } of read(resumeState)) {
           if (!metrics) metrics = registerBqTargetMetrics(ctx.metrics)
           const span = ctx.profiler.start({ name: 'bigquery', labels: 'db' })
           try {
             const next = ctx.stream.state.current
+            // The source has already clamped the finalized head + rollback chain through the
+            // pipe's monotonic watermark; feed the same values to both WAL writes so the
+            // IN_FLIGHT and COMMITTED rows agree.
             const finalized = ctx.stream.head.finalized
             const rollbackChain = ctx.stream.state.rollbackChain
             // Range of new blocks this batch is about to write: [low, next.number].

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import { BatchContext } from '~/core/index.js'
+import { createTestLogger } from '~/testing/index.js'
+
+import { ClickhouseState } from './clickhouse-state.js'
+
+/**
+ * Unit tests for the finalized-head wiring in ClickhouseState, using a mocked store (no live
+ * ClickHouse). `getCursor` hands the persisted finalized head back as resume state so the source
+ * can seed its monotonic watermark; `saveCursor` persists the (already source-clamped) finalized
+ * head + rollback chain verbatim. The clamp itself lives in the source now.
+ */
+
+function block(number: number, hash = `0x${number}`) {
+  return { number, hash }
+}
+
+function fakeSpan(): any {
+  const span: any = {
+    measure: (_name: any, fn: any) => fn(span),
+    start: () => span,
+    end: () => {},
+  }
+  return span
+}
+
+function ctxFor(
+  current: { number: number; hash: string },
+  finalized: { number: number; hash: string } | undefined,
+  rollbackChain: { number: number; hash: string }[],
+): BatchContext {
+  return {
+    logger: createTestLogger(),
+    profiler: fakeSpan(),
+    stream: {
+      head: { finalized },
+      state: { current, rollbackChain },
+    },
+  } as unknown as BatchContext
+}
+
+function makeStore(persistedFinalized: { number: number; hash: string }) {
+  const inserts: any[] = []
+  const store = {
+    client: { connectionParams: { database: 'default' } },
+    query: async () => ({
+      json: async () => [{ current: JSON.stringify(block(50)), finalized: JSON.stringify(persistedFinalized) }],
+    }),
+    insert: async (args: any) => {
+      inserts.push(args)
+    },
+    removeAllRowsByQuery: async () => {},
+    command: async () => {},
+  }
+
+  return { store, inserts }
+}
+
+describe('ClickhouseState — options', () => {
+  it('falls back to the default id when an explicit `undefined` is passed', () => {
+    const { store } = makeStore(block(100))
+    const state = new ClickhouseState(store as any, { id: undefined })
+
+    // getCursor/cleanup/fork bind {id:String}; an undefined id would break that binding.
+    expect(state.options.id).toBe('stream')
+  })
+})
+
+describe('ClickhouseState — resume state & cursor persistence', () => {
+  it('returns the persisted cursor and finalized head as TargetState', async () => {
+    const { store } = makeStore(block(100))
+    const state = new ClickhouseState(store as any, {})
+
+    const resume = await state.getCursor()
+
+    expect(resume).toEqual({ latest: block(50), finalized: block(100) })
+  })
+
+  it('persists the finalized head + rollback chain verbatim (the source already clamped them)', async () => {
+    const { store, inserts } = makeStore(block(100))
+    const state = new ClickhouseState(store as any, {})
+
+    await state.saveCursor(ctxFor(block(130), block(120), [block(121)]))
+
+    const row = inserts[0].values[0]
+    expect(row.current).toBe(JSON.stringify(block(130)))
+    expect(row.finalized).toBe(JSON.stringify(block(120)))
+    expect(row.rollback_chain).toBe(JSON.stringify([block(121)]))
+  })
+
+  it('persists the empty sentinel when there is no finalized head', async () => {
+    const { store, inserts } = makeStore(block(100))
+    const state = new ClickhouseState(store as any, {})
+
+    await state.saveCursor(ctxFor(block(130), undefined, []))
+
+    const row = inserts[0].values[0]
+    expect(row.finalized).toBe('')
+    expect(row.rollback_chain).toBe(JSON.stringify([]))
+  })
+})
+
+describe('ClickhouseState — fork', () => {
+  function forkStore(rows: { rollback_chain: string; finalized: string }[]) {
+    const queries: any[] = []
+    const store = {
+      client: { connectionParams: { database: 'default' } },
+      query: async (args: any) => {
+        queries.push(args)
+        return {
+          stream: async function* () {
+            yield rows.map((r) => ({ json: () => r }))
+          },
+        }
+      },
+    }
+    return { store, queries }
+  }
+
+  it('scopes the fork scan to its own stream id', async () => {
+    const { store, queries } = forkStore([
+      { rollback_chain: JSON.stringify([block(5), block(6)]), finalized: JSON.stringify(block(4)) },
+    ])
+    const state = new ClickhouseState(store as any, { id: 'pipe-a' })
+
+    await state.fork([block(5), block(6, '0x6a')])
+
+    // Must filter by id, like getCursor/cleanup — otherwise other streams sharing the table
+    // would mix their rollback chains into this fork resolution.
+    expect(queries[0].query).toMatch(/WHERE id = \{id:String\}/)
+    expect(queries[0].query_params).toEqual({ id: 'pipe-a' })
+  })
+
+  it('skips offsets with no finalized head instead of crashing (matches postgres/bigquery)', async () => {
+    // A source that never reported a finalized head persists finalized as '' with an empty
+    // rollback chain; fork resolution must skip it gracefully, not crash on JSON.parse('').
+    const { store } = forkStore([{ rollback_chain: '[]', finalized: '' }])
+    const state = new ClickhouseState(store as any, {})
+
+    await expect(state.fork([block(5)])).resolves.toBeNull()
+  })
+
+  it('resolves normally when finalized heads are present', async () => {
+    const { store } = forkStore([
+      { rollback_chain: JSON.stringify([block(5), block(6)]), finalized: JSON.stringify(block(4)) },
+    ])
+    const state = new ClickhouseState(store as any, {})
+
+    const safe = await state.fork([block(5), block(6, '0x6a')])
+    expect(safe).toEqual(block(5))
+  })
+})

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
@@ -1,4 +1,12 @@
-import { BatchContext, BlockCursor, Profiler, RollbackRecord, resolveForkCursor } from '~/core/index.js'
+import {
+  BatchContext,
+  BlockCursor,
+  Profiler,
+  RollbackRecord,
+  TargetState,
+  coerceFinalized,
+  resolveForkCursor,
+} from '~/core/index.js'
 
 import { ClickhouseStore } from './clickhouse-store.js'
 
@@ -67,9 +75,9 @@ export class ClickhouseState {
     this.options = {
       database: client.connectionParams?.database || 'default',
       table: 'sync',
-      id: 'stream',
       ...options,
-      // override after spread so an explicit `undefined` cannot clobber the default
+      // override after spread so an explicit `undefined` cannot clobber the defaults
+      id: options.id ?? 'stream',
       maxRows,
     }
 
@@ -102,6 +110,9 @@ export class ClickhouseState {
           {
             id: this.options.id,
             current: this.encodeCursor(current),
+            // The source has already clamped this finalized head + rollback chain through the
+            // pipe's monotonic watermark, so persisting them verbatim keeps the stored floor
+            // non-regressing without any target-local clamp.
             finalized: head.finalized ? this.encodeCursor(head.finalized) : '',
             rollback_chain: JSON.stringify(rollbackChain),
             sign: 1,
@@ -139,7 +150,7 @@ export class ClickhouseState {
     }
   }
 
-  async getCursor(): Promise<BlockCursor | undefined> {
+  async getCursor(): Promise<TargetState | undefined> {
     try {
       const res = await this.store.query({
         query: `SELECT * FROM ${this.#qualifiedName} WHERE id = {id:String} ORDER BY timestamp DESC LIMIT 1`,
@@ -147,9 +158,17 @@ export class ClickhouseState {
         query_params: { id: this.options.id },
       })
 
-      const [row] = await res.json<{ current: string; initial: string }>()
+      const [row] = await res.json<{ current: string; finalized: string }>()
       if (row) {
-        return this.decodeCursor(row.current)
+        // Hand the persisted finalized head back as resume state so the source can seed its
+        // monotonic watermark (survives an unclean restart mid-fork). It is the newest row's
+        // floor — a higher finalized left by a pre-fix regression in an older row is not
+        // recovered; defensive max-across-rows seed is deferred (PR #88 review). Explicit `null`
+        // when no finalized head was ever stored.
+        return {
+          latest: this.decodeCursor(row.current),
+          finalized: coerceFinalized(row.finalized ? this.decodeCursor(row.finalized) : undefined) ?? null,
+        }
       }
 
       return
@@ -165,9 +184,13 @@ export class ClickhouseState {
   }
 
   async fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null> {
+    // Filter by id (like getCursor and cleanup do): when multiple streams share one sync table,
+    // an unfiltered scan would mix other streams' rollback chains into this fork's resolution and
+    // could resolve to a foreign cursor, corrupting the rollback.
     const res = await this.store.query({
-      query: `SELECT * FROM ${this.#qualifiedName} ORDER BY "timestamp" DESC`,
+      query: `SELECT * FROM ${this.#qualifiedName} WHERE id = {id:String} ORDER BY "timestamp" DESC`,
       format: 'JSONEachRow',
+      query_params: { id: this.options.id },
     })
 
     async function* records(): AsyncIterable<RollbackRecord> {
@@ -176,7 +199,11 @@ export class ClickhouseState {
           const raw = row.json()
           yield {
             rollbackChain: JSON.parse(raw.rollback_chain) as BlockCursor[],
-            finalized: JSON.parse(raw.finalized) as BlockCursor,
+            // A row persisted before the source reported any finalized head stores '' (and always
+            // an empty rollback chain). Decode it to `undefined` so resolveForkCursor skips it
+            // gracefully — matching the postgres/bigquery targets — instead of crashing on
+            // JSON.parse('').
+            finalized: raw.finalized ? (JSON.parse(raw.finalized) as BlockCursor) : undefined,
           }
         }
       }

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickouse-target.ts
@@ -68,8 +68,8 @@ export function clickhouseTarget<T>({
         await onRollback?.({
           type: 'offset_check',
           store,
-          cursor,
-          safeCursor: cursor,
+          cursor: cursor.latest,
+          safeCursor: cursor.latest,
         })
       }
 

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
@@ -395,6 +395,12 @@ describe('Drizzle target', () => {
           },
         ]
       `)
+
+      // The fork drops the rolled-back sync row (block 5) above the safe cursor, so only the
+      // reprocessed write (block 7) remains — getCursor then resumes from the last write rather
+      // than a stale higher block.
+      const sync = await getAllFromSyncTable()
+      expect(sync.map((r) => Number(r['current_number']))).toEqual([7])
     })
 
     it('should rollback updates', async () => {

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
@@ -165,6 +165,9 @@ export function drizzleTarget<T>({
       await db.transaction(async (tx) => {
         await onBeforeRollback?.({ tx, cursor })
         await tracker.fork(tx, cursor)
+        // Drop the now-dead sync rows above the safe cursor so the resume row stays the last write
+        // and reprocessing can re-insert those block numbers without a primary-key collision.
+        await state.removeForkedRows(tx, cursor)
         await onAfterRollback?.({ tx, cursor })
       }, config)
 

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.test.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.test.ts
@@ -1,0 +1,166 @@
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+
+import { BatchContext } from '~/core/index.js'
+import { createTestLogger } from '~/testing/index.js'
+
+import { PostgresState } from './postgres-state.js'
+
+/**
+ * Unit tests for the finalized-head wiring in PostgresState, using a mocked pg client +
+ * transaction (no live Postgres). `getCursor` hands the persisted finalized head back as resume
+ * state so the source can seed its monotonic watermark; `saveCursor` persists the (already
+ * source-clamped) finalized head + rollback chain verbatim. The clamp itself lives in the source.
+ */
+
+function block(number: number, hash = `0x${number}`) {
+  return { number, hash }
+}
+
+function fakeSpan(): any {
+  const span: any = {
+    measure: (_name: any, fn: any) => fn(span),
+    start: () => span,
+    end: () => {},
+  }
+  return span
+}
+
+function ctxFor(
+  current: { number: number; hash: string },
+  finalized: { number: number; hash: string } | undefined,
+  rollbackChain: { number: number; hash: string }[],
+): BatchContext {
+  return {
+    logger: createTestLogger(),
+    profiler: fakeSpan(),
+    stream: {
+      head: { finalized },
+      state: { current, rollbackChain },
+    },
+  } as unknown as BatchContext
+}
+
+/** Extract the values bound into a captured drizzle SQL template. */
+function paramsOf(sql: any): unknown[] {
+  return new PgDialect().sqlToQuery(sql).params
+}
+
+/** Render a captured drizzle SQL template to its parameterised text. */
+function sqlTextOf(sql: any): string {
+  return new PgDialect().sqlToQuery(sql).sql
+}
+
+async function seededState(persistedFinalized: unknown) {
+  const client = {
+    query: async () => ({
+      rows: [
+        {
+          id: 'stream',
+          current_number: '50',
+          current_hash: '0x50',
+          current_timestamp: null,
+          finalized: persistedFinalized,
+          rollback_chain: [],
+        },
+      ],
+    }),
+  }
+  const state = new PostgresState(client as any, { unfinalizedBlocksRetention: 1000 })
+  await state.getCursor({ logger: createTestLogger() })
+
+  return state
+}
+
+describe('PostgresState — resume state & cursor persistence', () => {
+  it('returns the persisted cursor and finalized head as TargetState', async () => {
+    const state = await seededState(block(100))
+
+    const resume = await state.getCursor({ logger: createTestLogger() })
+
+    expect(resume).toEqual({ latest: { number: 50, hash: '0x50' }, finalized: block(100) })
+  })
+
+  it('returns finalized: null when no finalized head was persisted', async () => {
+    const state = await seededState({})
+
+    const resume = await state.getCursor({ logger: createTestLogger() })
+
+    expect(resume).toEqual({ latest: { number: 50, hash: '0x50' }, finalized: null })
+  })
+
+  it('persists the finalized head + rollback chain verbatim (the source already clamped them)', async () => {
+    const state = await seededState(block(100))
+
+    const executed: any[] = []
+    const tx = {
+      execute: async (sql: any) => {
+        executed.push(sql)
+        return { rowCount: 0 }
+      },
+    }
+
+    await state.saveCursor(tx as any, ctxFor(block(130), block(120), [block(121), block(122)]))
+
+    const insertParams = paramsOf(executed[0])
+    expect(insertParams).toContain(JSON.stringify(block(120)))
+    expect(insertParams).toContain(JSON.stringify([block(121), block(122)]))
+  })
+})
+
+describe('PostgresState — fork', () => {
+  function forkState(rows: { rollback_chain: unknown; finalized: unknown }[]) {
+    let call = 0
+    const client = {
+      // fork() paginates; serve the rows on the first page, then an empty page to terminate.
+      query: async () => {
+        const page = call === 0 ? rows : []
+        call++
+
+        return { rows: page }
+      },
+    }
+
+    return new PostgresState(client as any, {})
+  }
+
+  it('resolves the safe cursor from the persisted rollback chains', async () => {
+    const state = forkState([{ rollback_chain: [block(5), block(6)], finalized: block(4) }])
+
+    const safe = await state.fork([block(5), block(6, '0x6a')])
+
+    expect(safe).toEqual(block(5))
+  })
+
+  it('skips offsets with no finalized head ({}) without crashing', async () => {
+    // A source that never reported a finalized head persists `{}` with an empty rollback chain;
+    // fork resolution must skip it gracefully (jsonb, so no JSON.parse crash), like ClickHouse.
+    const state = forkState([{ rollback_chain: [], finalized: {} }])
+
+    await expect(state.fork([block(5)])).resolves.toBeNull()
+  })
+})
+
+describe('PostgresState — fork cleanup', () => {
+  it('deletes the now-dead sync rows above the fork cursor', async () => {
+    const state = await seededState(block(100))
+
+    const executed: any[] = []
+    const tx = {
+      execute: async (sql: any) => {
+        executed.push(sql)
+        return { rowCount: 0 }
+      },
+    }
+
+    await state.removeForkedRows(tx as any, block(997))
+
+    const text = sqlTextOf(executed[0])
+    const params = paramsOf(executed[0])
+    // Scope to this id and drop only rows strictly above the safe cursor (the dead chain),
+    // so the resume row stays the last write and reprocessing can re-insert those numbers.
+    expect(text).toMatch(/DELETE FROM/i)
+    expect(text).toMatch(/"current_number" > \$\d/)
+    expect(params).toEqual(['stream', 997])
+  })
+})

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.ts
@@ -1,6 +1,15 @@
 import { sql } from 'drizzle-orm'
 
-import { BatchContext, BlockCursor, Logger, Profiler, RollbackRecord, resolveForkCursor } from '~/core/index.js'
+import {
+  BatchContext,
+  BlockCursor,
+  Logger,
+  Profiler,
+  RollbackRecord,
+  TargetState,
+  coerceFinalized,
+  resolveForkCursor,
+} from '~/core/index.js'
 import { doWithRetry } from '~/internal/function.js'
 import { parseNumber } from '~/internal/number.js'
 import { Transaction } from '~/targets/drizzle/node-postgres/drizzle-target.js'
@@ -121,6 +130,9 @@ export class PostgresState {
     }: BatchContext,
     parentSpan: Profiler = profiler,
   ) {
+    // The source has already clamped this finalized head + rollback chain through the
+    // pipe's monotonic watermark, so persist them verbatim — the stored finalized floor
+    // stays non-regressing without a target-local clamp.
     const finalizedBlock = head.finalized?.number
 
     logger.debug(`Saving cursor at block ${current.number} for ${this.options.id} row...`)
@@ -168,7 +180,7 @@ export class PostgresState {
     }
   }
 
-  async getCursor({ logger }: { logger: Logger }): Promise<BlockCursor | undefined> {
+  async getCursor({ logger }: { logger: Logger }): Promise<TargetState | undefined> {
     try {
       const { rows } = await this.client.query<StateSelect>(
         `SELECT * FROM ${this.#sync.fqnName} WHERE id = $1 ORDER BY "current_number" DESC LIMIT 1`,
@@ -177,10 +189,19 @@ export class PostgresState {
       const [row] = rows
       if (!row) return
 
+      // Hand the persisted finalized head back as resume state so the source can seed its
+      // monotonic watermark (survives an unclean restart mid-fork). Taken from the resume row
+      // (the latest by current_number), so `latest` and `finalized` stay consistent. In steady
+      // state that row carries the highest finalized; right after a fork it can briefly hold an
+      // older finalized, but the source re-clamps the floor from the live head on the first batch
+      // (and re-forks off the stale `latest`), so it self-heals. `null` when none was stored.
       return {
-        number: parseNumber(row.current_number),
-        hash: row.current_hash,
-        timestamp: row.current_timestamp ? row.current_timestamp.getTime() / 1000 : undefined,
+        latest: {
+          number: parseNumber(row.current_number),
+          hash: row.current_hash,
+          timestamp: row.current_timestamp ? row.current_timestamp.getTime() / 1000 : undefined,
+        },
+        finalized: coerceFinalized(row.finalized) ?? null,
       }
     } catch (e) {
       if (!tableNotExists(e)) {
@@ -193,6 +214,20 @@ export class PostgresState {
     }
 
     return
+  }
+
+  /**
+   * Drop sync rows above the fork's safe cursor. Their cursors describe the now-dead chain, so
+   * keeping them would (a) let `getCursor` resume from a stale `current_number` (it is not
+   * monotonic in write order while reprocessing climbs back to the pre-fork height) and (b)
+   * collide with the primary key when reprocessing re-writes those block numbers. Runs inside the
+   * fork transaction so the rollback and this cleanup commit atomically.
+   */
+  async removeForkedRows(tx: Transaction, cursor: BlockCursor): Promise<void> {
+    await tx.execute(sql`
+      DELETE FROM ${sql.raw(this.#sync.fqnName)}
+      WHERE "id" = ${this.options.id} AND "current_number" > ${cursor.number}
+    `)
   }
 
   async fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null> {

--- a/packages/subsquid-pipes/src/targets/memory/memory-target.ts
+++ b/packages/subsquid-pipes/src/targets/memory/memory-target.ts
@@ -12,6 +12,9 @@ export function createMemoryTarget<T extends { blockNumber: number }[]>({
   return createTarget<T>({
     write: async ({ read }) => {
       for await (const batch of read()) {
+        // The source has already clamped finalized + rollbackChain through the pipe's
+        // monotonic finalized watermark, so a regressed/transiently-missing head can
+        // never un-finalize emitted data — the buffer releases rows directly.
         const finalized = buffer.push(batch.data, {
           finalized: batch.ctx.stream.head.finalized,
           rollbackChain: batch.ctx.stream.state.rollbackChain,

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-state.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-state.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { type BlockCursor, type Logger, formatBlock } from '~/core/index.js'
+import { type BlockCursor, type Logger, type TargetState, formatBlock } from '~/core/index.js'
 
 import { PQ_ERR, ParquetTargetError } from './errors.js'
 import { fsyncDir, fsyncFile } from './fs-durable.js'
@@ -16,8 +16,14 @@ const DATA_FILE_RE = /^(\d+)-(\d+)\.parquet$/
 type PersistedState = {
   /** Optional pipe namespace, mirrored from `settings.id`. */
   id?: string
-  /** Last durably-checkpointed cursor — `read(cursor)` resumes from `cursor.number + 1`. */
+  /** Last durably-checkpointed cursor — `read` resumes from `cursor.number + 1`. */
   cursor: BlockCursor
+  /**
+   * Finalized head observed at the checkpoint, persisted so the source can re-seed its monotonic
+   * finalized watermark after an unclean restart mid-fork. Absent in state written before this
+   * field existed (treated as "no persisted finalized head").
+   */
+  finalized?: BlockCursor
 }
 
 export type ParquetStateOptions = {
@@ -68,7 +74,7 @@ export class ParquetState {
    * committed cursor exists, additionally delete every published data file whose `maxBlock`
    * exceeds it (incomplete-checkpoint remnants).
    */
-  async getCursor(): Promise<BlockCursor | undefined> {
+  async getCursor(): Promise<TargetState | undefined> {
     await mkdir(this.#baseDir, { recursive: true })
     for (const table of this.#tables) {
       await mkdir(path.join(this.#baseDir, table), { recursive: true })
@@ -83,7 +89,9 @@ export class ParquetState {
 
     await this.#deleteFilesAboveCursor(state.cursor.number)
 
-    return state.cursor
+    // Hand the persisted finalized head back as resume state so the source can re-seed its
+    // monotonic watermark (explicit `null` when no finalized head was stored).
+    return { latest: state.cursor, finalized: state.finalized ?? null }
   }
 
   /**
@@ -91,8 +99,15 @@ export class ParquetState {
    * state file, then fsync the directory so the rename is durable. Called only after every open
    * writer for the checkpoint has been published.
    */
-  async saveCursor(cursor: BlockCursor): Promise<void> {
-    const payload: PersistedState = this.#id ? { id: this.#id, cursor } : { cursor }
+  async saveCursor(cursor: BlockCursor, finalized?: BlockCursor): Promise<void> {
+    const payload: PersistedState = { cursor }
+    if (this.#id) {
+      payload.id = this.#id
+    }
+    if (finalized) {
+      payload.finalized = finalized
+    }
+
     const tmpPath = path.join(this.#baseDir, `${TMP_PREFIX}state-${path.basename(this.#statePath)}`)
 
     await writeFile(tmpPath, JSON.stringify(payload))

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
@@ -1,10 +1,11 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { ParquetReader, ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { createTarget } from '~/core/index.js'
 import { evmPortalStream } from '~/evm/index.js'
 import {
   type MockPortal,
@@ -407,6 +408,49 @@ describe('parquetTarget', () => {
     })
   })
 
+  describe('finalized watermark (persist + restart)', () => {
+    it('persists the source-clamped finalized head through the loop at checkpoint', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3], 3)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      // The loop threads the finalized head into saveCursor, so the state file carries it for the
+      // source to re-seed its watermark on restart.
+      const persisted = JSON.parse(await readFile(path.join(dir, '_sqd_parquet_state.json'), 'utf8'))
+      expect(persisted.cursor).toEqual({ number: 3, hash: '0x3' })
+      expect(persisted.finalized).toEqual({ number: 3, hash: '0x3' })
+    })
+
+    it('re-seeds the watermark from a real persisted finalized head and clamps a regression below it', async () => {
+      // A real ParquetState persists a finalized head of 5, exactly as the target loop would.
+      const persistState = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+      await persistState.getCursor()
+      await persistState.saveCursor({ number: 5, hash: '0x5' }, { number: 5, hash: '0x5f' })
+
+      // Restart: a real getCursor hands that finalized head back as resume state.
+      const resume = await new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() }).getCursor()
+      expect(resume).toEqual({ latest: { number: 5, hash: '0x5' }, finalized: { number: 5, hash: '0x5f' } })
+
+      // The source seeds its floor from the persisted finalized and clamps a lower reported head.
+      mockPortal = await createMockPortal([blocksResponse([6], 3)])
+      const seen: unknown[] = []
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 6 }) }).pipeTo(
+        createTarget({
+          write: async ({ read }) => {
+            for await (const { ctx } of read(resume)) {
+              seen.push(ctx.stream.head.finalized)
+            }
+          },
+        }) as any,
+      )
+
+      // The persisted floor (5) survives the restart and clamps the lower reported head (3).
+      expect(seen).toEqual([{ number: 5, hash: '0x5f' }])
+    })
+  })
+
   describe('fork', () => {
     it('drops buffered forked rows and leaves the pre-fork published file intact', async () => {
       mockPortal = await createMockPortal([
@@ -689,6 +733,39 @@ describe('parquetTarget', () => {
 
       expect(await state.getCursor()).toBeUndefined()
       expect(await listAll(dir, 'blocks')).toEqual([])
+    })
+
+    it('returns the persisted cursor and finalized head as resume state', async () => {
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 5, hash: '0x5' }, finalized: { number: 5, hash: '0x5f' } }),
+      )
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+
+      expect(await state.getCursor()).toEqual({
+        latest: { number: 5, hash: '0x5' },
+        finalized: { number: 5, hash: '0x5f' },
+      })
+    })
+
+    it('returns finalized: null for state written before the finalized field existed', async () => {
+      await writeFile(path.join(dir, '_sqd_parquet_state.json'), JSON.stringify({ cursor: { number: 5, hash: '0x5' } }))
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+
+      expect(await state.getCursor()).toEqual({ latest: { number: 5, hash: '0x5' }, finalized: null })
+    })
+
+    it('persists the finalized head alongside the cursor so the source can re-seed on restart', async () => {
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+      await state.getCursor()
+
+      await state.saveCursor({ number: 7, hash: '0x7' }, { number: 7, hash: '0x7f' })
+
+      const persisted = JSON.parse(await readFile(path.join(dir, '_sqd_parquet_state.json'), 'utf8'))
+      expect(persisted).toMatchObject({
+        cursor: { number: 7, hash: '0x7' },
+        finalized: { number: 7, hash: '0x7f' },
+      })
     })
 
     it('throws (does not silently leave overlap) when an over-cursor file cannot be deleted', async () => {

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.ts
@@ -125,7 +125,8 @@ export function parquetTarget<T>(options: {
       // temp files. fork() runs inside read()'s generator while this for-await is suspended, so no
       // write races with it and close-in-finally is race-free.
       try {
-        const startCursor = await state.getCursor()
+        const resumeState = await state.getCursor()
+        const startCursor = resumeState?.latest
         lastCheckpointBlock = startCursor?.number ?? -1
 
         await onStart?.({ store, logger })
@@ -133,11 +134,14 @@ export function parquetTarget<T>(options: {
         // Captured for the checkpoint closure's metric labels — assigned on the first batch.
         let metricsId = ''
         let lastBoundary: BlockCursor | undefined = startCursor
+        // Latest (source-clamped) finalized head, persisted alongside the cursor at each checkpoint
+        // so the source can re-seed its watermark after an unclean restart. Seeded from resume state.
+        let lastFinalized: BlockCursor | undefined = resumeState?.finalized ?? undefined
 
         const checkpoint = async (cursor: BlockCursor | undefined, reason: string): Promise<void> => {
           const startedMs = Date.now()
           const published = await store.publishAll()
-          if (cursor) await state.saveCursor(cursor)
+          if (cursor) await state.saveCursor(cursor, lastFinalized)
 
           if (metrics) {
             for (const file of published) {
@@ -162,7 +166,7 @@ export function parquetTarget<T>(options: {
           }
         }
 
-        for await (const { data, ctx } of read(startCursor)) {
+        for await (const { data, ctx } of read(resumeState)) {
           if (!metrics) {
             metrics = registerParquetMetrics(ctx.metrics)
             metricsId = ctx.id
@@ -173,8 +177,12 @@ export function parquetTarget<T>(options: {
 
           // 2. finalization + the cursor this batch could checkpoint to. The boundary carries the
           //    HASH needed for resume; boundary.number = min(finalized, current), correct for
-          //    backfill / tip / no-finality / straddling batches.
+          //    backfill / tip / no-finality / straddling batches. `finalized` is already clamped by
+          //    the source, so it never regresses — persist it as the restart-seed floor.
           const finalized = ctx.stream.head.finalized
+          if (finalized) {
+            lastFinalized = finalized
+          }
           const current = ctx.stream.state.current
           const finalization: Finalization = { finalized, rollbackChain: ctx.stream.state.rollbackChain }
           const boundaryCursor = finalized && finalized.number <= current.number ? finalized : current


### PR DESCRIPTION
## Why

A target persists the finalized head it has seen and uses it to drive rollback. Today that head is taken at face value, but it can **regress**: different data sources disagree on how *deep* finality starts (a Portal replica swap, or — once RPC-fallback lands — a switch to an RPC source with a fixed confirmation depth), so an incoming finalized head can be *lower* than one already committed.

Lower value cannot be acted upon in most cases, as the main purpose of supplying finalized head is to let the target prune its state -> the state necessary to "un-finalize" is typically gone. The dangerous case is an **unclean restart mid-fork**: we persist finalized `X`, the process is killed, on restart a source reports finalized `Y < X`, and the target is asked to roll back below `X`. The watermark is seeded from the target's *persisted* finalized head, so it survives the restart and prevents the regression.

## What

A small monotonic high-watermark, owned by the **source** and seeded from the **target's persisted state**, that never lets the finalized head regress:

- **`core/finalized-watermark.ts`** — `maxFinalized`, `coerceFinalized`, and a stateful `FinalizedWatermark` (seed-from-persisted + monotonic clamp). Clamping up is safe because finalized *history* is agreed across sources — blocks in `(incoming, floor]` are identical, just not yet re-marked final by the new source.
- **Centralized in the source** (`PortalSource`): one `FinalizedWatermark` per pipe is seeded from `TargetState.finalized` when `read()` starts, and clamps `batch.head.finalized` before it reaches any consumer; the rollback chain is re-derived from the clamped head. Targets no longer clamp — they persist/return the finalized head verbatim.
- **Targets persist + return the finalized head** — **postgres (drizzle)**, **bigquery**, **clickhouse**, and **parquet** return it from `getCursor` as `TargetState`; **memory** consumes the source-clamped head directly (it does not persist).
- **ClickHouse `fork()` bug fix**: the rollback-chain query in `fork()` was missing a filter on the stream `id`, so it could mix rollback chains from multiple logical streams sharing one sync table and produce incorrect safe cursors. Now filtered by `id`, matching `getCursor`/cleanup.
- **ClickHouse empty-finalized handling**: a row persisted before any finalized head was reported stores `''`; `fork()` now decodes it to `undefined` and `resolveForkCursor` skips it (its rollback chain is always empty) — matching the postgres/bigquery targets — instead of crashing on `JSON.parse('')`.
- **ClickHouse `id` default**: an explicit `id: undefined` no longer clobbers the `'stream'` default (the `{id:String}` binding used by `getCursor`/`cleanup`/`fork` would otherwise break).
- **Postgres fork cleanup**: `fork()` now deletes `sync` rows above the safe cursor (the dead chain), so the resume row stays the last write — `getCursor` (ordered by `current_number`) can't pick a stale rolled-back row — and reprocessing can re-insert those block numbers without a primary-key collision.

`core/fork.ts` is intentionally unchanged: the source's clamp keeps each stored record's finalized floor monotonic, so the existing "fork below finalized → null" path stays correct.

## Commits

Grouped by concern, each reviewable on its own (core mechanism first, then per target):

1. **`feat(pipes): centralize the finalized watermark in the source`** — `FinalizedWatermark`, the source-level seed + monotonic clamp, the `TargetState` interface change, and the memory target consuming the clamped head.
2. **`fix(pipes): make ClickHouse fork resolution use the source watermark`** — `id`-scoped rollback-chain query, empty-finalized (`''`) decode/skip, and the `id`-default guard.
3. **`fix(pipes): drop dead Postgres sync rows on fork so resume stays correct`** — `fork()` deletes dead-chain `sync` rows so the `current_number`-ordered resume can't pick a stale row.
4. **`refactor(pipes): wire the BigQuery target to the source watermark`** — drops BigQuery's per-target watermark, resolves fork state against the source head.
5. **`feat(pipes): persist the finalized head in the Parquet target`** — persists + returns the finalized head, with a persist→restart→seed round-trip test.

## Tests

All mocked — no live services. Unit coverage of the clamp / restart-mid-fork logic (`finalized-watermark.test.ts`) and the source-level seed+clamp (`portal-source.test.ts`), plus per-target tests: postgres/clickhouse/bigquery/parquet seed-from-persisted + clamp/persist-on-save; ClickHouse fork `id`-scoping, empty-finalized skip, and `id`-default guard; postgres fork resolution and dead-row cleanup; bigquery recovery-path finalized; and a parquet persist→restart→seed→clamp round-trip.

## Notes

- This is a self-contained correctness fix with no public API surface change.
- It's the **prerequisite** for the RPC-fallback work: the fallback source is stateless and passes `finalizedHead` through unchanged, relying on this watermark. The fallback source ships in a **separate, stacked PR** (`feat/rpc-fallback-source`, based on this branch).
- Restart seeding reads the latest persisted row, which is authoritative going forward: the source clamp keeps persisted finalized monotonic, ClickHouse/BigQuery resume by write-time, and Postgres now drops dead `sync` rows on fork so its `current_number`-ordered lookup can't pick a stale row.

