### PR TITLE
feat(pipes): add Parquet writer target

### DIFF
--- a/docs/examples/evm/17.parquet.example.ts
+++ b/docs/examples/evm/17.parquet.example.ts
@@ -1,0 +1,140 @@
+/**
+ * Parquet target — write a stream to rotating, finalized-only Parquet files.
+ *
+ * Indexes ERC20 Transfer + Approval events from Ethereum mainnet into local Parquet files
+ * under `<OUT>/transfers/` and `<OUT>/approvals/`. Each file is named by its block range
+ * (`<min>-<max>.parquet`) and is immutable once published — the standard columnar format read
+ * directly by DuckDB, Spark, Athena and ClickHouse `s3()` (no import step).
+ *
+ * Why this target:
+ *   - **Finalized-only.** A row is written only once its block is at/below the portal's
+ *     finalized head, so a reorg never touches a file on disk. This example uses a fixed,
+ *     already-finalized range, so every row is written immediately; on a live `from: 'latest'`
+ *     range the unfinalized tail is held in memory until it finalizes.
+ *   - **Constant memory.** Rows stream to a temp file that rotates by byte size
+ *     (`rollover.maxBytes`), so a multi-GB backfill never lands wholly in RAM. `rowGroupSize`
+ *     bounds the writer's in-memory buffer.
+ *   - **Crash-safe.** A durable cursor (`<OUT>/_sqd_parquet_state.json`) advances only at a
+ *     checkpoint; on restart, any file above the cursor is dropped and re-fetched.
+ *
+ * Note: `onData` must be a pure function of the batch for finalized blocks (no wall-clock / RNG
+ * affecting a row's identity) — recovery re-processes finalized blocks and relies on
+ * regenerating byte-identical rows. Parquet has no server-side dedupe.
+ *
+ * Prerequisites:
+ *   - `@dsnp/parquetjs` is an optional peer dependency — install it: `npm i @dsnp/parquetjs`.
+ *
+ * To run:
+ * ```bash
+ * PARQUET_OUT=./parquet-out tsx docs/examples/evm/17.parquet.example.ts
+ * ```
+ *
+ * Inspect with DuckDB (query the files directly):
+ * ```bash
+ * duckdb -c "SELECT count(*), min(blockNumber), max(blockNumber) FROM './parquet-out/transfers/*.parquet'"
+ * duckdb -c "SELECT token, count(*) c FROM './parquet-out/transfers/*.parquet' GROUP BY 1 ORDER BY c DESC LIMIT 10"
+ * ```
+ */
+
+import { commonAbis, evmDecoder, evmPortalStream } from '@subsquid/pipes/evm'
+import { parquetTarget } from '@subsquid/pipes/targets/parquet'
+
+const OUT = process.env['PARQUET_OUT'] ?? './parquet-out'
+
+async function main() {
+  await evmPortalStream({
+    id: 'erc20-parquet',
+    portal: 'https://portal.sqd.dev/datasets/ethereum-mainnet',
+    outputs: evmDecoder({
+      // A small, already-finalized historical range so files appear immediately and the run
+      // terminates. Swap to `{ from: 'latest' }` to watch the finalized-only buffer hold the
+      // unfinalized tail back until it finalizes.
+      range: { from: 21_000_000, to: 21_000_100 },
+      events: {
+        transfers: commonAbis.erc20.events.Transfer,
+        approvals: commonAbis.erc20.events.Approval,
+      },
+    }),
+  }).pipeTo(
+    // The decoded data type is inferred from the evmDecoder events config above.
+    parquetTarget({
+      dir: OUT,
+      // The block-number column defaults to `blockNumber` and must be present + integer-typed.
+      // Writing to a table not declared here throws synchronously from `store.insert`.
+      tables: [
+        {
+          table: 'transfers',
+          schema: {
+            blockNumber: { type: 'INT64' },
+            logIndex: { type: 'INT32' },
+            txIndex: { type: 'INT32' },
+            timestamp: { type: 'TIMESTAMP_MILLIS', optional: true },
+            token: { type: 'UTF8' },
+            from: { type: 'UTF8' },
+            to: { type: 'UTF8' },
+            // A uint256 amount fits no Parquet numeric — keep the exact decimal as text.
+            amount: { type: 'UTF8' },
+          },
+        },
+        {
+          table: 'approvals',
+          schema: {
+            blockNumber: { type: 'INT64' },
+            logIndex: { type: 'INT32' },
+            txIndex: { type: 'INT32' },
+            timestamp: { type: 'TIMESTAMP_MILLIS', optional: true },
+            token: { type: 'UTF8' },
+            owner: { type: 'UTF8' },
+            spender: { type: 'UTF8' },
+            amount: { type: 'UTF8' },
+          },
+        },
+      ],
+      settings: {
+        // Small cap so the example rotates into several files instead of one big one. Production
+        // defaults to 128 MiB. `maxBytes` is a soft cap, checked at each batch boundary.
+        rollover: { maxBytes: 8 * 1024 * 1024 },
+        // SNAPPY (the default) is a good speed/ratio tradeoff; GZIP / BROTLI compress harder.
+        compression: 'SNAPPY',
+      },
+      onData: ({ store, data, ctx }) => {
+        ctx.logger.debug(`batch: ${data.transfers.length} transfers, ${data.approvals.length} approvals`)
+
+        // Rows are staged per table; the finalized ones flush to the open Parquet writer after
+        // `onData` returns. The JS → Parquet input contract: INT64 ← number/bigint,
+        // TIMESTAMP_MILLIS ← Date (or null for an optional column), UTF8 ← string.
+        store.insert(
+          'transfers',
+          data.transfers.map((t) => ({
+            blockNumber: t.block.number,
+            logIndex: t.rawEvent.logIndex,
+            txIndex: t.rawEvent.transactionIndex,
+            timestamp: t.timestamp ?? null,
+            token: t.rawEvent.address,
+            from: t.event.from,
+            to: t.event.to,
+            amount: t.event.value.toString(),
+          })),
+        )
+
+        store.insert(
+          'approvals',
+          data.approvals.map((a) => ({
+            blockNumber: a.block.number,
+            logIndex: a.rawEvent.logIndex,
+            txIndex: a.rawEvent.transactionIndex,
+            timestamp: a.timestamp ?? null,
+            token: a.rawEvent.address,
+            owner: a.event.owner,
+            spender: a.event.spender,
+            amount: a.event.value.toString(),
+          })),
+        )
+      },
+    }),
+  )
+
+  console.log(`Done. Parquet files written under ${OUT}/ — query them with DuckDB (see the header).`)
+}
+
+void main()

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -21,15 +21,16 @@
     "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
+    "@dsnp/parquetjs": "1.8.7",
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
     "@subsquid/borsh": "0.3.0",
-    "protobufjs": "7.5.0",
     "@types/better-sqlite3": "7.6.13",
     "@types/express": "4.17.23",
     "@types/node": "22.14.1",
     "@types/pg": "8.15.6",
     "@vitest/coverage-v8": "3.2.4",
+    "protobufjs": "7.5.0",
     "typescript": "5.9.2",
     "viem": "^2.45.1",
     "vitest": "3.2.4"
@@ -48,16 +49,20 @@
     "prom-client": "15.1.3"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0",
+    "@dsnp/parquetjs": "1.8.7",
     "@clickhouse/client": "1.14.0",
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
+    "@opentelemetry/api": "^1.9.0",
     "better-sqlite3": "12.4.5",
     "drizzle-orm": "0.44.7",
     "pg": "8.16.3",
     "protobufjs": "^7.2.4"
   },
   "peerDependenciesMeta": {
+    "@dsnp/parquetjs": {
+      "optional": true
+    },
     "@opentelemetry/api": {
       "optional": true
     },
@@ -131,6 +136,11 @@
       "import": "./dist/targets/bigquery/index.js",
       "require": "./dist/targets/bigquery/index.cjs"
     },
+    "./targets/parquet": {
+      "types": "./dist/targets/parquet/index.d.ts",
+      "import": "./dist/targets/parquet/index.js",
+      "require": "./dist/targets/parquet/index.cjs"
+    },
     "./targets/clickhouse": {
       "types": "./dist/targets/clickhouse/index.d.ts",
       "import": "./dist/targets/clickhouse/index.js",
@@ -198,6 +208,9 @@
       ],
       "targets/bigquery": [
         "./dist/targets/bigquery/index.d.ts"
+      ],
+      "targets/parquet": [
+        "./dist/targets/parquet/index.d.ts"
       ],
       "targets/clickhouse": [
         "./dist/targets/clickhouse/index.d.ts"

--- a/packages/subsquid-pipes/src/targets/parquet/errors.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/errors.ts
@@ -1,0 +1,40 @@
+import { PipeError, SdkError } from '~/core/errors.js'
+
+/**
+ * Common error wrapper for everything thrown by the Parquet target.
+ *
+ * All target-originated errors extend this class and carry an `E12xx` code so
+ * downstream code can pattern-match on `instanceof ParquetTargetError` and react
+ * (alerting, retries, etc.) without scraping `.message`. The numeric code prefix
+ * follows the project's existing convention (E0xxx = source, E1xxx = targets);
+ * BigQuery occupies E11xx, so the Parquet target uses E12xx.
+ */
+export class ParquetTargetError extends PipeError {
+  constructor(code: string, message: string | string[]) {
+    super(code, SdkError.TargetConfiguration, message)
+  }
+}
+
+// E12xx — Parquet target codes
+export const PQ_ERR = {
+  /** `tables[]` is empty — the target has nothing to write. */
+  NO_TABLES: 'E1201',
+  /** Two declared tables share the same name. */
+  DUPLICATE_TABLE: 'E1202',
+  /** A table schema is empty (no columns declared). */
+  EMPTY_SCHEMA: 'E1203',
+  /** Table schema is missing the declared block-number column. */
+  BLOCK_COLUMN_MISSING: 'E1204',
+  /** Block-number column is not an integer type (must be INT64/INT32/TIMESTAMP_MILLIS). */
+  BLOCK_COLUMN_TYPE: 'E1205',
+  /** A column declared an unsupported compression codec. */
+  UNSUPPORTED_COMPRESSION: 'E1206',
+  /** A column declared an unsupported Parquet type. */
+  UNSUPPORTED_TYPE: 'E1207',
+  /** User wrote to a table that wasn't registered in `tables[]`. */
+  UNREGISTERED_TABLE: 'E1208',
+  /** `publish()` refused to overwrite an existing data file (would lose data). */
+  FILE_COLLISION: 'E1209',
+  /** Persisted state file exists but could not be parsed. */
+  STATE_CORRUPT: 'E1210',
+} as const

--- a/packages/subsquid-pipes/src/targets/parquet/fs-durable.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/fs-durable.ts
@@ -1,0 +1,39 @@
+import { open as fsOpen, stat } from 'node:fs/promises'
+
+/** Whether a path exists (any type). */
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** fsync a file by path: open `r+`, sync, close. */
+export async function fsyncFile(p: string): Promise<void> {
+  const fh = await fsOpen(p, 'r+')
+  try {
+    await fh.sync()
+  } finally {
+    await fh.close()
+  }
+}
+
+/**
+ * fsync a directory so a contained `rename`/create survives a crash. Node has no path-based dir
+ * fsync, so open the directory and fsync the returned fd. Best-effort: some platforms (notably
+ * Windows) reject fsync on a directory handle — the atomic rename already gives crash-consistent
+ * visibility on POSIX, so a failure here is non-fatal.
+ */
+export async function fsyncDir(dir: string): Promise<void> {
+  let fh: Awaited<ReturnType<typeof fsOpen>> | undefined
+  try {
+    fh = await fsOpen(dir, 'r')
+    await fh.sync()
+  } catch {
+    // best-effort
+  } finally {
+    await fh?.close()
+  }
+}

--- a/packages/subsquid-pipes/src/targets/parquet/index.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/index.ts
@@ -1,0 +1,10 @@
+export { PQ_ERR, ParquetTargetError } from './errors.js'
+export { type AppendStat, ParquetStore, type RotationLimits } from './parquet-store.js'
+export { type ParquetRollover, type ParquetSettings, parquetTarget } from './parquet-target.js'
+export {
+  type Codec,
+  type ParquetColumn,
+  type ParquetColumnType,
+  type ParquetColumns,
+  type ParquetTable,
+} from './schema.js'

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-state.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-state.ts
@@ -1,0 +1,165 @@
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { type BlockCursor, type Logger, formatBlock } from '~/core/index.js'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { fsyncDir, fsyncFile } from './fs-durable.js'
+import { TMP_PREFIX } from './writer.js'
+
+/** Base name of the durable state file living at the root of the output dir. */
+const STATE_BASENAME = '_sqd_parquet_state'
+
+/** Published data files are named `<min>-<max>.parquet`; nothing else in a table dir is ours. */
+const DATA_FILE_RE = /^(\d+)-(\d+)\.parquet$/
+
+type PersistedState = {
+  /** Optional pipe namespace, mirrored from `settings.id`. */
+  id?: string
+  /** Last durably-checkpointed cursor — `read(cursor)` resumes from `cursor.number + 1`. */
+  cursor: BlockCursor
+}
+
+export type ParquetStateOptions = {
+  /** Output base directory — the isolation unit (one pipe per dir). */
+  dir: string
+  /** Declared table names; their sub-directories are created on startup. */
+  tables: string[]
+  /** Optional namespace so multiple pipes can share a dir (separate state files). */
+  id?: string
+  logger: Logger
+}
+
+/**
+ * Durable cursor + crash recovery for the Parquet target.
+ *
+ * The output directory is the isolation unit — one pipe per dir — which removes any dependency
+ * on `ctx.id` being available before the first batch. The cursor is persisted to a single JSON
+ * file written atomically (temp + fsync + rename + dir fsync).
+ *
+ * Recovery on startup reconciles the on-disk files with the committed cursor: any published file
+ * holding blocks above the cursor is a remnant of a checkpoint that published files but crashed
+ * before persisting the new cursor, and any `.tmp-*` file is an aborted in-progress segment —
+ * both are deleted so `read(cursor)` regenerates that (deterministic, finalized) data cleanly.
+ */
+export class ParquetState {
+  readonly #baseDir: string
+  readonly #tables: string[]
+  readonly #id: string | undefined
+  readonly #statePath: string
+  readonly #logger: Logger
+
+  constructor(options: ParquetStateOptions) {
+    this.#baseDir = options.dir
+    this.#tables = options.tables
+    this.#id = options.id
+    this.#logger = options.logger
+    this.#statePath = path.join(
+      options.dir,
+      options.id ? `${STATE_BASENAME}.${options.id}.json` : `${STATE_BASENAME}.json`,
+    )
+  }
+
+  /**
+   * Prepares the output directory and returns the cursor to resume from (or `undefined` to start
+   * from the stream beginning).
+   *
+   * Always: `mkdir -p` the base dir + every table dir, and delete every `.tmp-*` file. When a
+   * committed cursor exists, additionally delete every published data file whose `maxBlock`
+   * exceeds it (incomplete-checkpoint remnants).
+   */
+  async getCursor(): Promise<BlockCursor | undefined> {
+    await mkdir(this.#baseDir, { recursive: true })
+    for (const table of this.#tables) {
+      await mkdir(path.join(this.#baseDir, table), { recursive: true })
+    }
+
+    await this.#deleteTempFiles()
+
+    const state = await this.#readState()
+    if (!state) {
+      return undefined
+    }
+
+    await this.#deleteFilesAboveCursor(state.cursor.number)
+
+    return state.cursor
+  }
+
+  /**
+   * Atomically persists the checkpoint cursor: write a temp file, fsync it, rename over the
+   * state file, then fsync the directory so the rename is durable. Called only after every open
+   * writer for the checkpoint has been published.
+   */
+  async saveCursor(cursor: BlockCursor): Promise<void> {
+    const payload: PersistedState = this.#id ? { id: this.#id, cursor } : { cursor }
+    const tmpPath = path.join(this.#baseDir, `${TMP_PREFIX}state-${path.basename(this.#statePath)}`)
+
+    await writeFile(tmpPath, JSON.stringify(payload))
+    await fsyncFile(tmpPath)
+    await rename(tmpPath, this.#statePath)
+    await fsyncDir(this.#baseDir)
+  }
+
+  async #readState(): Promise<PersistedState | undefined> {
+    let raw: string
+    try {
+      raw = await readFile(this.#statePath, 'utf8')
+    } catch {
+      return undefined
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as PersistedState
+      if (!parsed?.cursor || typeof parsed.cursor.number !== 'number') {
+        throw new Error('missing cursor.number')
+      }
+
+      return parsed
+    } catch (error) {
+      throw new ParquetTargetError(
+        PQ_ERR.STATE_CORRUPT,
+        `Parquet state file '${this.#statePath}' exists but could not be parsed: ` +
+          `${error instanceof Error ? error.message : String(error)}. Inspect or remove it to recover.`,
+      )
+    }
+  }
+
+  /** Deletes every `.tmp-*` file in the base dir and each table dir. */
+  async #deleteTempFiles(): Promise<void> {
+    for (const dir of [this.#baseDir, ...this.#tables.map((t) => path.join(this.#baseDir, t))]) {
+      const entries = await readdir(dir).catch(() => [] as string[])
+      for (const name of entries) {
+        if (name.startsWith(TMP_PREFIX)) {
+          await unlink(path.join(dir, name)).catch(() => {})
+        }
+      }
+    }
+  }
+
+  /** Deletes every published `<min>-<max>.parquet` whose `max` exceeds the committed cursor. */
+  async #deleteFilesAboveCursor(cursorNumber: number): Promise<void> {
+    let removed = 0
+    for (const table of this.#tables) {
+      const dir = path.join(this.#baseDir, table)
+      const entries = await readdir(dir).catch(() => [] as string[])
+      for (const name of entries) {
+        const match = DATA_FILE_RE.exec(name)
+        if (!match) continue
+
+        const maxBlock = Number.parseInt(match[2], 10)
+        if (maxBlock > cursorNumber) {
+          await unlink(path.join(dir, name)).catch(() => {})
+          removed++
+        }
+      }
+    }
+
+    if (removed > 0) {
+      this.#logger.warn(
+        `Crash recovery: removed ${removed} Parquet file(s) above the committed cursor ` +
+          `(block ${formatBlock(cursorNumber)}) before resuming.`,
+      )
+    }
+  }
+}

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
@@ -1,0 +1,188 @@
+import path from 'node:path'
+
+import { ParquetSchema } from '@dsnp/parquetjs'
+
+import { type BlockCursor, type Finalization, type FinalizationBuffer, createFinalizationBuffer } from '~/core/index.js'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { type Codec, type ParquetTable, blockColumnOf, toParquetSchemaShape } from './schema.js'
+import { ParquetSegmentWriter, type PublishedSegment } from './writer.js'
+
+type Row = Record<string, unknown>
+
+/** Per-table immutable config resolved once at construction. */
+type TableConfig = {
+  blockColumn: string
+  schema: ParquetSchema
+  dir: string
+}
+
+/** Rotation thresholds checked at each batch boundary. */
+export type RotationLimits = {
+  maxBytes: number
+  maxRows?: number
+}
+
+/** Per-table count of rows appended in a `flushBatch` call (for metrics). */
+export type AppendStat = { table: string; rows: number }
+
+/**
+ * Staging + per-table finalization buffers + open segment writers for the Parquet target.
+ *
+ * `insert(table, rows)` stages a batch's rows (rejecting unknown tables synchronously, like
+ * `bigquery-store`). `flushBatch` folds each table's staged rows through its
+ * {@link FinalizationBuffer} and appends the released (finalized) rows to that table's open
+ * segment writer — opening a writer lazily only when there is at least one finalized row, so
+ * empty/low-volume tables never create degenerate files.
+ *
+ * Every declared table's buffer is advanced on every batch (even with no staged rows) so that
+ * (a) low-volume tables still release previously-buffered rows once a later finalized head passes
+ * them, and (b) every buffer carries the same rollback chain for fork resolution.
+ */
+export class ParquetStore {
+  readonly #configs = new Map<string, TableConfig>()
+  readonly #buffers = new Map<string, FinalizationBuffer<Row>>()
+  readonly #staged = new Map<string, Row[]>()
+  // The current open segment per table — at most one. Reset (published/discarded) at checkpoints.
+  readonly #writers = new Map<string, ParquetSegmentWriter>()
+  readonly #rowGroupSize: number
+
+  constructor(options: { dir: string; tables: ParquetTable[]; rowGroupSize: number; defaultCodec: Codec }) {
+    this.#rowGroupSize = options.rowGroupSize
+
+    for (const table of options.tables) {
+      const blockColumn = blockColumnOf(table)
+      this.#configs.set(table.table, {
+        blockColumn,
+        schema: new ParquetSchema(toParquetSchemaShape(table, options.defaultCodec)),
+        dir: path.join(options.dir, table.table),
+      })
+      this.#buffers.set(
+        table.table,
+        createFinalizationBuffer<Row>({ getBlockNumber: (row) => Number(row[blockColumn]) }),
+      )
+    }
+  }
+
+  /**
+   * Stages rows for `table` until the next `flushBatch`. Throws synchronously if `table` was not
+   * declared in `tables[]` — an unknown table can never be finalized, rotated or recovered, so
+   * surfacing it immediately (before any I/O) is safer than silently dropping the rows.
+   */
+  insert(table: string, rows: Row[]): void {
+    if (!this.#configs.has(table)) {
+      throw new ParquetTargetError(
+        PQ_ERR.UNREGISTERED_TABLE,
+        `Table '${table}' is not declared. Declared tables: ${[...this.#configs.keys()].sort().join(', ')}. ` +
+          `Add it to parquetTarget({ tables: [...] }).`,
+      )
+    }
+    if (rows.length === 0) return
+
+    const existing = this.#staged.get(table)
+    if (existing) {
+      existing.push(...rows)
+    } else {
+      this.#staged.set(table, [...rows])
+    }
+  }
+
+  /**
+   * Advances every table's finalization buffer with this batch's staged rows + finalization
+   * state, appends the now-finalized rows to each table's (lazily-opened) segment writer, and
+   * clears staging. Returns per-table appended-row counts for metrics.
+   */
+  async flushBatch(finalization: Finalization): Promise<AppendStat[]> {
+    const stats: AppendStat[] = []
+
+    for (const [table, config] of this.#configs) {
+      const buffer = this.#buffers.get(table)!
+      const staged = this.#staged.get(table) ?? []
+      const released = buffer.push(staged, finalization)
+
+      if (released.length > 0) {
+        const writer = this.#getOrCreateWriter(table, config)
+        for (const row of released) {
+          await writer.appendRow(row, Number(row[config.blockColumn]))
+        }
+        stats.push({ table, rows: released.length })
+      }
+    }
+
+    this.#staged.clear()
+
+    return stats
+  }
+
+  /** True if any open writer has reached the byte or row rotation threshold. */
+  async shouldRotate(limits: RotationLimits): Promise<boolean> {
+    for (const writer of this.#writers.values()) {
+      if (limits.maxRows !== undefined && writer.rowCount >= limits.maxRows) return true
+      if ((await writer.size()) >= limits.maxBytes) return true
+    }
+
+    return false
+  }
+
+  /** Whether any segment writer is currently open (has buffered ≥1 finalized row on disk). */
+  get hasOpenWriters(): boolean {
+    return this.#writers.size > 0
+  }
+
+  /**
+   * Publishes every currently-open segment writer (each holds ≥1 finalized row by lazy-open) and
+   * resets them, returning each published file's stats. Call immediately before persisting the
+   * checkpoint cursor.
+   */
+  async publishAll(): Promise<(PublishedSegment & { table: string })[]> {
+    const published: (PublishedSegment & { table: string })[] = []
+
+    for (const [table, writer] of this.#writers) {
+      published.push({ table, ...(await writer.publish()) })
+    }
+    this.#writers.clear()
+
+    return published
+  }
+
+  /**
+   * Resolves the safe cursor for a reorg and drops every buffered (unfinalized) row above it.
+   * Open writers and published files are never touched — they hold only finalized rows, which
+   * can never reorg.
+   *
+   * Every buffer carries the same rollback chain (advanced on every batch), so each resolves the
+   * same safe cursor; we drop rows in all of them and return the agreed result.
+   */
+  async fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null> {
+    let safe: BlockCursor | null = null
+
+    for (const buffer of this.#buffers.values()) {
+      safe = await buffer.fork(previousBlocks)
+    }
+
+    return safe
+  }
+
+  /**
+   * Best-effort teardown for the error path: discards (closes + deletes) every open segment's
+   * temp file. The discarded rows are finalized-but-not-checkpointed, so they regenerate from the
+   * portal on the next run since the cursor never advanced past them.
+   */
+  async close(): Promise<void> {
+    for (const writer of this.#writers.values()) {
+      await writer.discard()
+    }
+    this.#writers.clear()
+    this.#staged.clear()
+  }
+
+  #getOrCreateWriter(table: string, config: TableConfig): ParquetSegmentWriter {
+    let writer = this.#writers.get(table)
+    if (!writer) {
+      writer = new ParquetSegmentWriter({ dir: config.dir, schema: config.schema, rowGroupSize: this.#rowGroupSize })
+      this.#writers.set(table, writer)
+    }
+
+    return writer
+  }
+}

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
@@ -1,0 +1,610 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { ParquetReader, ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { evmPortalStream } from '~/evm/index.js'
+import {
+  type MockPortal,
+  type MockResponse,
+  blockDecoder,
+  createMockPortal,
+  createTestLogger,
+} from '~/testing/index.js'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { ParquetState } from './parquet-state.js'
+import type { ParquetStore } from './parquet-store.js'
+import { parquetTarget } from './parquet-target.js'
+import { type ParquetTable, validateTables } from './schema.js'
+import { ParquetSegmentWriter } from './writer.js'
+
+// ---------------------------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------------------------
+
+type BlockRow = { blockNumber: number; hash: string; timestamp: number }
+type LogRow = { blockNumber: number; logIndex: number; address: string }
+
+const BLOCKS_TABLE: ParquetTable = {
+  table: 'blocks',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+/** Decoded EVM headers expose `number`/`hash`/`timestamp`; map them onto the `blocks` schema. */
+const insertBlocks = ({
+  store,
+  data,
+}: {
+  store: ParquetStore
+  data: { number: number; hash: string; timestamp: number }[]
+}) => {
+  store.insert(
+    'blocks',
+    data.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+  )
+}
+
+/** Builds a 200 response carrying the given block numbers, optionally with a finalized head. */
+function blocksResponse(numbers: number[], finalized?: number): MockResponse {
+  return {
+    statusCode: 200,
+    data: numbers.map((n) => ({ header: { number: n, hash: `0x${n}`, timestamp: n * 1000 } })),
+    head: finalized === undefined ? undefined : { finalized: { number: finalized, hash: `0x${finalized}` } },
+  }
+}
+
+/** Published data file names (excludes temp + state files), sorted lexically. */
+async function listDataFiles(dir: string, table: string): Promise<string[]> {
+  const entries = await readdir(path.join(dir, table)).catch(() => [] as string[])
+
+  return entries.filter((f) => /^\d+-\d+\.parquet$/.test(f)).sort()
+}
+
+/** All entries in a table dir (to assert temp-file cleanup). */
+async function listAll(dir: string, table: string): Promise<string[]> {
+  return (await readdir(path.join(dir, table)).catch(() => [] as string[])).sort()
+}
+
+async function readRows<T>(dir: string, table: string, decode: (raw: Record<string, unknown>) => T): Promise<T[]> {
+  const files = await listDataFiles(dir, table)
+  const rows: T[] = []
+  for (const file of files) {
+    const reader = await ParquetReader.openFile(path.join(dir, table, file))
+    const cursor = reader.getCursor()
+    let raw: Record<string, unknown> | null
+    while ((raw = (await cursor.next()) as Record<string, unknown> | null)) {
+      rows.push(decode(raw))
+    }
+    await reader.close()
+  }
+
+  return rows
+}
+
+/** Reads the `blocks` table, normalized + sorted by block number. */
+async function readBlocks(dir: string): Promise<BlockRow[]> {
+  const rows = await readRows(dir, 'blocks', (raw) => ({
+    blockNumber: Number(raw['blockNumber']),
+    hash: String(raw['hash']),
+    timestamp: Number(raw['timestamp']),
+  }))
+
+  return rows.sort((a, b) => a.blockNumber - b.blockNumber)
+}
+
+/** Reads the `logs` table, normalized + sorted. */
+async function readLogs(dir: string): Promise<LogRow[]> {
+  const rows = await readRows(dir, 'logs', (raw) => ({
+    blockNumber: Number(raw['blockNumber']),
+    logIndex: Number(raw['logIndex']),
+    address: String(raw['address']),
+  }))
+
+  return rows.sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex)
+}
+
+/** Writes a Parquet file directly (used to seed stale/over-cursor files for recovery tests). */
+async function seedParquetFile(filePath: string, rows: BlockRow[]): Promise<void> {
+  const schema = new ParquetSchema({
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  })
+  const writer = await ParquetWriter.openFile(schema, filePath, { rowGroupSize: 1 })
+  for (const row of rows) await writer.appendRow(row)
+  await writer.close()
+}
+
+// ---------------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------------
+
+describe('parquetTarget', () => {
+  let mockPortal: MockPortal | undefined
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'sqd-parquet-test-'))
+  })
+
+  afterEach(async () => {
+    await mockPortal?.close()
+    mockPortal = undefined
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  describe('schema validation', () => {
+    it('rejects an empty tables list', () => {
+      expect.assertions(1)
+      try {
+        validateTables([])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.NO_TABLES)
+      }
+    })
+
+    it('rejects a schema missing the block-number column', () => {
+      expect.assertions(1)
+      try {
+        validateTables([{ table: 't', schema: { hash: { type: 'UTF8' } } }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_MISSING)
+      }
+    })
+
+    it('rejects a non-integer block-number column', () => {
+      expect.assertions(1)
+      try {
+        validateTables([{ table: 't', schema: { blockNumber: { type: 'UTF8' } } }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+      }
+    })
+
+    it('rejects duplicate table names', () => {
+      expect.assertions(1)
+      try {
+        validateTables([BLOCKS_TABLE, BLOCKS_TABLE])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.DUPLICATE_TABLE)
+      }
+    })
+
+    it('rejects an empty schema', () => {
+      expect.assertions(1)
+      try {
+        validateTables([{ table: 't', schema: {} }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.EMPTY_SCHEMA)
+      }
+    })
+
+    it('rejects an unsupported column type', () => {
+      expect.assertions(1)
+      try {
+        validateTables([
+          { table: 't', schema: { blockNumber: { type: 'INT64' }, amount: { type: 'DECIMAL' as never } } },
+        ])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_TYPE)
+      }
+    })
+
+    it('rejects an unsupported compression codec', () => {
+      expect.assertions(1)
+      try {
+        validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64', compression: 'ZSTD' as never } } }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_COMPRESSION)
+      }
+    })
+  })
+
+  describe('finalized-only', () => {
+    it('does not write blocks above the finalized head', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3, 4, 5], 2)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 5 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      // Only blocks 1–2 are finalized (head = 2); 3–5 stay buffered and are never written.
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2])
+    })
+
+    it('publishes previously-unfinalized blocks once a later batch finalizes them', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3, 4, 5], 2), blocksResponse([6, 7], 7)])
+
+      // maxBytes:1 keeps the two responses as distinct batches so the second batch's higher
+      // finalized head genuinely releases what the first batch left buffered.
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: mockPortal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 7 }),
+      }).pipeTo(parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }))
+
+      // The later finalized head (7) releases the 3–5 held from the first batch.
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3, 4, 5, 6, 7])
+    })
+  })
+
+  describe('read-back correctness', () => {
+    it('writes exactly the finalized rows with correct types and <min>-<max> filename', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3], 3)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000001-000000000003.parquet'])
+      expect(await readBlocks(dir)).toEqual([
+        { blockNumber: 1, hash: '0x1', timestamp: 1000 },
+        { blockNumber: 2, hash: '0x2', timestamp: 2000 },
+        { blockNumber: 3, hash: '0x3', timestamp: 3000 },
+      ])
+    })
+
+    it('reads INT64 columns back as bigint (input contract)', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1], 1)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 1 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      const reader = await ParquetReader.openFile(path.join(dir, 'blocks', '000000000001-000000000001.parquet'))
+      const raw = (await reader.getCursor().next()) as Record<string, unknown>
+      await reader.close()
+      expect(typeof raw['blockNumber']).toBe('bigint')
+      expect(raw['blockNumber']).toBe(1n)
+    })
+  })
+
+  describe('rotation', () => {
+    it('rotates into multiple files with disjoint, contiguous ranges under a small maxBytes', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1], 1), blocksResponse([2], 2), blocksResponse([3], 3)])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: mockPortal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE],
+          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          onData: insertBlocks,
+        }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000001-000000000001.parquet',
+        '000000000002-000000000002.parquet',
+        '000000000003-000000000003.parquet',
+      ])
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('recovery', () => {
+    it('removes over-cursor and temp files, resumes from the cursor, stays duplicate-free', async () => {
+      // Seed a committed cursor at block 2, a stale data file above it, and an orphan temp file.
+      await writeFile(path.join(dir, '_sqd_parquet_state.json'), JSON.stringify({ cursor: { number: 2, hash: '0x2' } }))
+      const blocksDir = path.join(dir, 'blocks')
+      await mkdir(blocksDir, { recursive: true })
+      await seedParquetFile(path.join(blocksDir, '000000000003-000000000005.parquet'), [
+        { blockNumber: 3, hash: 'STALE', timestamp: 0 },
+      ])
+      await writeFile(path.join(blocksDir, '.tmp-orphan.parquet'), 'garbage')
+
+      mockPortal = await createMockPortal([
+        {
+          ...blocksResponse([3, 4, 5], 5),
+          validateRequest: (req) => {
+            expect(req).toMatchObject({ fromBlock: 3, parentBlockHash: '0x2' })
+          },
+        },
+      ])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 5 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      // The stale STALE-hash row was deleted and replaced by correct, duplicate-free data.
+      expect(await readBlocks(dir)).toEqual([
+        { blockNumber: 3, hash: '0x3', timestamp: 3000 },
+        { blockNumber: 4, hash: '0x4', timestamp: 4000 },
+        { blockNumber: 5, hash: '0x5', timestamp: 5000 },
+      ])
+      // No orphan temp file survives recovery.
+      expect((await listAll(dir, 'blocks')).some((f) => f.startsWith('.tmp-'))).toBe(false)
+    })
+  })
+
+  describe('fork', () => {
+    it('drops buffered forked rows and leaves the pre-fork published file intact', async () => {
+      mockPortal = await createMockPortal([
+        blocksResponse([1, 2, 3, 4, 5], 1),
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 2, hash: '0x2' },
+              { number: 3, hash: '0x3' },
+              { number: 4, hash: '0x4-1' },
+              { number: 5, hash: '0x5-1' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+          ],
+          head: { finalized: { number: 7, hash: '0x7a' } },
+          validateRequest: (req) => {
+            expect(req).toMatchObject({ fromBlock: 4, parentBlockHash: '0x3' })
+          },
+        },
+      ])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 7 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE],
+          // Checkpoint every batch so block 1 is published before the fork fires.
+          settings: { rollover: { intervalBlocks: 1 } },
+          onData: insertBlocks,
+        }),
+      )
+
+      // Forked blocks (0x4-1 / 0x5-1) were dropped from the buffer; the new chain replaces them.
+      expect(await readBlocks(dir)).toEqual([
+        { blockNumber: 1, hash: '0x1', timestamp: 1000 },
+        { blockNumber: 2, hash: '0x2', timestamp: 2000 },
+        { blockNumber: 3, hash: '0x3', timestamp: 3000 },
+        { blockNumber: 4, hash: '0x4a', timestamp: 4000 },
+        { blockNumber: 5, hash: '0x5a', timestamp: 5000 },
+        { blockNumber: 6, hash: '0x6a', timestamp: 6000 },
+        { blockNumber: 7, hash: '0x7a', timestamp: 7000 },
+      ])
+      // The block-1 file was published before the reorg and must survive it untouched.
+      expect(await listDataFiles(dir, 'blocks')).toContain('000000000001-000000000001.parquet')
+    })
+  })
+
+  describe('empty table', () => {
+    it('produces no file for a declared table that receives no rows', async () => {
+      const emptyTable: ParquetTable = { table: 'empty', schema: { blockNumber: { type: 'INT64' } } }
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3], 3)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE, emptyTable], onData: insertBlocks }),
+      )
+
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3])
+      // The empty table's directory exists but holds no parquet file.
+      expect(await listDataFiles(dir, 'empty')).toEqual([])
+    })
+  })
+
+  describe('no-finality passthrough', () => {
+    it('writes every row immediately when there is no finalized head', async () => {
+      // No `head` → no finalized head → threshold Infinity → nothing is buffered.
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3])])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('multi-table', () => {
+    it('writes independent files per table from the same batch', async () => {
+      const logsTable: ParquetTable = {
+        table: 'logs',
+        schema: {
+          blockNumber: { type: 'INT64' },
+          logIndex: { type: 'INT32' },
+          address: { type: 'UTF8' },
+        },
+      }
+      mockPortal = await createMockPortal([blocksResponse([1, 2, 3], 3)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE, logsTable],
+          onData: ({ store, data }) => {
+            store.insert(
+              'blocks',
+              data.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+            )
+            // Two log rows per block, giving the logs table a different shape + cardinality.
+            store.insert(
+              'logs',
+              data.flatMap((b) => [
+                { blockNumber: b.number, logIndex: 0, address: `0xa${b.number}` },
+                { blockNumber: b.number, logIndex: 1, address: `0xb${b.number}` },
+              ]),
+            )
+          },
+        }),
+      )
+
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3])
+      expect(await readLogs(dir)).toEqual([
+        { blockNumber: 1, logIndex: 0, address: '0xa1' },
+        { blockNumber: 1, logIndex: 1, address: '0xb1' },
+        { blockNumber: 2, logIndex: 0, address: '0xa2' },
+        { blockNumber: 2, logIndex: 1, address: '0xb2' },
+        { blockNumber: 3, logIndex: 0, address: '0xa3' },
+        { blockNumber: 3, logIndex: 1, address: '0xb3' },
+      ])
+      // Each table published its own single file covering blocks 1–3.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000001-000000000003.parquet'])
+      expect(await listDataFiles(dir, 'logs')).toEqual(['000000000001-000000000003.parquet'])
+    })
+  })
+
+  describe('store.insert guard', () => {
+    it('throws synchronously when inserting into an undeclared table', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1], 1)])
+
+      await expect(
+        evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 1 }) }).pipeTo(
+          parquetTarget({
+            dir,
+            tables: [BLOCKS_TABLE],
+            onData: ({ store }) => {
+              store.insert('not_declared', [{ blockNumber: 1 }])
+            },
+          }),
+        ),
+      ).rejects.toThrowError(/not declared/)
+    })
+
+    it('accumulates multiple inserts into the same table within a batch', async () => {
+      mockPortal = await createMockPortal([blocksResponse([1, 2], 2)])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 2 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE],
+          onData: ({ store, data }) => {
+            // Two separate inserts for the same table must both be staged + flushed.
+            for (const b of data) {
+              store.insert('blocks', [{ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp }])
+            }
+          },
+        }),
+      )
+
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2])
+    })
+  })
+
+  describe('crash safety', () => {
+    it('discards open temp files and does not advance the cursor when a batch throws', async () => {
+      // Batch 1 opens a writer with a finalized row (no checkpoint — huge default maxBytes);
+      // batch 2 throws before any checkpoint, so the open temp file must be discarded and the
+      // cursor must never be persisted. maxBytes:1 forces one batch per response.
+      mockPortal = await createMockPortal([blocksResponse([1], 1), blocksResponse([2], 2)])
+
+      let batches = 0
+      await expect(
+        evmPortalStream({
+          id: 'test',
+          portal: { url: mockPortal.url, maxBytes: 1 },
+          outputs: blockDecoder({ from: 0, to: 2 }),
+        }).pipeTo(
+          parquetTarget({
+            dir,
+            tables: [BLOCKS_TABLE],
+            onData: ({ store, data }) => {
+              insertBlocks({ store, data })
+              batches++
+              if (batches === 2) throw new Error('boom')
+            },
+          }),
+        ),
+      ).rejects.toThrowError('boom')
+
+      // No file was published (the open writer was discarded, not finalized)...
+      expect(await listDataFiles(dir, 'blocks')).toEqual([])
+      // ...no temp file leaked...
+      expect((await listAll(dir, 'blocks')).filter((f) => f.startsWith('.tmp-'))).toEqual([])
+      // ...and the cursor was never persisted (no checkpoint happened).
+      expect((await listAll(dir, '')).includes('_sqd_parquet_state.json')).toBe(false)
+    })
+  })
+
+  describe('ParquetSegmentWriter', () => {
+    it('lazy-opens, tracks range/rowCount, and publishes <min>-<max>', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      expect(writer.isOpen).toBe(false)
+      expect(await writer.size()).toBe(0)
+
+      await writer.appendRow({ blockNumber: 5 }, 5)
+      await writer.appendRow({ blockNumber: 8 }, 8)
+      expect(writer.isOpen).toBe(true)
+      expect(writer.rowCount).toBe(2)
+      expect(writer.minBlock).toBe(5)
+      expect(writer.maxBlock).toBe(8)
+      expect(await writer.size()).toBeGreaterThan(0)
+
+      const published = await writer.publish()
+      expect(published.path.endsWith('000000000005-000000000008.parquet')).toBe(true)
+      expect(published.rows).toBe(2)
+      expect(published.bytes).toBeGreaterThan(0)
+    })
+
+    it('refuses to overwrite an existing file (collision)', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const first = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      await first.appendRow({ blockNumber: 1 }, 1)
+      await first.publish()
+
+      const second = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      await second.appendRow({ blockNumber: 1 }, 1)
+      await expect(second.publish()).rejects.toThrowError(/Refusing to overwrite/)
+      await second.discard()
+    })
+
+    it('discard() removes the temp file of an unpublished segment', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      await writer.appendRow({ blockNumber: 1 }, 1)
+      await writer.discard()
+
+      expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
+    })
+  })
+
+  describe('ParquetState', () => {
+    it('throws STATE_CORRUPT on an unparseable state file', async () => {
+      await writeFile(path.join(dir, '_sqd_parquet_state.json'), 'not-json')
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+
+      await expect(state.getCursor()).rejects.toThrowError(/could not be parsed/)
+    })
+
+    it('returns undefined on a cold start and creates table directories', async () => {
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: createTestLogger() })
+
+      expect(await state.getCursor()).toBeUndefined()
+      expect(await listAll(dir, 'blocks')).toEqual([])
+    })
+  })
+})
+
+describe('parquet index barrel', () => {
+  it('re-exports the public API', async () => {
+    const mod = await import('./index.js')
+    expect(typeof mod.parquetTarget).toBe('function')
+    expect(typeof mod.ParquetStore).toBe('function')
+    expect(typeof mod.ParquetTargetError).toBe('function')
+    expect(mod.PQ_ERR.NO_TABLES).toBe('E1201')
+  })
+})

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.ts
@@ -1,0 +1,243 @@
+import {
+  type BlockCursor,
+  type Counter,
+  type Ctx,
+  type Finalization,
+  type Histogram,
+  type Logger,
+  type Metrics,
+  createTarget,
+  formatBlock,
+  formatNumber,
+  humanBytes,
+} from '~/core/index.js'
+
+import { ParquetState } from './parquet-state.js'
+import { ParquetStore } from './parquet-store.js'
+import { type Codec, type ParquetTable, validateTables } from './schema.js'
+
+/** Default rollover byte size — 128 MiB is a good Parquet file size for data-lake query engines. */
+const DEFAULT_MAX_BYTES = 128 * 1024 * 1024
+/** Default rows per row group — the in-memory "split size" that bounds writer memory. */
+const DEFAULT_ROW_GROUP_SIZE = 100_000
+const DEFAULT_CODEC: Codec = 'SNAPPY'
+
+export type ParquetRollover = {
+  /** Soft byte cap per file — checked at each batch boundary, so a huge batch can overshoot. Default 128 MiB. */
+  maxBytes?: number
+  /** Optional row cap per file, checked alongside `maxBytes`. */
+  maxRows?: number
+  /** Optional wall-clock checkpoint floor (ms) — recommended for live tailing so finalized data isn't stuck in an open file. */
+  intervalMs?: number
+  /** Optional block-count checkpoint floor — checkpoint once the cursor advances this many blocks. */
+  intervalBlocks?: number
+}
+
+export type ParquetSettings = {
+  rollover?: ParquetRollover
+  /** Rows per row group — bounds writer memory. Default 100_000. */
+  rowGroupSize?: number
+  /** Default per-column compression. Default `'SNAPPY'`. */
+  compression?: Codec
+  /** Optional namespace for the state file, if multiple pipes must share one `dir`. */
+  id?: string
+}
+
+type ParquetTargetMetrics = {
+  rowsWritten: Counter<'id' | 'table'>
+  bytesWritten: Counter<'id' | 'table'>
+  filesPublished: Counter<'id' | 'table'>
+  checkpointDuration: Histogram<'id'>
+}
+
+/**
+ * Writes a stream to rotating, **finalized-only** Parquet files — the columnar format read by
+ * DuckDB, Spark, Athena and ClickHouse's `s3()`.
+ *
+ * **Finalized-only.** Parquet files are immutable once written, so a block that could still
+ * reorg is never written. Each table buffers unfinalized rows in memory (via the shared
+ * {@link createFinalizationBuffer}) and only appends a row once its block is at or below the
+ * portal's finalized head. A reorg drops the in-memory buffer; published files are never touched.
+ *
+ * **Constant memory.** Finalized rows stream straight to a temp file and the file rotates by byte
+ * size, so a multi-gigabyte finalized backfill never lands wholly in RAM (`@dsnp/parquetjs`
+ * flushes row groups to disk incrementally — verified by the Step 0 spike). `rowGroupSize` bounds
+ * the writer's in-memory buffer.
+ *
+ * **Crash safety.** A writer holding ≥1 finalized row is always published at the very next
+ * checkpoint, and the persisted cursor advances only at a checkpoint — so no finalized row is ever
+ * held past the cursor. On restart, recovery deletes any published file above the cursor (an
+ * incomplete checkpoint) and any temp file, then `read(cursor)` re-fetches the deterministic,
+ * finalized data after the cursor, which regenerates identically.
+ *
+ * **Contract (load-bearing): `onData` must be a pure function of the batch for finalized blocks.**
+ * Recovery re-processes finalized blocks after a crash and relies on regenerating byte-identical
+ * rows. Do not let wall-clock time, RNG, or external mutable state affect a row's identity. Unlike
+ * BigQuery (which dedupes server-side via committed-stream offsets), Parquet has no server-side
+ * dedupe, so this purity contract is the recovery guarantee.
+ *
+ * Known trade-offs:
+ * - One busy table's checkpoint rotates **all** open writers, so low-volume tables get smaller
+ *   files (the "small files" problem) — inherent to a single global cursor.
+ * - Byte-only rotation can stall the cursor on a slow live tail (finalized data stays invisible
+ *   until the file closes; a crash re-fetches more). Set `rollover.intervalMs`/`intervalBlocks`
+ *   for live tailing.
+ * - A **no-finality dataset has no finalized head**, so the threshold is `Infinity` and every row
+ *   is written immediately: the files are **not reorg-safe**, and if such a chain forks the pipe
+ *   goes fatal (same as the memory target).
+ *
+ * @param options.dir - Output directory. It is the isolation unit — **one pipe per dir**. Holds a
+ *   `<table>/` sub-directory per table plus a `_sqd_parquet_state.json` cursor file.
+ * @param options.tables - Declared tables with explicit schemas; the block-number column must be
+ *   present and integer-typed. Writing to an undeclared table from `onData` throws.
+ * @param options.onData - Per-batch handler; call `store.insert(table, rows)` to stage rows.
+ */
+export function parquetTarget<T>(options: {
+  dir: string
+  tables: ParquetTable[]
+  settings?: ParquetSettings
+  onStart?: (ctx: { store: ParquetStore; logger: Logger }) => Promise<unknown> | unknown
+  onData: (ctx: { store: ParquetStore; data: T; ctx: Ctx }) => Promise<unknown> | unknown
+}) {
+  const { dir, tables, settings = {}, onStart, onData } = options
+
+  validateTables(tables)
+
+  const rowGroupSize = settings.rowGroupSize ?? DEFAULT_ROW_GROUP_SIZE
+  const defaultCodec = settings.compression ?? DEFAULT_CODEC
+  const maxBytes = settings.rollover?.maxBytes ?? DEFAULT_MAX_BYTES
+  const { maxRows, intervalMs, intervalBlocks } = settings.rollover ?? {}
+
+  const store = new ParquetStore({ dir, tables, rowGroupSize, defaultCodec })
+
+  return createTarget<T>({
+    write: async ({ read, logger }) => {
+      // Lazy: registered on the first batch from `ctx.metrics`.
+      let metrics: ParquetTargetMetrics | undefined
+
+      const state = new ParquetState({ dir, tables: tables.map((t) => t.table), id: settings.id, logger })
+
+      // Tracks checkpoint progress; the closure below mutates it.
+      let lastCheckpointMs = Date.now()
+      let lastCheckpointBlock = -1
+
+      // The try/finally wraps the ENTIRE write() body, so a startup throw still discards any open
+      // temp files. fork() runs inside read()'s generator while this for-await is suspended, so no
+      // write races with it and close-in-finally is race-free.
+      try {
+        const startCursor = await state.getCursor()
+        lastCheckpointBlock = startCursor?.number ?? -1
+
+        await onStart?.({ store, logger })
+
+        // Captured for the checkpoint closure's metric labels — assigned on the first batch.
+        let metricsId = ''
+        let lastBoundary: BlockCursor | undefined = startCursor
+
+        const checkpoint = async (cursor: BlockCursor | undefined, reason: string): Promise<void> => {
+          const startedMs = Date.now()
+          const published = await store.publishAll()
+          if (cursor) await state.saveCursor(cursor)
+
+          if (metrics) {
+            for (const file of published) {
+              metrics.bytesWritten.inc({ id: metricsId, table: file.table }, file.bytes)
+              metrics.filesPublished.inc({ id: metricsId, table: file.table }, 1)
+            }
+            metrics.checkpointDuration.observe({ id: metricsId }, (Date.now() - startedMs) / 1000)
+          }
+
+          lastCheckpointMs = Date.now()
+          if (cursor) lastCheckpointBlock = cursor.number
+
+          if (published.length > 0) {
+            const rows = published.reduce((s, f) => s + f.rows, 0)
+            const bytes = published.reduce((s, f) => s + f.bytes, 0)
+            logger.info({
+              message: `checkpoint (${reason}): published ${published.length} file(s), ${formatNumber(rows)} rows / ${humanBytes(bytes)}${cursor ? `, cursor → block ${formatBlock(cursor.number)}` : ''}`,
+              files: published.map((f) => f.path),
+            })
+          } else if (cursor) {
+            logger.debug(`checkpoint (${reason}): no open files, cursor → block ${formatBlock(cursor.number)}`)
+          }
+        }
+
+        for await (const { data, ctx } of read(startCursor)) {
+          if (!metrics) {
+            metrics = registerParquetMetrics(ctx.metrics)
+            metricsId = ctx.id
+          }
+
+          // 1. user stages rows via store.insert(...)
+          await onData({ store, data, ctx: { logger, profiler: ctx.profiler } })
+
+          // 2. finalization + the cursor this batch could checkpoint to. The boundary carries the
+          //    HASH needed for resume; boundary.number = min(finalized, current), correct for
+          //    backfill / tip / no-finality / straddling batches.
+          const finalized = ctx.stream.head.finalized
+          const current = ctx.stream.state.current
+          const finalization: Finalization = { finalized, rollbackChain: ctx.stream.state.rollbackChain }
+          const boundaryCursor = finalized && finalized.number <= current.number ? finalized : current
+          lastBoundary = boundaryCursor
+
+          // 3. release finalized rows into the (lazily-opened) writers.
+          const appended = await store.flushBatch(finalization)
+          for (const stat of appended) {
+            metrics.rowsWritten.inc({ id: ctx.id, table: stat.table }, stat.rows)
+          }
+
+          // 4. checkpoint on any rollover trigger.
+          const reasons: string[] = []
+          if (await store.shouldRotate({ maxBytes, maxRows })) reasons.push('size')
+          if (intervalMs !== undefined && Date.now() - lastCheckpointMs >= intervalMs) reasons.push('interval-ms')
+          if (intervalBlocks !== undefined && boundaryCursor.number - lastCheckpointBlock >= intervalBlocks) {
+            reasons.push('interval-blocks')
+          }
+
+          if (reasons.length > 0) await checkpoint(boundaryCursor, reasons.join('+'))
+        }
+
+        // 5. stream end — flush any open writers and persist the final cursor.
+        if (lastBoundary !== undefined && (store.hasOpenWriters || lastBoundary.number > lastCheckpointBlock)) {
+          await checkpoint(lastBoundary, 'stream-end')
+        }
+      } finally {
+        await store.close()
+      }
+    },
+
+    // Reorg: drop buffered (unfinalized) rows above the safe cursor across every table buffer.
+    // Published files and open writers hold only finalized rows, so they are never rolled back.
+    fork: (previousBlocks) => store.fork(previousBlocks),
+  })
+}
+
+function registerParquetMetrics(metrics: Metrics): ParquetTargetMetrics {
+  // Sub-second checkpoints on a healthy pipeline up to tens of seconds when a large file is being
+  // closed + fsynced; the long tail beyond 30s lands in +Inf.
+  const checkpointBuckets = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30]
+
+  return {
+    rowsWritten: metrics.counter({
+      name: 'sqd_parquet_rows_written_total',
+      help: 'Finalized rows appended to Parquet writers, by table.',
+      labelNames: ['id', 'table'] as const,
+    }),
+    bytesWritten: metrics.counter({
+      name: 'sqd_parquet_bytes_written_total',
+      help: 'Bytes of published Parquet files, by table (on-disk size including footer).',
+      labelNames: ['id', 'table'] as const,
+    }),
+    filesPublished: metrics.counter({
+      name: 'sqd_parquet_files_published_total',
+      help: 'Parquet files published (closed + atomically renamed), by table.',
+      labelNames: ['id', 'table'] as const,
+    }),
+    checkpointDuration: metrics.histogram({
+      name: 'sqd_parquet_checkpoint_duration_seconds',
+      help: 'Wallclock duration (seconds) of one checkpoint (publish open files + persist cursor).',
+      labelNames: ['id'] as const,
+      buckets: checkpointBuckets,
+    }),
+  }
+}

--- a/packages/subsquid-pipes/src/targets/parquet/schema.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/schema.ts
@@ -1,0 +1,173 @@
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+
+/**
+ * Compression codecs supported by `@dsnp/parquetjs` (verified by the Step 0 spike against
+ * the pinned version — the library also recognises the *names* `LZO`/`LZ4`/`ZSTD` but throws
+ * `Unsupported compression method` at write time, so they are intentionally excluded here).
+ */
+export type Codec = 'UNCOMPRESSED' | 'SNAPPY' | 'GZIP' | 'BROTLI'
+
+/**
+ * Parquet primitive/logical types exposed by this target. This is our own union — the public
+ * API carries **no compile-time dependency** on `@dsnp/parquetjs` types; the strings are
+ * translated to the library's `ParquetSchema` internally by the writer.
+ *
+ * JS → Parquet input contract (what `onData` must put in each row), per the Step 0 spike:
+ * - `INT64`            ← `number` **or** `bigint` (reads back as `bigint`)
+ * - `INT32`            ← `number`
+ * - `DOUBLE`           ← `number`
+ * - `BOOLEAN`          ← `boolean`
+ * - `UTF8`             ← `string` (store hashes/addresses here for human-readable columns)
+ * - `BYTE_ARRAY`       ← `Buffer` / `Uint8Array` (a hex string must be `Buffer.from(hex, 'hex')`)
+ * - `TIMESTAMP_MILLIS` ← `Date` **or** `number` (epoch millis; reads back as `Date`)
+ * - any column with `optional: true` may also be `null` / `undefined`
+ *
+ * `DECIMAL` is intentionally unsupported — use `UTF8` or a scaled `INT64` instead.
+ */
+export type ParquetColumnType = 'INT64' | 'INT32' | 'UTF8' | 'BYTE_ARRAY' | 'BOOLEAN' | 'DOUBLE' | 'TIMESTAMP_MILLIS'
+
+/** Declaration for a single Parquet column. */
+export type ParquetColumn = {
+  type: ParquetColumnType
+  /** Allow `null`/`undefined` for this column. Defaults to `false` (required). */
+  optional?: boolean
+  /** Per-column compression codec. Defaults to the target's `settings.compression` (`'SNAPPY'`). */
+  compression?: Codec
+}
+
+/** Map of column name → column declaration. */
+export type ParquetColumns = Record<string, ParquetColumn>
+
+/** A named Parquet table with an explicit, declared schema. */
+export type ParquetTable = {
+  /** Table name — becomes a sub-directory `<dir>/<table>/` holding its `.parquet` files. */
+  table: string
+  /** Declared columns. Must be non-empty and include {@link ParquetTable.blockNumberColumn}. */
+  schema: ParquetColumns
+  /**
+   * Column carrying the block number, used for finalization, file-range naming and recovery.
+   * Must be present in `schema` with an integer type (`INT64`/`INT32`/`TIMESTAMP_MILLIS`).
+   * Defaults to `'blockNumber'`.
+   */
+  blockNumberColumn?: string
+}
+
+/** The library-shaped schema object (our type) handed to `new ParquetSchema(...)` by the writer. */
+export type ParquetSchemaShape = Record<string, { type: ParquetColumnType; optional: boolean; compression: Codec }>
+
+export const DEFAULT_BLOCK_COLUMN = 'blockNumber'
+export const DEFAULT_CODEC: Codec = 'SNAPPY'
+
+const SUPPORTED_CODECS = new Set<string>(['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'BROTLI'])
+const SUPPORTED_TYPES = new Set<string>([
+  'INT64',
+  'INT32',
+  'UTF8',
+  'BYTE_ARRAY',
+  'BOOLEAN',
+  'DOUBLE',
+  'TIMESTAMP_MILLIS',
+])
+// Block numbers must be integers so file-range naming and `maxBlock > cursor` recovery
+// comparisons are well-defined. TIMESTAMP_MILLIS is int64-backed and accepted for parity
+// with the declared contract, though `INT64` is the natural choice.
+const INTEGER_BLOCK_TYPES = new Set<ParquetColumnType>(['INT64', 'INT32', 'TIMESTAMP_MILLIS'])
+
+/** The block-number column name for a table, applying the default. */
+export function blockColumnOf(table: ParquetTable): string {
+  return table.blockNumberColumn ?? DEFAULT_BLOCK_COLUMN
+}
+
+/**
+ * Validates the full `tables[]` config at target construction — empty list, duplicate names,
+ * then each table. Throwing here surfaces config mistakes at startup, not deep in the first
+ * batch (mirrors BigQuery's `ensureTrackedTable` up-front validation).
+ */
+export function validateTables(tables: ParquetTable[]): void {
+  if (tables.length === 0) {
+    throw new ParquetTargetError(PQ_ERR.NO_TABLES, 'parquetTarget: `tables` must declare at least one table.')
+  }
+
+  const seen = new Set<string>()
+  for (const table of tables) {
+    if (seen.has(table.table)) {
+      throw new ParquetTargetError(
+        PQ_ERR.DUPLICATE_TABLE,
+        `parquetTarget: duplicate table '${table.table}'. Each table name must be unique.`,
+      )
+    }
+    seen.add(table.table)
+
+    validateTable(table)
+  }
+}
+
+/**
+ * Validates one table: non-empty schema, every column's type + compression are supported, the
+ * block-number column is present and integer-typed.
+ *
+ * Unlike BigQuery — which *forces* the partition column to `INT64 NOT NULL` via DDL
+ * (`normalizePartitionColumn`) — Parquet has no DDL/type-forcing layer, so we must validate the
+ * block column's type ourselves rather than silently coerce it.
+ */
+export function validateTable(table: ParquetTable): void {
+  const columns = Object.entries(table.schema)
+  if (columns.length === 0) {
+    throw new ParquetTargetError(
+      PQ_ERR.EMPTY_SCHEMA,
+      `parquetTarget: table '${table.table}' has an empty schema. Declare at least one column.`,
+    )
+  }
+
+  for (const [name, column] of columns) {
+    if (!SUPPORTED_TYPES.has(column.type)) {
+      throw new ParquetTargetError(
+        PQ_ERR.UNSUPPORTED_TYPE,
+        `parquetTarget: table '${table.table}' column '${name}' has unsupported type '${column.type}'. ` +
+          `Supported types: ${[...SUPPORTED_TYPES].join(', ')}.`,
+      )
+    }
+    if (column.compression && !SUPPORTED_CODECS.has(column.compression)) {
+      throw new ParquetTargetError(
+        PQ_ERR.UNSUPPORTED_COMPRESSION,
+        `parquetTarget: table '${table.table}' column '${name}' declares unsupported compression ` +
+          `'${column.compression}'. Supported codecs: ${[...SUPPORTED_CODECS].join(', ')}.`,
+      )
+    }
+  }
+
+  const blockColumn = blockColumnOf(table)
+  const declared = table.schema[blockColumn]
+  if (!declared) {
+    throw new ParquetTargetError(
+      PQ_ERR.BLOCK_COLUMN_MISSING,
+      `parquetTarget: table '${table.table}' schema does not include the block-number column ` +
+        `'${blockColumn}'. Add it to the schema as an integer column (INT64), or set ` +
+        `blockNumberColumn to the column that carries the block number.`,
+    )
+  }
+  if (!INTEGER_BLOCK_TYPES.has(declared.type)) {
+    throw new ParquetTargetError(
+      PQ_ERR.BLOCK_COLUMN_TYPE,
+      `parquetTarget: table '${table.table}' block-number column '${blockColumn}' has type ` +
+        `'${declared.type}', but must be an integer type (${[...INTEGER_BLOCK_TYPES].join(', ')}).`,
+    )
+  }
+}
+
+/**
+ * Translates a validated {@link ParquetTable} schema into the library-shaped object handed to
+ * `new ParquetSchema(...)`, filling in the per-column compression default.
+ */
+export function toParquetSchemaShape(table: ParquetTable, defaultCodec: Codec): ParquetSchemaShape {
+  const shape: ParquetSchemaShape = {}
+  for (const [name, column] of Object.entries(table.schema)) {
+    shape[name] = {
+      type: column.type,
+      optional: column.optional ?? false,
+      compression: column.compression ?? defaultCodec,
+    }
+  }
+
+  return shape
+}

--- a/packages/subsquid-pipes/src/targets/parquet/writer.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/writer.ts
@@ -1,0 +1,182 @@
+import { rename, stat, unlink } from 'node:fs/promises'
+import path from 'node:path'
+
+import { ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { fsyncDir, fsyncFile, pathExists } from './fs-durable.js'
+
+/** Zero-pad block numbers in published filenames so they sort lexically (`0000000042`). */
+export const BLOCK_PAD = 12
+
+/** Prefix every in-progress temp file carries; recovery deletes anything matching `.tmp-*`. */
+export const TMP_PREFIX = '.tmp-'
+
+// Process-unique counter for temp file names. Recovery wipes all `.tmp-*` on startup, so a
+// reset-to-0 across restarts can never collide with a leftover temp file.
+let segmentSeq = 0
+
+/** Summary of a segment that was just published to its final path. */
+export type PublishedSegment = {
+  path: string
+  rows: number
+  bytes: number
+  minBlock: number
+  maxBlock: number
+}
+
+export type ParquetSegmentWriterOptions = {
+  /** The table's directory: `<baseDir>/<table>`. Created by the state layer before writes. */
+  dir: string
+  /** Pre-built library schema for this table. */
+  schema: ParquetSchema
+  /** Rows per row group — the "split size" that bounds the writer's in-memory buffer. */
+  rowGroupSize: number
+}
+
+/**
+ * Wraps a single open `ParquetWriter` writing **one** output file (a "segment") for one table.
+ *
+ * The underlying file is **lazy-opened on the first `appendRow`**, so a table that receives no
+ * rows in a checkpoint window never creates a degenerate empty `.parquet` file. The writer
+ * tracks the block range and row count it has seen, exposes the growing temp file size for
+ * byte-based rotation, and publishes atomically:
+ *
+ *   `close()` (footer) → fsync file → atomic `rename` temp → `<dir>/<min>-<max>.parquet` → fsync dir
+ *
+ * A published file is immutable and contains only finalized rows, so it is never rewritten.
+ */
+export class ParquetSegmentWriter {
+  readonly #dir: string
+  readonly #schema: ParquetSchema
+  readonly #rowGroupSize: number
+  readonly #tmpPath: string
+
+  #writer: ParquetWriter | undefined
+  #rowCount = 0
+  #minBlock: number | undefined
+  #maxBlock: number | undefined
+  #closed = false
+
+  constructor(options: ParquetSegmentWriterOptions) {
+    this.#dir = options.dir
+    this.#schema = options.schema
+    this.#rowGroupSize = options.rowGroupSize
+    this.#tmpPath = path.join(options.dir, `${TMP_PREFIX}${(segmentSeq++).toString().padStart(6, '0')}.parquet`)
+  }
+
+  /** Whether the underlying file has been opened (i.e. at least one row was appended). */
+  get isOpen(): boolean {
+    return this.#writer !== undefined
+  }
+
+  get rowCount(): number {
+    return this.#rowCount
+  }
+
+  get minBlock(): number | undefined {
+    return this.#minBlock
+  }
+
+  get maxBlock(): number | undefined {
+    return this.#maxBlock
+  }
+
+  /**
+   * Appends one row, lazy-opening the temp file on first use. `blockNumber` is tracked
+   * separately (not re-read from the row) so range naming stays correct regardless of the
+   * declared block column's encoding.
+   */
+  async appendRow(row: Record<string, unknown>, blockNumber: number): Promise<void> {
+    if (!this.#writer) {
+      this.#writer = await ParquetWriter.openFile(this.#schema, this.#tmpPath, { rowGroupSize: this.#rowGroupSize })
+    }
+
+    await this.#writer.appendRow(row)
+
+    this.#rowCount++
+    if (this.#minBlock === undefined || blockNumber < this.#minBlock) this.#minBlock = blockNumber
+    if (this.#maxBlock === undefined || blockNumber > this.#maxBlock) this.#maxBlock = blockNumber
+  }
+
+  /**
+   * Current on-disk size of the temp file in bytes (0 before the file is opened). Reads
+   * `fs.stat` because `@dsnp/parquetjs` flushes row groups to disk incrementally, so the file
+   * size grows during appends and is a faithful rotation signal (verified by the Step 0 spike).
+   */
+  async size(): Promise<number> {
+    if (!this.#writer) return 0
+    try {
+      return (await stat(this.#tmpPath)).size
+    } catch {
+      return 0
+    }
+  }
+
+  /**
+   * Finalizes the segment: writes the Parquet footer, fsyncs the file, atomically renames the
+   * temp file to `<dir>/<min>-<max>.parquet`, then fsyncs the directory so the rename is durable.
+   * Returns the published file's path, row count, byte size and block range.
+   *
+   * Refuses to overwrite an existing target file — a collision means two segments claimed the
+   * same block range, which would silently drop data.
+   */
+  async publish(): Promise<PublishedSegment> {
+    if (!this.#writer || this.#minBlock === undefined || this.#maxBlock === undefined) {
+      throw new ParquetTargetError(
+        PQ_ERR.FILE_COLLISION,
+        `Internal: publish() called on an empty segment in '${this.#dir}'. Only segments with ` +
+          `at least one row may be published.`,
+      )
+    }
+
+    await this.#writer.close()
+    this.#closed = true
+
+    // fsync the temp file so the footer is durable before the rename makes it visible.
+    await fsyncFile(this.#tmpPath)
+
+    const finalPath = path.join(this.#dir, `${pad(this.#minBlock)}-${pad(this.#maxBlock)}.parquet`)
+    if (await pathExists(finalPath)) {
+      throw new ParquetTargetError(
+        PQ_ERR.FILE_COLLISION,
+        `Refusing to overwrite existing Parquet file '${finalPath}'. A file for block range ` +
+          `${this.#minBlock}-${this.#maxBlock} already exists — this indicates overlapping segments ` +
+          `or a dirty output directory.`,
+      )
+    }
+
+    await rename(this.#tmpPath, finalPath)
+    await fsyncDir(this.#dir)
+
+    const bytes = await stat(finalPath)
+      .then((s) => s.size)
+      .catch(() => 0)
+
+    return { path: finalPath, rows: this.#rowCount, bytes, minBlock: this.#minBlock, maxBlock: this.#maxBlock }
+  }
+
+  /**
+   * Best-effort cleanup of an unpublished segment: closes the writer (if open) and deletes the
+   * temp file. Used on the error path — the temp file holds finalized-but-not-checkpointed rows
+   * that will be regenerated from the portal on the next run, since the cursor never advanced.
+   */
+  async discard(): Promise<void> {
+    if (this.#writer && !this.#closed) {
+      try {
+        await this.#writer.close()
+      } catch {
+        // best-effort
+      }
+    }
+    try {
+      await unlink(this.#tmpPath)
+    } catch {
+      // best-effort — the temp file may not exist yet (never opened) or already be gone
+    }
+  }
+}
+
+function pad(block: number): string {
+  return Math.trunc(block).toString().padStart(BLOCK_PAD, '0')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
         specifier: 15.1.3
         version: 15.1.3
     devDependencies:
+      '@dsnp/parquetjs':
+        specifier: 1.8.7
+        version: 1.8.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@google-cloud/bigquery':
         specifier: 8.3.0
         version: 8.3.0
@@ -347,7 +350,7 @@ importers:
         version: 5.9.2
       viem:
         specifier: ^2.45.1
-        version: 2.46.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 2.46.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.8.2)
@@ -448,6 +451,109 @@ packages:
   '@apollo/utils.withrequired@3.0.0':
     resolution: {integrity: sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==}
     engines: {node: '>=16'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.8':
+    resolution: {integrity: sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1075.0':
+    resolution: {integrity: sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    resolution: {integrity: sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    resolution: {integrity: sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -564,6 +670,10 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@dsnp/parquetjs@1.8.7':
+    resolution: {integrity: sha512-3DkkN3FKJ++BQy8PE3LONoVSVBONG7hld9D+VqBp1Dcfw2PGSnWyg20NET5cJkiygWK2y2H1ra8GWk3yixzuuA==}
+    engines: {node: '>=18.18.2'}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -2149,6 +2259,42 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/core@3.26.0':
+    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@solana/addresses@5.5.1':
     resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
     engines: {node: '>=20.18.0'}
@@ -2564,6 +2710,9 @@ packages:
   '@types/mustache@4.2.6':
     resolution: {integrity: sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==}
 
+  '@types/node-int64@0.4.32':
+    resolution: {integrity: sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -2581,6 +2730,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/q@1.5.8':
+    resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -2604,6 +2756,9 @@ packages:
 
   '@types/serve-static@1.15.8':
     resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
+
+  '@types/thrift@0.10.17':
+    resolution: {integrity: sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2688,6 +2843,14 @@ packages:
     resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
     engines: {node: '>=16.0.0'}
 
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
+  '@zenfs/core@1.11.4':
+    resolution: {integrity: sha512-jFihhedKitw1X9rlImtaca4KTs1Xk9awo4GxUemqt2ucE1jLi10lyRfFFbiYXZsFDkuCWGHwEQwv7BeDIEXMbQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -2698,6 +2861,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2781,6 +2948,9 @@ packages:
   ast-v8-to-istanbul@0.3.5:
     resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
+  async-limiter@1.0.1:
+    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
@@ -2839,6 +3009,9 @@ packages:
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -2846,11 +3019,22 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  brotli-wasm@3.0.1:
+    resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
+    engines: {node: '>=v18.0.0'}
+
+  browser-or-node@1.3.0:
+    resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
+
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
 
   bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+
+  bson@6.10.3:
+    resolution: {integrity: sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==}
+    engines: {node: '>=16.20.1'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -3438,11 +3622,19 @@ packages:
   event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -3775,6 +3967,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  int53@1.0.0:
+    resolution: {integrity: sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -4241,6 +4436,9 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
   number-flow@0.5.8:
     resolution: {integrity: sha512-FPr1DumWyGi5Nucoug14bC6xEz70A1TnhgSHhKyfqjgji2SOTz+iLJxKtv37N5JyJbteGYCm6NQ9p1O4KZ7iiA==}
 
@@ -4474,6 +4672,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prom-client@14.2.0:
     resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
     engines: {node: '>=10'}
@@ -4518,6 +4720,14 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  q@1.5.1:
+    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
+    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -4613,6 +4823,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -4631,6 +4845,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4711,11 +4926,6 @@ packages:
   secure-json-parse@4.0.0:
     resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -4791,6 +5001,9 @@ packages:
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  snappyjs@0.7.0:
+    resolution: {integrity: sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -4969,6 +5182,10 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  thrift@0.21.0:
+    resolution: {integrity: sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==}
+    engines: {node: '>= 10.18.0'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -5188,16 +5405,23 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utilium@1.10.1:
+    resolution: {integrity: sha512-GQINDTb/ocyz4acQj3GXAe0wipYxws6L+9ouqaq10KlInTk9DGvW9TJd0pYa/Xu3cppNnZuB4T/sBuSXpcN2ng==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5374,6 +5598,17 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@5.2.5:
+    resolution: {integrity: sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
     engines: {node: '>=8.3.0'}
@@ -5401,6 +5636,9 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5557,6 +5795,235 @@ snapshots:
 
   '@apollo/utils.withrequired@3.0.0': {}
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/middleware-flexible-checksums': 3.974.33
+      '@aws-sdk/middleware-sdk-s3': 3.972.54
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.26.0
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
@@ -5679,6 +6146,25 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.9
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@dsnp/parquetjs@1.8.7(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1075.0
+      '@types/node-int64': 0.4.32
+      '@types/thrift': 0.10.17
+      '@zenfs/core': 1.11.4
+      brotli-wasm: 3.0.1
+      bson: 6.10.3
+      int53: 1.0.0
+      long: 5.3.2
+      node-int64: 0.4.0
+      snappyjs: 0.7.0
+      thrift: 0.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      varint: 6.0.0
+      xxhash-wasm: 1.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -6979,6 +7465,54 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/core@3.26.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@solana/addresses@5.5.1(typescript@5.9.2)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@5.9.2)
@@ -7459,6 +7993,10 @@ snapshots:
 
   '@types/mustache@4.2.6': {}
 
+  '@types/node-int64@0.4.32':
+    dependencies:
+      '@types/node': 22.18.13
+
   '@types/node@12.20.55': {}
 
   '@types/node@20.19.39':
@@ -7482,6 +8020,8 @@ snapshots:
       '@types/node': 22.18.13
       pg-protocol: 1.10.3
       pg-types: 2.2.0
+
+  '@types/q@1.5.8': {}
 
   '@types/qs@6.14.0': {}
 
@@ -7509,6 +8049,12 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.18.13
       '@types/send': 0.17.5
+
+  '@types/thrift@0.10.17':
+    dependencies:
+      '@types/node': 22.18.13
+      '@types/node-int64': 0.4.32
+      '@types/q': 1.5.8
 
   '@types/unist@2.0.11': {}
 
@@ -7626,6 +8172,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@xterm/xterm@5.5.0':
+    optional: true
+
+  '@zenfs/core@1.11.4':
+    dependencies:
+      '@types/node': 22.18.13
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      readable-stream: 4.7.0
+      utilium: 1.10.1
+
   abitype@1.2.3(typescript@5.9.2)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.2
@@ -7635,6 +8192,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 4.3.6
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
 
   accepts@2.0.0:
     dependencies:
@@ -7709,6 +8270,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  async-limiter@1.0.1: {}
+
   async-retry@1.3.3:
     dependencies:
       retry: 0.13.1
@@ -7782,6 +8345,8 @@ snapshots:
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
+  bowser@2.14.1: {}
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -7790,6 +8355,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brotli-wasm@3.0.1: {}
+
+  browser-or-node@1.3.0: {}
+
   bs58@4.0.1:
     dependencies:
       base-x: 3.0.11
@@ -7797,6 +8366,8 @@ snapshots:
   bs58@5.0.0:
     dependencies:
       base-x: 4.0.1
+
+  bson@6.10.3: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -8091,8 +8662,7 @@ snapshots:
 
   detect-libc@2.1.1: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -8327,9 +8897,13 @@ snapshots:
       d: 1.0.2
       es5-ext: 0.10.64
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.1: {}
+
+  events@3.3.0: {}
 
   expand-template@2.0.3: {}
 
@@ -8713,6 +9287,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
+  int53@1.0.0: {}
+
   internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
@@ -8756,9 +9332,17 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-ws@4.0.1(ws@5.2.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 5.2.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
   isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   isows@1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
     dependencies:
@@ -9092,7 +9676,7 @@ snapshots:
 
   node-abi@3.77.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   node-addon-api@2.0.2: {}
 
@@ -9109,6 +9693,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4: {}
+
+  node-int64@0.4.0: {}
 
   number-flow@0.5.8:
     dependencies:
@@ -9358,7 +9944,7 @@ snapshots:
 
   prebuild-install@7.1.3:
     dependencies:
-      detect-libc: 2.1.1
+      detect-libc: 2.1.2
       expand-template: 2.0.3
       github-from-package: 0.0.0
       minimist: 1.2.8
@@ -9376,6 +9962,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   process-warning@5.0.0: {}
+
+  process@0.11.10: {}
 
   prom-client@14.2.0:
     dependencies:
@@ -9458,6 +10046,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  q@1.5.1: {}
 
   qs@6.14.0:
     dependencies:
@@ -9559,6 +10149,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   readdirp@4.1.2: {}
 
@@ -9699,8 +10297,6 @@ snapshots:
 
   secure-json-parse@4.0.0: {}
 
-  semver@7.7.2: {}
-
   semver@7.7.4: {}
 
   send@1.2.0:
@@ -9831,6 +10427,8 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  snappyjs@0.7.0: {}
 
   sonic-boom@4.2.0:
     dependencies:
@@ -10003,6 +10601,17 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  thrift@0.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      browser-or-node: 1.3.0
+      isomorphic-ws: 4.0.1(ws@5.2.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      node-int64: 0.4.0
+      q: 1.5.1
+      ws: 5.2.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   tiny-invariant@1.3.3: {}
 
@@ -10197,11 +10806,19 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utilium@1.10.1:
+    dependencies:
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      '@xterm/xterm': 5.5.0
+
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  varint@6.0.0: {}
 
   vary@1.1.2: {}
 
@@ -10222,16 +10839,16 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  viem@2.46.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@4.3.6):
+  viem@2.46.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.2)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.12.4(typescript@5.9.2)(zod@4.3.6)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10454,10 +11071,22 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@5.2.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      async-limiter: 1.0.1
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
   ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 6.0.6
+
+  ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
 
   ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     optionalDependencies:
@@ -10465,6 +11094,8 @@ snapshots:
       utf-8-validate: 6.0.6
 
   xtend@4.0.2: {}
+
+  xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Parquet writer target

Adds `parquetTarget`, streaming pipe output to rotating, **finalized-only** Parquet files — the columnar format read by DuckDB, Spark, Athena and ClickHouse `s3()`. Builds on the reusable finalization buffer already on this branch.

> **Base:** this PR targets `design/sdk1` (where the finalization buffer lives) — it is not on `main`.

### How it works
- **Finalized-only.** Each table buffers unfinalized rows in the shared `createFinalizationBuffer` and only appends a row once its block is at/below the portal's finalized head. Reorgs drop the in-memory buffer; published files are never touched.
- **Constant memory + byte rotation.** Finalized rows stream to a temp file; `@dsnp/parquetjs` flushes row groups to disk incrementally, so `fs.stat` reflects real size and RSS plateaus. Files rotate at `rollover.maxBytes` (default 128 MiB); `rowGroupSize` bounds the writer buffer.
- **Crash safety.** A writer with ≥1 finalized row is always published at the next checkpoint, and the durable cursor (`_sqd_parquet_state.json`, atomic temp+fsync+rename) advances only at a checkpoint. Recovery deletes any published file above the cursor and any `.tmp-*` file, then re-fetches the deterministic finalized data.
- **`onData` purity contract** is documented in the `parquetTarget` JSDoc — Parquet has no server-side dedupe (unlike BigQuery), so recovery relies on `onData` being a pure function of finalized blocks.

### Step 0 spike finding (codec correction)
The plan's `Codec` union was corrected by the load-bearing spike: `@dsnp/parquetjs` supports **only `UNCOMPRESSED` / `SNAPPY` / `GZIP` / `BROTLI`** — `LZO` / `LZ4` / `ZSTD` are recognised as names but throw `Unsupported compression method` at write time. The spike also confirmed incremental row-group flush (the assumption byte-rotation + constant memory depend on).

### Files
`src/targets/parquet/`: `schema` · `errors` · `writer` · `fs-durable` · `parquet-store` · `parquet-state` · `parquet-target` · `index`.
Packaging: `@dsnp/parquetjs` added as an **optional** peer dep (+ dev dep); `./targets/parquet` added to `exports` + `typesVersions`.

### Test coverage (base → head)
The base branch has no Parquet target, so every file below is new. Tests use the internal framework only (`createMockPortal` + `evmPortalStream(...).pipeTo(...)`), read files back with `ParquetReader`, write to temp dirs, and clean up in `afterEach`.

| File | Base | Head % Stmts | % Branch | % Funcs |
|------|------|-------------:|---------:|--------:|
| errors.ts | — | 100 | 100 | 100 |
| schema.ts | — | 100 | 100 | 100 |
| index.ts | — | 100 | 100 | 100 |
| fs-durable.ts | — | 100 | 83.3 | 100 |
| parquet-store.ts | — | 100 | 90.0 | 100 |
| parquet-target.ts | — | 98.2 | 87.5 | 100 |
| parquet-state.ts | — | 98.0 | 80.8 | 100 |
| writer.ts | — | 90.4 | 84.6 | 100 |
| **All parquet (head)** | **0%** | **97.57** | **88.07** | **100** |

26 tests cover: finalized-only, cross-batch release, read-back + `<min>-<max>` filenames, byte rotation, crash recovery, reorg/fork, empty table, no-finality passthrough, multi-table, crash-safety discard, `ParquetSegmentWriter`/`ParquetState` units, and schema/insert validation guards. Remaining uncovered lines are defensive catch / internal-invariant branches.

### Verification
- `pnpm vitest run src/targets/parquet/ src/core/finalization-buffer.test.ts src/targets/memory/` → **44 passing** (the other finalization-buffer consumers still pass).
- Full package suite (excluding ClickHouse/Postgres external-service tests): **417 passing**; the only failure is the pre-existing empty `delta-db` WIP stub, unrelated to this change.
- `tsc --noEmit` clean; Biome clean; build emits `dist/targets/parquet/*` and `require('@subsquid/pipes/targets/parquet').parquetTarget` resolves.

### Trade-offs (documented in JSDoc)
Global checkpoint → smaller files for low-volume tables; byte-only rotation can stall the cursor on a slow live tail (set `intervalMs`/`intervalBlocks` for live tailing); no-finality datasets are **not** reorg-safe by construction; `maxBytes` is a soft cap checked at batch boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

