### PR TITLE
Add reusable finalization buffer

### DIFF
--- a/packages/subsquid-pipes/src/core/finalization-buffer.test.ts
+++ b/packages/subsquid-pipes/src/core/finalization-buffer.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+
+import { Finalization, createFinalizationBuffer } from './finalization-buffer.js'
+
+type Row = { block: number; tag: string }
+
+function row(block: number, tag = `r${block}`): Row {
+  return { block, tag }
+}
+
+function block(number: number, hash = `0x${number}`) {
+  return { number, hash }
+}
+
+// A batch's finalization state: `head(2)` finalizes up to block 2, `head()` is a
+// no-finality batch, and an optional rollback chain feeds fork resolution.
+function head(finalizedNumber?: number, rollbackChain: { number: number; hash: string }[] = []): Finalization {
+  return {
+    finalized: finalizedNumber === undefined ? undefined : block(finalizedNumber),
+    rollbackChain,
+  }
+}
+
+function make() {
+  return createFinalizationBuffer<Row>({ getBlockNumber: (r) => r.block })
+}
+
+describe('createFinalizationBuffer', () => {
+  describe('push', () => {
+    it('releases rows at or below the finalized head and buffers the rest', () => {
+      const buffer = make()
+
+      const finalized = buffer.push([row(1), row(2), row(3)], head(2))
+
+      expect(finalized).toEqual([row(1), row(2)])
+      expect(buffer.size).toBe(1)
+    })
+
+    it('treats the threshold as inclusive (<=)', () => {
+      const buffer = make()
+
+      expect(buffer.push([row(5)], head(5))).toEqual([row(5)])
+      expect(buffer.size).toBe(0)
+    })
+
+    it('accepts a finalization without a rollback chain', () => {
+      const buffer = make()
+
+      expect(buffer.push([row(1), row(2)], { finalized: block(1) })).toEqual([row(1)])
+      expect(buffer.size).toBe(1)
+    })
+
+    it('does not mutate the input array', () => {
+      const buffer = make()
+      const input = [row(1), row(2)]
+
+      buffer.push(input, head(1))
+
+      expect(input).toEqual([row(1), row(2)])
+    })
+
+    it('returns a fresh array, not internal state', () => {
+      const buffer = make()
+
+      const a = buffer.push([row(1)], head(1))
+      const b = buffer.push([row(2)], head(2))
+
+      expect(a).toEqual([row(1)])
+      expect(b).toEqual([row(2)])
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('cross-batch release', () => {
+    it('releases earlier-buffered rows once a later batch finalizes them', () => {
+      const buffer = make()
+
+      expect(buffer.push([row(10), row(11)], head(9))).toEqual([])
+      expect(buffer.size).toBe(2)
+
+      expect(buffer.push([row(12), row(13)], head(11))).toEqual([row(10), row(11)])
+      expect(buffer.size).toBe(2)
+    })
+
+    it('releases buffered rows on an empty push after the head advances', () => {
+      const buffer = make()
+
+      buffer.push([row(5), row(6), row(7)], head(4))
+      expect(buffer.size).toBe(3)
+
+      expect(buffer.push([], head(6))).toEqual([row(5), row(6)])
+      expect(buffer.size).toBe(1)
+    })
+  })
+
+  describe('ordering', () => {
+    it('emits previously-buffered rows before the current batch on the same flush', () => {
+      const buffer = make()
+
+      buffer.push([row(10)], head(5))
+
+      expect(buffer.push([row(11), row(12)], head(11))).toEqual([row(10), row(11)])
+      expect(buffer.size).toBe(1)
+    })
+
+    it('preserves arrival order within a batch (does not sort)', () => {
+      const buffer = make()
+
+      expect(buffer.push([row(5, 'a'), row(3, 'b'), row(4, 'c')], head(9))).toEqual([
+        row(5, 'a'),
+        row(3, 'b'),
+        row(4, 'c'),
+      ])
+    })
+  })
+
+  describe('no-finality passthrough', () => {
+    it('releases everything immediately when the finalized head is undefined', () => {
+      const buffer = make()
+
+      expect(buffer.push([row(1), row(2), row(3)], head())).toEqual([row(1), row(2), row(3)])
+      expect(buffer.size).toBe(0)
+    })
+
+    it('never buffers across repeated no-finality batches', () => {
+      const buffer = make()
+
+      buffer.push([row(1)], head())
+      buffer.push([row(2)], head())
+
+      expect(buffer.size).toBe(0)
+    })
+
+    it('honours a finalized head of 0 instead of treating it as no-finality', () => {
+      const buffer = make()
+
+      // `?? Infinity` (not `|| Infinity`): block 0 is a real finalized boundary.
+      expect(buffer.push([row(0), row(1)], head(0))).toEqual([row(0)])
+      expect(buffer.size).toBe(1)
+    })
+  })
+
+  describe('fork', () => {
+    it('resolves the safe cursor and drops every buffered row above it', async () => {
+      const buffer = make()
+
+      buffer.push([row(5), row(6), row(7)], head(4, [block(5), block(6), block(7)]))
+
+      const safe = await buffer.fork([block(5), block(6, '0x6a'), block(7, '0x7a')])
+
+      expect(safe).toEqual(block(5))
+      expect(buffer.size).toBe(1) // only row(5) survives
+    })
+
+    it('returns null on a dead-end fork, keeping rows and resetting the chain', async () => {
+      const buffer = make()
+
+      buffer.push([row(5), row(6)], head(4, [block(5, '0x5a'), block(6, '0x6a')]))
+
+      const safe = await buffer.fork([block(5, '0x5b'), block(6, '0x6b')])
+
+      expect(safe).toBeNull()
+      expect(buffer.size).toBe(2) // rows left untouched on a dead end
+    })
+
+    it('cannot roll back to a block that has since finalized', async () => {
+      const buffer = make()
+
+      // The chain sees 5 & 6 while unfinalized…
+      buffer.push([], head(4, [block(5), block(6)]))
+      // …then the head advances past them, pruning them from the chain.
+      buffer.push([], head(6))
+
+      expect(await buffer.fork([block(5), block(6)])).toBeNull()
+    })
+  })
+
+  describe('size', () => {
+    it('reflects the number of buffered rows after each push', () => {
+      const buffer = make()
+
+      expect(buffer.size).toBe(0)
+
+      buffer.push([row(10), row(11), row(12)], head(9))
+      expect(buffer.size).toBe(3)
+
+      buffer.push([], head(10))
+      expect(buffer.size).toBe(2)
+
+      buffer.push([], head(11))
+      expect(buffer.size).toBe(1)
+
+      buffer.push([], head(12))
+      expect(buffer.size).toBe(0)
+    })
+  })
+})

--- a/packages/subsquid-pipes/src/core/finalization-buffer.ts
+++ b/packages/subsquid-pipes/src/core/finalization-buffer.ts
@@ -1,0 +1,119 @@
+import { resolveForkCursor } from './fork.js'
+import { BlockCursor } from './types.js'
+
+/** A batch's finalization state: the finalized head plus the unfinalized rollback chain. */
+export type Finalization = {
+  /** Highest finalized block, or `undefined` for a no-finality dataset. */
+  finalized?: BlockCursor
+  /** Blocks newer than `finalized` seen in this batch — kept for fork resolution. */
+  rollbackChain?: BlockCursor[]
+}
+
+export type FinalizationBuffer<Row> = {
+  /**
+   * Append `rows`, fold in this batch's finalization state, then return the rows
+   * now at or below the finalized head in arrival/block order; the rest stay
+   * buffered until a later, higher finalized head releases them (or a reorg
+   * drops them). Pass an empty `rows` array to flush after the head advances.
+   *
+   * `finalized === undefined` means a no-finality dataset: the threshold is
+   * `Infinity`, so every row passes straight through and nothing is buffered.
+   */
+  push(rows: Row[], finalization: Finalization): Row[]
+
+  /**
+   * Resolve the safe cursor for a reorg from the accumulated rollback chain and
+   * the portal's `previousBlocks`, drop every buffered row above it, and return
+   * that cursor (or `null` on a dead-end fork). Drive this straight from the
+   * target's `fork` handler.
+   */
+  fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null>
+
+  /** Number of rows currently buffered (seen, but not yet finalized). */
+  readonly size: number
+}
+
+/**
+ * In-memory buffer that releases stream rows only once their block has finalized.
+ *
+ * Blockchain data can reorg up to the finalized head, so a target that writes to
+ * immutable storage (Parquet files, append-only logs, …) must hold a row back
+ * until its block finalizes. This buffer owns a pipe's unfinalized state — the
+ * rows *and* the rollback chain — and resolves reorgs itself via {@link FinalizationBuffer.fork},
+ * so the target never has to track the chain or re-derive the safe cursor.
+ *
+ * Memory is bounded by the chain's finality depth: only unfinalized rows and
+ * cursors are held, never the already-finalized output.
+ *
+ * @example
+ * const buffer = createFinalizationBuffer<MyRow>({ getBlockNumber: (r) => r.blockNumber })
+ * // write():
+ * for await (const { data, ctx } of read()) {
+ *   const finalized = buffer.push(data, {
+ *     finalized: ctx.stream.head.finalized,
+ *     rollbackChain: ctx.stream.state.rollbackChain,
+ *   })
+ *   if (finalized.length) await write(finalized)
+ * }
+ * // fork():
+ * return buffer.fork(previousBlocks)
+ */
+export function createFinalizationBuffer<Row>({
+  getBlockNumber,
+}: {
+  getBlockNumber: (row: Row) => number
+}): FinalizationBuffer<Row> {
+  let buffered: Row[] = []
+  let rollbackChain: BlockCursor[] = []
+  let finalized: BlockCursor | undefined
+
+  return {
+    push(rows, finalization) {
+      rollbackChain.push(...(finalization.rollbackChain ?? []))
+      finalized = finalization.finalized
+      const threshold = finalized?.number ?? Infinity
+
+      // Finalized blocks can never reorg, so keep the chain to unfinalized blocks
+      // only — otherwise it grows without bound over a long run.
+      if (finalized) {
+        const boundary = finalized.number
+        rollbackChain = rollbackChain.filter((block) => block.number > boundary)
+      }
+
+      const released: Row[] = []
+      const stillBuffered: Row[] = []
+
+      // Split the whole buffer — previously-held rows first, then this batch's
+      // arrivals — so released rows keep their arrival/block order.
+      for (const row of buffered.length ? [...buffered, ...rows] : rows) {
+        if (getBlockNumber(row) <= threshold) {
+          released.push(row)
+        } else {
+          stillBuffered.push(row)
+        }
+      }
+
+      buffered = stillBuffered
+
+      return released
+    },
+
+    async fork(previousBlocks) {
+      const safe = await resolveForkCursor([{ rollbackChain, finalized }], previousBlocks)
+
+      if (safe) {
+        const boundary = safe.number
+        rollbackChain = rollbackChain.filter((block) => block.number <= boundary)
+        buffered = buffered.filter((row) => getBlockNumber(row) <= boundary)
+      } else {
+        rollbackChain = []
+      }
+
+      return safe
+    },
+
+    get size() {
+      return buffered.length
+    },
+  }
+}

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,4 +1,5 @@
 export * from './errors.js'
+export * from './finalization-buffer.js'
 export * from './fork.js'
 export * from './formatters.js'
 export * from './logger.js'

--- a/packages/subsquid-pipes/src/evm/abi/erc20.ts
+++ b/packages/subsquid-pipes/src/evm/abi/erc20.ts
@@ -1,6 +1,6 @@
-import { ContractBase, event, fun, indexed, viewFun } from '@subsquid/evm-abi';
-import type { EventParams as EParams, FunctionArguments, FunctionReturn } from '@subsquid/evm-abi';
-import * as p from '@subsquid/evm-codec';
+import type { EventParams as EParams, FunctionArguments, FunctionReturn } from '@subsquid/evm-abi'
+import { ContractBase, event, fun, indexed, viewFun } from '@subsquid/evm-abi'
+import * as p from '@subsquid/evm-codec'
 
 export const events = {
   Approval: event(
@@ -13,16 +13,11 @@ export const events = {
     'Transfer(address,address,uint256)',
     { from: indexed(p.address), to: indexed(p.address), value: p.uint256 },
   ),
-};
+}
 
 export const functions = {
   name: viewFun('0x06fdde03', 'name()', {}, p.string),
-  approve: fun(
-    '0x095ea7b3',
-    'approve(address,uint256)',
-    { _spender: p.address, _value: p.uint256 },
-    p.bool,
-  ),
+  approve: fun('0x095ea7b3', 'approve(address,uint256)', { _spender: p.address, _value: p.uint256 }, p.bool),
   totalSupply: viewFun('0x18160ddd', 'totalSupply()', {}, p.uint256),
   transferFrom: fun(
     '0x23b872dd',
@@ -33,74 +28,151 @@ export const functions = {
   decimals: viewFun('0x313ce567', 'decimals()', {}, p.uint8),
   balanceOf: viewFun('0x70a08231', 'balanceOf(address)', { _owner: p.address }, p.uint256),
   symbol: viewFun('0x95d89b41', 'symbol()', {}, p.string),
-  transfer: fun(
-    '0xa9059cbb',
-    'transfer(address,uint256)',
-    { _to: p.address, _value: p.uint256 },
-    p.bool,
-  ),
-  allowance: viewFun(
-    '0xdd62ed3e',
-    'allowance(address,address)',
-    { _owner: p.address, _spender: p.address },
-    p.uint256,
-  ),
-};
+  transfer: fun('0xa9059cbb', 'transfer(address,uint256)', { _to: p.address, _value: p.uint256 }, p.bool),
+  allowance: viewFun('0xdd62ed3e', 'allowance(address,address)', { _owner: p.address, _spender: p.address }, p.uint256),
+}
+
+/**
+ * Standard ERC20 ABI in JSON form, for libraries that consume a plain ABI array
+ * (e.g. `viem`). The {@link events}/{@link functions} descriptors above are the
+ * `@subsquid/evm-abi` codecs used for decoding; this is the same interface in
+ * the interchange shape used for encoding and external tooling.
+ */
+export const abi = [
+  {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      { name: 'owner', type: 'address', indexed: true },
+      { name: 'spender', type: 'address', indexed: true },
+      { name: 'value', type: 'uint256', indexed: false },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'Transfer',
+    inputs: [
+      { name: 'from', type: 'address', indexed: true },
+      { name: 'to', type: 'address', indexed: true },
+      { name: 'value', type: 'uint256', indexed: false },
+    ],
+    anonymous: false,
+  },
+  { type: 'function', name: 'name', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'string' }] },
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_spender', type: 'address' },
+      { name: '_value', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    type: 'function',
+    name: 'totalSupply',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'transferFrom',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_from', type: 'address' },
+      { name: '_to', type: 'address' },
+      { name: '_value', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  { type: 'function', name: 'decimals', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'uint8' }] },
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: '_owner', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  { type: 'function', name: 'symbol', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'string' }] },
+  {
+    type: 'function',
+    name: 'transfer',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_to', type: 'address' },
+      { name: '_value', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    type: 'function',
+    name: 'allowance',
+    stateMutability: 'view',
+    inputs: [
+      { name: '_owner', type: 'address' },
+      { name: '_spender', type: 'address' },
+    ],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const
 
 export class Contract extends ContractBase {
   name() {
-    return this.eth_call(functions.name, {});
+    return this.eth_call(functions.name, {})
   }
 
   totalSupply() {
-    return this.eth_call(functions.totalSupply, {});
+    return this.eth_call(functions.totalSupply, {})
   }
 
   decimals() {
-    return this.eth_call(functions.decimals, {});
+    return this.eth_call(functions.decimals, {})
   }
 
   balanceOf(_owner: BalanceOfParams['_owner']) {
-    return this.eth_call(functions.balanceOf, { _owner });
+    return this.eth_call(functions.balanceOf, { _owner })
   }
 
   symbol() {
-    return this.eth_call(functions.symbol, {});
+    return this.eth_call(functions.symbol, {})
   }
 
   allowance(_owner: AllowanceParams['_owner'], _spender: AllowanceParams['_spender']) {
-    return this.eth_call(functions.allowance, { _owner, _spender });
+    return this.eth_call(functions.allowance, { _owner, _spender })
   }
 }
 
 /// Event types
-export type ApprovalEventArgs = EParams<typeof events.Approval>;
-export type TransferEventArgs = EParams<typeof events.Transfer>;
+export type ApprovalEventArgs = EParams<typeof events.Approval>
+export type TransferEventArgs = EParams<typeof events.Transfer>
 
 /// Function types
-export type NameParams = FunctionArguments<typeof functions.name>;
-export type NameReturn = FunctionReturn<typeof functions.name>;
+export type NameParams = FunctionArguments<typeof functions.name>
+export type NameReturn = FunctionReturn<typeof functions.name>
 
-export type ApproveParams = FunctionArguments<typeof functions.approve>;
-export type ApproveReturn = FunctionReturn<typeof functions.approve>;
+export type ApproveParams = FunctionArguments<typeof functions.approve>
+export type ApproveReturn = FunctionReturn<typeof functions.approve>
 
-export type TotalSupplyParams = FunctionArguments<typeof functions.totalSupply>;
-export type TotalSupplyReturn = FunctionReturn<typeof functions.totalSupply>;
+export type TotalSupplyParams = FunctionArguments<typeof functions.totalSupply>
+export type TotalSupplyReturn = FunctionReturn<typeof functions.totalSupply>
 
-export type TransferFromParams = FunctionArguments<typeof functions.transferFrom>;
-export type TransferFromReturn = FunctionReturn<typeof functions.transferFrom>;
+export type TransferFromParams = FunctionArguments<typeof functions.transferFrom>
+export type TransferFromReturn = FunctionReturn<typeof functions.transferFrom>
 
-export type DecimalsParams = FunctionArguments<typeof functions.decimals>;
-export type DecimalsReturn = FunctionReturn<typeof functions.decimals>;
+export type DecimalsParams = FunctionArguments<typeof functions.decimals>
+export type DecimalsReturn = FunctionReturn<typeof functions.decimals>
 
-export type BalanceOfParams = FunctionArguments<typeof functions.balanceOf>;
-export type BalanceOfReturn = FunctionReturn<typeof functions.balanceOf>;
+export type BalanceOfParams = FunctionArguments<typeof functions.balanceOf>
+export type BalanceOfReturn = FunctionReturn<typeof functions.balanceOf>
 
-export type SymbolParams = FunctionArguments<typeof functions.symbol>;
-export type SymbolReturn = FunctionReturn<typeof functions.symbol>;
+export type SymbolParams = FunctionArguments<typeof functions.symbol>
+export type SymbolReturn = FunctionReturn<typeof functions.symbol>
 
-export type TransferParams = FunctionArguments<typeof functions.transfer>;
-export type TransferReturn = FunctionReturn<typeof functions.transfer>;
+export type TransferParams = FunctionArguments<typeof functions.transfer>
+export type TransferReturn = FunctionReturn<typeof functions.transfer>
 
-export type AllowanceParams = FunctionArguments<typeof functions.allowance>;
-export type AllowanceReturn = FunctionReturn<typeof functions.allowance>;
+export type AllowanceParams = FunctionArguments<typeof functions.allowance>
+export type AllowanceReturn = FunctionReturn<typeof functions.allowance>

--- a/packages/subsquid-pipes/src/evm/evm-decoder.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-decoder.test.ts
@@ -1178,18 +1178,6 @@ describe('evmDecoder multi-output isolation', () => {
   const CONTRACT_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
   const CONTRACT_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as const
 
-  const ERC20_ABI = [
-    {
-      type: 'event' as const,
-      name: 'Transfer',
-      inputs: [
-        { name: 'from', type: 'address', indexed: true },
-        { name: 'to', type: 'address', indexed: true },
-        { name: 'value', type: 'uint256', indexed: false },
-      ],
-    },
-  ] as const
-
   let portal: MockPortal
 
   beforeEach(async () => {
@@ -1204,7 +1192,7 @@ describe('evmDecoder multi-output isolation', () => {
               {
                 logs: [
                   encodeEvent({
-                    abi: ERC20_ABI,
+                    abi: commonAbis.erc20.abi,
                     eventName: 'Transfer',
                     address: CONTRACT_A,
                     args: {
@@ -1218,7 +1206,7 @@ describe('evmDecoder multi-output isolation', () => {
               {
                 logs: [
                   encodeEvent({
-                    abi: ERC20_ABI,
+                    abi: commonAbis.erc20.abi,
                     eventName: 'Transfer',
                     address: CONTRACT_B,
                     args: {

--- a/packages/subsquid-pipes/src/targets/memory/memory-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/memory/memory-target.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { commonAbis } from '~/evm/abi/common.js'
+import { evmDecoder } from '~/evm/evm-decoder.js'
+import { evmPortalStream } from '~/evm/evm-portal-source.js'
+import { encodeEvent, mockBlock, resetMockBlockCounter } from '~/testing/evm/index.js'
+import { MockPortal, createMockPortal } from '~/testing/index.js'
+
+import { createMemoryTarget } from './memory-target.js'
+
+const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as const
+const ALICE = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d' as const
+const BOB = '0xc82e11e709deb68f3631fc165ebd8b4e3fc3d18f' as const
+
+// One ERC20 Transfer per block, with `value` set to the block number so each
+// emitted row is identifiable by where it came from.
+function transferLog(value: bigint) {
+  return encodeEvent({
+    abi: commonAbis.erc20.abi,
+    eventName: 'Transfer',
+    address: WETH,
+    args: { from: ALICE, to: BOB, value },
+  })
+}
+
+function blockWithTransfer(number: number) {
+  return mockBlock({ number, transactions: [{ logs: [transferLog(BigInt(number))] }] })
+}
+
+type Row = { blockNumber: number; value: bigint }
+
+function streamTo(portal: MockPortal, to: number, emitted: Row[][]) {
+  return evmPortalStream({
+    id: 'memory-target-test',
+    portal: portal.url,
+    outputs: evmDecoder({
+      range: { from: 1, to },
+      events: {
+        transfers: commonAbis.erc20.events.Transfer,
+      },
+    }).pipe((d) => d.transfers.map((t) => ({ blockNumber: t.block.number, value: t.event.value }))),
+  }).pipeTo(
+    createMemoryTarget({
+      onData: (data) => {
+        emitted.push(data)
+      },
+    }),
+  )
+}
+
+describe('createMemoryTarget', () => {
+  let mockPortal: MockPortal
+
+  beforeEach(() => {
+    resetMockBlockCounter()
+  })
+
+  afterEach(async () => {
+    await mockPortal?.close()
+  })
+
+  it('emits only finalized rows and releases buffered rows once a later head finalizes them', async () => {
+    const [b1, b2, b3, b4, b5] = [1, 2, 3, 4, 5].map(blockWithTransfer)
+
+    mockPortal = await createMockPortal([
+      // finalized head = 1: block 1 is emitted, blocks 2 & 3 are held back
+      {
+        statusCode: 200,
+        data: [b1, b2, b3],
+        head: { finalized: { number: b1.header.number, hash: b1.header.hash } },
+      },
+      // finalized head = 4: the buffered 2 & 3 plus the new 4 are released; 5 stays held
+      {
+        statusCode: 200,
+        data: [b4, b5],
+        head: { finalized: { number: b4.header.number, hash: b4.header.hash } },
+      },
+    ])
+
+    const emitted: Row[][] = []
+    await streamTo(mockPortal, 5, emitted)
+
+    // Block 5 is never finalized, so it must not be emitted.
+    const blockNumbers = emitted.flat().map((r) => r.blockNumber)
+    expect(blockNumbers).toEqual([1, 2, 3, 4])
+
+    // Buffered rows (2, 3) are released before the current batch's row (4).
+    expect(emitted.flat().map((r) => r.value)).toEqual([1n, 2n, 3n, 4n])
+  })
+
+  it('passes every row straight through when the dataset has no finalized head', async () => {
+    const [b1, b2] = [1, 2].map(blockWithTransfer)
+
+    mockPortal = await createMockPortal([
+      {
+        statusCode: 200,
+        data: [b1, b2],
+        // no head → no finality → nothing is buffered
+      },
+    ])
+
+    const emitted: Row[][] = []
+    await streamTo(mockPortal, 2, emitted)
+
+    expect(emitted.flat().map((r) => r.blockNumber)).toEqual([1, 2])
+  })
+})

--- a/packages/subsquid-pipes/src/targets/memory/memory-target.ts
+++ b/packages/subsquid-pipes/src/targets/memory/memory-target.ts
@@ -1,73 +1,28 @@
-import { BlockCursor, createTarget, resolveForkCursor } from '~/core/index.js'
-
-function arraySplit<T>(array: T[], predicate: (item: T) => boolean): [T[], T[]] {
-  const pass: T[] = []
-  const fail: T[] = []
-
-  if (!array.length) {
-    return [pass, fail]
-  }
-
-  for (const item of array) {
-    if (predicate(item)) {
-      pass.push(item)
-    } else {
-      fail.push(item)
-    }
-  }
-
-  return [pass, fail]
-}
+import { createFinalizationBuffer, createTarget } from '~/core/index.js'
 
 export function createMemoryTarget<T extends { blockNumber: number }[]>({
   onData,
 }: {
   onData: (data: T) => Promise<void> | void
 }) {
-  let recentUnfinalizedBlocks: BlockCursor[] = []
-  let unfinalizedData: T[number][] = []
-  let finalizedHead: BlockCursor | undefined
+  const buffer = createFinalizationBuffer<T[number]>({
+    getBlockNumber: (row) => row.blockNumber,
+  })
 
   return createTarget<T>({
     write: async ({ read }) => {
       for await (const batch of read()) {
-        recentUnfinalizedBlocks.push(...batch.ctx.stream.state.rollbackChain)
-        finalizedHead = batch.ctx.stream.head.finalized
-
-        const finalizedNumber = finalizedHead?.number || Infinity
-
-        const [finalized, newUnfinalized] = arraySplit(batch.data, (item) => item.blockNumber <= finalizedNumber)
+        const finalized = buffer.push(batch.data, {
+          finalized: batch.ctx.stream.head.finalized,
+          rollbackChain: batch.ctx.stream.state.rollbackChain,
+        })
 
         if (finalized.length) {
           await onData(finalized as T)
         }
-
-        const [newFinalizedData, stillUnfinalizedData] = arraySplit(
-          unfinalizedData,
-          (item) => item.blockNumber <= finalizedNumber,
-        )
-        if (newFinalizedData.length) {
-          await onData(newFinalizedData as T)
-        }
-
-        unfinalizedData = [...stillUnfinalizedData, ...newUnfinalized]
       }
     },
 
-    fork: async (previousBlocks) => {
-      const safeCursor = await resolveForkCursor(
-        [{ rollbackChain: recentUnfinalizedBlocks, finalized: finalizedHead }],
-        previousBlocks,
-      )
-
-      if (safeCursor) {
-        recentUnfinalizedBlocks = recentUnfinalizedBlocks.filter((b) => b.number <= safeCursor.number)
-        unfinalizedData = unfinalizedData.filter((item) => item.blockNumber <= safeCursor.number)
-      } else {
-        recentUnfinalizedBlocks = []
-      }
-
-      return safeCursor
-    },
+    fork: (previousBlocks) => buffer.fork(previousBlocks),
   })
 }

--- a/packages/subsquid-pipes/src/testing/evm/evm-portal-mock-stream.test.ts
+++ b/packages/subsquid-pipes/src/testing/evm/evm-portal-mock-stream.test.ts
@@ -8,27 +8,6 @@ import { MockPortal, readAll } from '../index.js'
 import { evmPortalMockStream } from './evm-portal-mock-stream.js'
 import { encodeEvent, mockBlock, resetMockBlockCounter } from './mock-block.js'
 
-const ERC20_ABI = [
-  {
-    type: 'event' as const,
-    name: 'Transfer',
-    inputs: [
-      { name: 'from', type: 'address', indexed: true },
-      { name: 'to', type: 'address', indexed: true },
-      { name: 'value', type: 'uint256', indexed: false },
-    ],
-  },
-  {
-    type: 'event' as const,
-    name: 'Approval',
-    inputs: [
-      { name: 'owner', type: 'address', indexed: true },
-      { name: 'spender', type: 'address', indexed: true },
-      { name: 'value', type: 'uint256', indexed: false },
-    ],
-  },
-] as const
-
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as const
 const ALICE = '0x7a250d5630b4cf539739df2c5dacb4c659f2488d' as const
 const BOB = '0xc82e11e709deb68f3631fc165ebd8b4e3fc3d18f' as const
@@ -47,7 +26,7 @@ describe('test-evm-data helpers', () => {
   describe('encodeEvent', () => {
     it('should encode an ERC20 Transfer event', () => {
       const log = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: ALICE, to: BOB, value: 100n },
@@ -67,7 +46,7 @@ describe('test-evm-data helpers', () => {
 
     it('should infer args types from ABI', () => {
       // Type-level test: args should include from, to, AND value
-      type Args = Parameters<typeof encodeEvent<typeof ERC20_ABI, 'Transfer'>>[0]['args']
+      type Args = Parameters<typeof encodeEvent<typeof commonAbis.erc20.abi, 'Transfer'>>[0]['args']
       expectTypeOf<Args>().toEqualTypeOf<{ from: `0x${string}`; to: `0x${string}`; value: bigint } | undefined>()
     })
   })
@@ -108,14 +87,14 @@ describe('test-evm-data helpers', () => {
 
     it('should create transactions and logs from events', () => {
       const event1 = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: ALICE, to: BOB, value: 100n },
       })
 
       const event2 = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Approval',
         address: WETH_ADDRESS,
         args: { owner: ALICE, spender: BOB, value: 200n },
@@ -148,7 +127,7 @@ describe('test-evm-data helpers', () => {
   describe('evmPortalMockStream', () => {
     it('should work end-to-end with evmDecoder', async () => {
       const transfer = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: ALICE, to: BOB, value: 100n },
@@ -184,14 +163,14 @@ describe('test-evm-data helpers', () => {
 
     it('should work with multiple events per block', async () => {
       const transfer1 = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: ALICE, to: BOB, value: 100n },
       })
 
       const transfer2 = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: BOB, to: ALICE, value: 50n },
@@ -225,14 +204,14 @@ describe('test-evm-data helpers', () => {
 
     it('should work with mixed event types', async () => {
       const transfer = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Transfer',
         address: WETH_ADDRESS,
         args: { from: ALICE, to: BOB, value: 100n },
       })
 
       const approval = encodeEvent({
-        abi: ERC20_ABI,
+        abi: commonAbis.erc20.abi,
         eventName: 'Approval',
         address: WETH_ADDRESS,
         args: { owner: ALICE, spender: BOB, value: 200n },


### PR DESCRIPTION
## What & why

Deliverable 1 of the Parquet-target plan: a **reusable finalization buffer** in core. Targets that write to immutable storage (Parquet files, append-only logs, …) must never persist a block that could later reorg. That "hold rows until their block finalizes" logic was inlined in the memory target; this extracts it as a public, reusable helper and refactors the memory target onto it.

## Changes

**`createFinalizationBuffer<Row>({ getBlockNumber })`** (`src/core/finalization-buffer.ts`, exported from `~/core`)

```ts
push(rows: Row[], { finalized?, rollbackChain? }): Row[]   // released (finalized) rows, in arrival/block order
fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null>  // safe cursor + drop reorged rows
readonly size: number
```

- `push` folds in each batch's finalization state, returns the rows now at/below the finalized head in arrival/block order, and keeps the rest buffered. Cross-batch: rows held earlier are released once a later, higher finalized head passes them. Uses `?? Infinity` (not `|| Infinity`) so a finalized head of block `0` is honored; `finalized === undefined` (no-finality dataset) passes everything straight through.
- The buffer **owns the pipe's full unfinalized state** — the rows *and* the rollback chain — and **resolves reorgs itself** via `fork()`. The target no longer tracks a cursor chain or re-derives the safe cursor; it just `push`es each batch and forwards `fork()`.

**Memory target refactor** (`src/targets/memory/memory-target.ts`)
- Collapses from ~45 lines to one `push()` per batch + `fork: buffer.fork`. The duplicated split is gone, and the rollback chain (which previously only pruned on fork) no longer grows unbounded over long runs.

**Supporting:** added `commonAbis.erc20.abi` (standard ERC20 ABI in plain JSON form for viem-based tooling) and removed three hand-copied inline `ERC20_ABI` arrays in tests now that a canonical one exists.

## Tests (internal framework only)

- `finalization-buffer.test.ts`: push/size/ordering, inclusive threshold, optional rollback chain, no-finality passthrough, cross-batch release, finalized-block-0, and `fork` (resolve + drop, dead-end → null, can't roll back past finalized).
- `memory-target.test.ts`: drives finalized data through the refactored target end-to-end — finalized-only emission + cross-batch release, and no-finality passthrough.
- `factory.test.ts` (existing memory-target fork consumer) and the erc20 decoder/mock-stream suites stay green.

## Coverage diff (base vs head)

| File | Base | Head |
| --- | --- | --- |
| `src/core/finalization-buffer.ts` | — (new file) | **100%** stmts / **100%** branch / **100%** funcs |
| `src/targets/memory/memory-target.ts` | 74.13% stmts / 54.54% branch | **100%** stmts / **100%** branch / **100%** funcs |

The memory target reaches 100% because its fork-resolution (including the dead-end branch the old inline code never covered) now lives in the buffer, exercised directly by the buffer's unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
