### PR TITLE
fix(bigquery): anchor the WAL cursor to the fork safe point

### DIFF
--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
@@ -133,6 +133,16 @@ export class BigQueryState {
   }
 
   /**
+   * The last durably persisted cursor — advanced by `saveCommitPost`, rewound by
+   * `saveRollbackPost` on a fork, and restored by `getCursor` on recovery. The write loop reads
+   * this as the single source of truth for the pre-batch cursor, so a reorg cannot leave a stale
+   * copy behind.
+   */
+  get lastCommittedCursor(): BlockCursor | undefined {
+    return this.#lastCommittedCursor
+  }
+
+  /**
    * Reads the last committed cursor and runs crash recovery if needed.
    *
    * Lazy auto-creates the sync table on Not Found — `getCursor` may be called by the framework

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.lifecycle.test.ts
@@ -1186,4 +1186,106 @@ describe('bigqueryTarget — fork lifecycle', () => {
     await target.fork!([cursor(5, 'BAD')])
     expect(onAfterRollback).not.toHaveBeenCalled()
   })
+
+  it('after a fork, the first reprocessed batch anchors its WAL range/cursor to the safe cursor, not the stale pre-fork cursor', async () => {
+    // Regression (data integrity): fork() rewinds the stream to a safe cursor S below the pre-fork
+    // committed cursor P and DELETEs (S, upper]. write() tracks previousCursor in a closure fork()
+    // cannot reach; if it stays at P, the first reprocessed batch writes an IN_FLIGHT_COMMIT row
+    // with current=P and range_low=P+1. On a crash mid-batch, getCursor recovery then rewinds to P
+    // and — since range_low > range_high — skips the cleanup DELETE, permanently gapping blocks
+    // S+1..P and orphaning the partial write. The fix makes write() adopt the fork's safe cursor,
+    // so the row anchors to S (current=S, range_low=S+1, range_low <= range_high).
+
+    // Committed row: getCursor resumes at P=10, and its rollback chain lets the fork resolve a
+    // common ancestor at S=5.
+    const chain = [
+      cursor(5, '0x5'),
+      cursor(6, '0x6'),
+      cursor(7, '0x7'),
+      cursor(8, '0x8'),
+      cursor(9, '0x9'),
+      cursor(10, '0x10'),
+    ]
+    bqSetup = makeBigQuery({
+      queryRows: [
+        {
+          id: 'stream',
+          op: 'commit',
+          current: JSON.stringify(cursor(10, '0x10')),
+          finalized: null,
+          rollback_chain: JSON.stringify(chain),
+          range_low: null,
+          range_high: null,
+          committed: true,
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+      ],
+    })
+
+    // Capture every WAL sync row appended (the `op` field is present on sync rows, absent on data
+    // rows) so we can inspect the reprocessed batch's IN_FLIGHT_COMMIT row.
+    const syncRows: Record<string, unknown>[] = []
+    const target = bigqueryTarget<unknown>({
+      client: { bigquery: bqSetup.bq, writer: writerSetup.writer },
+      dataset: 'd',
+      tables: TABLES,
+      settings: {
+        protoWriterFactory: ({ protoDescriptor }) => ({
+          appendRows: ({ serializedRows }) => {
+            for (const row of decodeProtoRows(serializedRows, protoDescriptor)) {
+              if ('op' in row) syncRows.push(row)
+            }
+            return { getResult: async () => ({}) }
+          },
+          close: () => {},
+        }),
+      },
+      onData: async ({ store, data }) => {
+        store.insert('events', [data as Record<string, unknown>])
+      },
+    })
+
+    // The new canonical chain diverges from ours above block 5 (hashes 0xB6..0xB10), so the fork
+    // resolves the safe cursor to block 5.
+    const previousBlocks = [
+      cursor(5, '0x5'),
+      cursor(6, '0xB6'),
+      cursor(7, '0xB7'),
+      cursor(8, '0xB8'),
+      cursor(9, '0xB9'),
+      cursor(10, '0xB10'),
+    ]
+
+    async function* read() {
+      // The reorg fires while write()'s for-await is suspended, before the first reprocessed batch.
+      const safe = await target.fork!(previousBlocks)
+      expect(safe?.number).toBe(5) // fork resolved to S=5
+
+      // First reprocessed batch on the new chain, ending at block 7 (S=5 < 7 <= P=10).
+      yield {
+        data: { block_number: 6, tx_hash: '0x6-new' },
+        ctx: makeBatchContext(cursor(7, '0x7-new'), [cursor(6, '0x6-new'), cursor(7, '0x7-new')], 0),
+      }
+    }
+
+    await target.write({ read: read as never, logger: createTestLogger() })
+
+    // Among the sync rows (fork's rollback pair, then the batch's commit pair), the first
+    // op='commit' row is the reprocessed batch's IN_FLIGHT_COMMIT (pre-commit) row.
+    const inFlight = syncRows.find((r) => r['op'] === 'commit') as {
+      current: string
+      range_low: string | number
+      range_high: string | number
+    }
+    expect(inFlight).toBeDefined()
+
+    // Anchored to the safe cursor S=5, NOT the stale pre-fork P=10.
+    expect(JSON.parse(inFlight.current).number).toBe(5)
+    // Range floor is S+1=6 (INT64 decodes as a string via protobufjs — coerce to compare).
+    expect(Number(inFlight.range_low)).toBe(6)
+    expect(Number(inFlight.range_high)).toBe(7)
+    // And not inverted: low <= high, so recovery's bounded DELETE actually runs (the bug produced
+    // range_low=11 > range_high=7, which recovery skips → the gap).
+    expect(Number(inFlight.range_low)).toBeLessThanOrEqual(Number(inFlight.range_high))
+  })
 })

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.ts
@@ -169,9 +169,6 @@ export function bigqueryTarget<T>(options: {
 
         // Recovery: getCursor re-executes any outstanding IN_FLIGHT operation before returning.
         const resumeState = await state.getCursor({ logger })
-        // The resume cursor doubles as the WAL pre-commit "previous cursor"; keep it as a plain
-        // BlockCursor (separate from the TargetState handed to read()) for the range arithmetic.
-        let previousCursor = resumeState?.latest
         for await (const { data, ctx } of read(resumeState)) {
           if (!metrics) metrics = registerBqTargetMetrics(ctx.metrics)
           const span = ctx.profiler.start({ name: 'bigquery', labels: 'db' })
@@ -182,6 +179,10 @@ export function bigqueryTarget<T>(options: {
             // IN_FLIGHT and COMMITTED rows agree.
             const finalized = ctx.stream.head.finalized
             const rollbackChain = ctx.stream.state.rollbackChain
+            // Pre-batch cursor = the last durably persisted position. `state` is the single source
+            // of truth: saveCommitPost advances it, saveRollbackPost rewinds it on a fork, so after
+            // a reorg it already points at the safe cursor — no separate copy in write() to drift.
+            const previousCursor = state.lastCommittedCursor
             // Range of new blocks this batch is about to write: [low, next.number].
             //   - Subsequent batches: low = previousCursor.number + 1.
             //   - Very first batch (no previousCursor): low = stream.state.initial — the
@@ -245,8 +246,6 @@ export function bigqueryTarget<T>(options: {
               totalRows,
               totalBytes,
             })
-
-            previousCursor = next
           } finally {
             span.end()
           }


### PR DESCRIPTION
## Problem (data integrity)

The BigQuery target's `write()` loop tracked its own `previousCursor` in a closure, but `fork()` is a **sibling closure that cannot reach it**. On a reorg, `fork()` rewinds the stream to a safe cursor `S` below the last committed cursor `P` and DELETEs `(S, upper]`, yet the loop's `previousCursor` stays at `P`.

The first reprocessed batch (ending at block `B`, where `S < B ≤ P`) then writes an `IN_FLIGHT_COMMIT` WAL row with `current = P` and `range = {low: P+1, high: B}` — inverted, `low > high`. If the process crashes on that batch (after `saveCommitPre`, before `saveCommitPost`):

- `getCursor` reads the latest row (`ORDER BY timestamp DESC LIMIT 1`) — the broken `IN_FLIGHT_COMMIT`, since it was written *after* the fork's `ROLLED_BACK` row.
- `low > high` → recovery **skips** `#recoveryDeleteRange` and returns `current = P` → indexing resumes from `P+1`.
- Blocks `S+1..P` were deleted by the fork and are **never re-indexed** → permanent data gap; partial rows are left **orphaned**.

Without a crash the bug is benign — `saveCommitPost` writes the correct `COMMITTED` row (keyed off `next`) and supersedes the broken in-flight row. The corruption only surfaces when a crash freezes the state on the stale in-flight row.

**Origin:** present since the target was introduced in #78 (`570ce7e`) — *not* `d418098`, which only refactored the resume-cursor plumbing and touched adjacent lines.

## Fix

The root cause was **duplicated cursor state**: `write()` kept its own `previousCursor` while `BigQueryState` already tracks `#lastCommittedCursor`. Rather than patch the two copies back into sync, remove the duplicate:

- `write()` reads the pre-batch cursor from `state.lastCommittedCursor` (new getter) — the single source of truth.
- `BigQueryState` already advances it in `saveCommitPost`, **rewinds it in `saveRollbackPost` on a fork**, and restores it in `getCursor` on recovery.

So after a reorg the pre-batch cursor already reflects `S`, the in-flight row records `current = S` / `range = {low: S+1, high: B}` (no inversion), and recovery cleans `[S+1, B]` and resumes from `S`. The desync is now impossible by construction (no second copy to drift), and the crash-then-retry re-entry edge case disappears (`getCursor` re-establishes the cursor on every `write()` entry).

## Test

`bigquery-target.lifecycle.test.ts`: drives a fork to `S=5` with a committed cursor at `P=10`, then asserts the reprocessed batch's `IN_FLIGHT_COMMIT` WAL row anchors to the safe cursor (`current=5`, `range_low=6`, `range_low ≤ range_high`) instead of the stale pre-fork values (`current=10`, `range_low=11`). Verified it **fails when the loop reads a stale cursor** (`expected 10 to be 5`; log shows the inverted `blocks 11 → 7`) and passes with the fix. Uses the internal fake infrastructure — no live BigQuery.

## Coverage (base vs head) — `bigquery-target.ts`

|                       | Stmts | Branch  | Funcs | Lines |
| --------------------- | ----- | ------- | ----- | ----- |
| Base (`design/sdk1`)  | 100%  | 95.34%  | 100%  | 100%  |
| Head                  | 100%  | 97.72%  | 100%  | 100%  |

New code fully covered; branch coverage improves and the previously-uncovered `resumeState?.latest` branch is eliminated (that line is gone). The new `lastCommittedCursor` getter is exercised by every write batch.

All non-integration BigQuery tests pass (102 passed, 18 integration skipped); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
