### PR TITLE
refactor(parquet): resolve the fork cursor once across table buffers

### DIFF
--- a/packages/subsquid-pipes/src/core/finalization-buffer.test.ts
+++ b/packages/subsquid-pipes/src/core/finalization-buffer.test.ts
@@ -175,6 +175,58 @@ describe('createFinalizationBuffer', () => {
     })
   })
 
+  describe('resolveFork / dropAbove (split fork for shared-chain buffers)', () => {
+    it('resolveFork resolves the safe cursor without mutating the buffer', async () => {
+      const buffer = make()
+      buffer.push([row(5), row(6), row(7)], head(4, [block(5), block(6), block(7)]))
+
+      const safe = await buffer.resolveFork([block(5), block(6, '0x6a'), block(7, '0x7a')])
+
+      expect(safe).toEqual(block(5))
+      // Side-effect-free (unlike fork): rows stay buffered…
+      expect(buffer.size).toBe(3)
+      // …and a second resolve on the untouched chain returns the same cursor.
+      expect(await buffer.resolveFork([block(5), block(6, '0x6a'), block(7, '0x7a')])).toEqual(block(5))
+      expect(buffer.size).toBe(3)
+    })
+
+    it('dropAbove drops every buffered row above the given cursor', () => {
+      const buffer = make()
+      buffer.push([row(5), row(6), row(7)], head(4, [block(5), block(6), block(7)]))
+
+      buffer.dropAbove(block(5))
+
+      expect(buffer.size).toBe(1) // only row(5) survives
+    })
+
+    it('dropAbove(null) keeps rows for a dead-end fork', () => {
+      const buffer = make()
+      buffer.push([row(5), row(6)], head(4, [block(5), block(6)]))
+
+      buffer.dropAbove(null)
+
+      expect(buffer.size).toBe(2)
+    })
+
+    it('resolves once and drops across sibling buffers that share the chain (ParquetStore pattern)', async () => {
+      // Buffers advanced in lockstep carry identical chains, so the cursor is resolved from one
+      // and applied to every buffer — no per-buffer re-resolution.
+      const a = make()
+      const b = make()
+      const fin = head(4, [block(5), block(6), block(7)])
+      a.push([row(5), row(6), row(7)], fin)
+      b.push([row(5), row(6), row(7)], fin)
+
+      const safe = await a.resolveFork([block(5), block(6, '0x6a'), block(7, '0x7a')])
+      a.dropAbove(safe)
+      b.dropAbove(safe)
+
+      expect(safe).toEqual(block(5))
+      expect(a.size).toBe(1)
+      expect(b.size).toBe(1)
+    })
+  })
+
   describe('size', () => {
     it('reflects the number of buffered rows after each push', () => {
       const buffer = make()

--- a/packages/subsquid-pipes/src/core/finalization-buffer.ts
+++ b/packages/subsquid-pipes/src/core/finalization-buffer.ts
@@ -22,10 +22,25 @@ export type FinalizationBuffer<Row> = {
   push(rows: Row[], finalization: Finalization): Row[]
 
   /**
-   * Resolve the safe cursor for a reorg from the accumulated rollback chain and
-   * the portal's `previousBlocks`, drop every buffered row above it, and return
-   * that cursor (or `null` on a dead-end fork). Drive this straight from the
-   * target's `fork` handler.
+   * Resolve the safe cursor for a reorg from the accumulated rollback chain and the portal's
+   * `previousBlocks`, WITHOUT mutating the buffer. Returns that cursor (or `null` on a dead-end
+   * fork). Pair with {@link dropAbove}, or use {@link fork} to do both in one call.
+   *
+   * Sibling buffers advanced in lockstep carry an identical chain, so a caller with many buffers
+   * can resolve the cursor once and apply it to all of them via {@link dropAbove} instead of
+   * re-resolving the same walk per buffer.
+   */
+  resolveFork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null>
+
+  /**
+   * Drop every buffered row above `safe` and trim the rollback chain to it — or, on a `null`
+   * dead-end fork, keep the rows and reset the chain. Feed it a cursor from {@link resolveFork}.
+   */
+  dropAbove(safe: BlockCursor | null): void
+
+  /**
+   * Resolve the safe cursor and drop every buffered row above it — {@link resolveFork} then
+   * {@link dropAbove} in one call. Convenient for a single-buffer target's `fork` handler.
    */
   fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null>
 
@@ -67,6 +82,19 @@ export function createFinalizationBuffer<Row>({
   let rollbackChain: BlockCursor[] = []
   let finalized: BlockCursor | undefined
 
+  const resolveFork = (previousBlocks: BlockCursor[]): Promise<BlockCursor | null> =>
+    resolveForkCursor([{ rollbackChain, finalized }], previousBlocks)
+
+  const dropAbove = (safe: BlockCursor | null): void => {
+    if (safe) {
+      const boundary = safe.number
+      rollbackChain = rollbackChain.filter((block) => block.number <= boundary)
+      buffered = buffered.filter((row) => getBlockNumber(row) <= boundary)
+    } else {
+      rollbackChain = []
+    }
+  }
+
   return {
     push(rows, finalization) {
       rollbackChain.push(...(finalization.rollbackChain ?? []))
@@ -98,16 +126,13 @@ export function createFinalizationBuffer<Row>({
       return released
     },
 
-    async fork(previousBlocks) {
-      const safe = await resolveForkCursor([{ rollbackChain, finalized }], previousBlocks)
+    resolveFork,
 
-      if (safe) {
-        const boundary = safe.number
-        rollbackChain = rollbackChain.filter((block) => block.number <= boundary)
-        buffered = buffered.filter((row) => getBlockNumber(row) <= boundary)
-      } else {
-        rollbackChain = []
-      }
+    dropAbove,
+
+    async fork(previousBlocks) {
+      const safe = await resolveFork(previousBlocks)
+      dropAbove(safe)
 
       return safe
     },

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
@@ -161,14 +161,19 @@ export class ParquetStore {
    * Open writers and published files are never touched — they hold only finalized rows, which
    * can never reorg.
    *
-   * Every buffer carries the same rollback chain (advanced on every batch), so each resolves the
-   * same safe cursor; we drop rows in all of them and return the agreed result.
+   * Every buffer carries an identical rollback chain (`flushBatch` advances them all in lockstep
+   * with the same finalization), so resolve the safe cursor ONCE and reuse it to drop rows in
+   * each buffer — resolving per buffer would repeat the identical walk N times.
    */
   async fork(previousBlocks: BlockCursor[]): Promise<BlockCursor | null> {
-    let safe: BlockCursor | null = null
+    const buffers = [...this.#buffers.values()]
+    if (buffers.length === 0) {
+      return null
+    }
 
-    for (const buffer of this.#buffers.values()) {
-      safe = await buffer.fork(previousBlocks)
+    const safe = await buffers[0].resolveFork(previousBlocks)
+    for (const buffer of buffers) {
+      buffer.dropAbove(safe)
     }
 
     return safe

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
@@ -504,6 +504,70 @@ describe('parquetTarget', () => {
       // The block-1 file was published before the reorg and must survive it untouched.
       expect(await listDataFiles(dir, 'blocks')).toContain('000000000001-000000000001.parquet')
     })
+
+    it('drops forked rows in every table buffer, not just the first (multi-table)', async () => {
+      const logsTable: ParquetTable = {
+        table: 'logs',
+        schema: {
+          blockNumber: { type: 'INT64' },
+          logIndex: { type: 'INT32' },
+          address: { type: 'UTF8' },
+        },
+      }
+      mockPortal = await createMockPortal([
+        blocksResponse([1, 2, 3, 4, 5], 1),
+        {
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 2, hash: '0x2' },
+              { number: 3, hash: '0x3' },
+              { number: 4, hash: '0x4-1' },
+              { number: 5, hash: '0x5-1' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 4, hash: '0x4a', timestamp: 4000 } },
+            { header: { number: 5, hash: '0x5a', timestamp: 5000 } },
+            { header: { number: 6, hash: '0x6a', timestamp: 6000 } },
+            { header: { number: 7, hash: '0x7a', timestamp: 7000 } },
+          ],
+          head: { finalized: { number: 7, hash: '0x7a' } },
+        },
+      ])
+
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 7 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE, logsTable],
+          onData: ({ store, data }) => {
+            store.insert(
+              'blocks',
+              data.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+            )
+            // One log row per block, tagged with the block hash so the forked chain (0x4-1 / 0x5-1)
+            // is distinguishable from the replacement chain (0x4a / 0x5a).
+            store.insert(
+              'logs',
+              data.map((b) => ({ blockNumber: b.number, logIndex: 0, address: b.hash })),
+            )
+          },
+        }),
+      )
+
+      // Both tables dropped the forked rows: no duplicate block 4/5 in either. If fork() had
+      // dropped rows in only the first buffer, the logs table would still carry the stale forked
+      // rows (blockNumbers [1, 2, 3, 4, 4, 5, 5, 6, 7]).
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3, 4, 5, 6, 7])
+      const logs = await readLogs(dir)
+      expect(logs.map((r) => r.blockNumber)).toEqual([1, 2, 3, 4, 5, 6, 7])
+      // Blocks 4 & 5 in the logs table carry the replacement-chain hash, proving the drop happened.
+      expect(logs.find((r) => r.blockNumber === 4)?.address).toBe('0x4a')
+      expect(logs.find((r) => r.blockNumber === 5)?.address).toBe('0x5a')
+    })
   })
 
   describe('empty table', () => {


### PR DESCRIPTION
## What

`ParquetStore.fork` resolved the reorg safe cursor **separately in every table's `FinalizationBuffer`**, even though all buffers carry an identical rollback chain (`flushBatch` advances them in lockstep with the same finalization). For an N-table pipe, N-1 of those `resolveForkCursor` walks were redundant work (and every buffer holds its own copy of the identical chain).

## Change

Split `FinalizationBuffer.fork` into two composable steps:

- `resolveFork(previousBlocks)` — resolves the safe cursor, **no mutation**.
- `dropAbove(safe)` — drops buffered rows above the cursor and trims the chain (or clears it on a `null` dead-end fork).

`fork` stays as a thin `resolveFork` + `dropAbove` wrapper, so single-buffer targets (e.g. `memory-target`) are unchanged.

`ParquetStore.fork` now resolves the cursor **once** (on the first buffer) and reuses it to drop rows in every buffer.

Pure optimization — the fork result is identical (the resolved cursor was already the same across buffers, since the chains are identical). No behavior change.

## Tests

- `finalization-buffer.test.ts`: `resolveFork` is side-effect-free (rows stay buffered; idempotent), `dropAbove` drops/keeps rows correctly, and the "resolve once → drop across sibling buffers" pattern (the shape `ParquetStore` relies on).
- `parquet-target.test.ts`: a **multi-table** reorg where both tables' buffers must drop the forked rows. Verified it **fails if only the first buffer is dropped** (`[1, 2, 3, 4, 4, 5, 5, 6, 7]` vs the expected `[1, 2, 3, 4, 5, 6, 7]`).

## Coverage (base vs head)

| File                    | Stmts         | Branch          | Funcs   | Lines         |
| ----------------------- | ------------- | --------------- | ------- | ------------- |
| `finalization-buffer.ts`| 100 → 100     | 100 → 100       | 100     | 100 → 100     |
| `parquet-store.ts`      | 93.14 → 92.17 | 78.87 → 78.08   | 100     | 93.14 → 92.17 |

`finalization-buffer.ts` stays at 100% (new `resolveFork` / `dropAbove` fully covered). The small dip on `parquet-store.ts` is a single defensive `if (buffers.length === 0) return null` guard — unreachable in practice (a store always has ≥1 validated table), kept for readability over the branchless alternative. `tsc --noEmit` clean; Biome clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
