### PR TITLE
ci: Trusted Publishing release workflow + skill for @subsquid/pipes (on main)

### DIFF
--- a/.claude/skills/subsquid-pipes-release/SKILL.md
+++ b/.claude/skills/subsquid-pipes-release/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: subsquid-pipes-release
+description: Cut a new @subsquid/pipes release — bump the version, tag, push, watch the Release workflow, and publish GitHub release notes. Handles stable releases and alpha/beta/rc prereleases (published to matching npm dist-tags via Trusted Publishing). Use when the user asks to "release", "publish", "cut a version", "ship", or "cut an alpha/beta" for @subsquid/pipes.
+---
+
+# @subsquid/pipes release
+
+End-to-end release procedure for **`@subsquid/pipes`** (the core SDK). Bumps `packages/subsquid-pipes/package.json`, tags `pipes-v<version>`, pushes, watches the `Release @subsquid/pipes` workflow ([release-subsquid-pipes.yml](../../../.github/workflows/release-subsquid-pipes.yml)), then rewrites the auto-generated GitHub release notes for stable releases.
+
+Publishing runs on **npm Trusted Publishing** (OIDC + provenance, no `NPM_TOKEN`). The tagged commit is the source of truth: the workflow refuses to publish unless `package.json` already carries the version in the tag.
+
+Supports **prereleases** (`1.0.0-alpha.14`, `1.0.0-beta.1`, `1.0.0-rc.1`) as well as stable versions. A prerelease publishes to a matching npm dist-tag (`@alpha`/`@beta`/`@rc`) instead of `@latest` and is flagged as a GitHub pre-release. See [Prereleases (alpha/beta)](#prereleases-alphabeta).
+
+> **Scope:** this skill releases `@subsquid/pipes` only. `@subsquid/pipes-cli` has its own separate procedure — use the `deploy-pipes-cli` skill for that. Don't cross the two: they have different tag prefixes (`pipes-v*` vs `pipes-cli-v*`) and different publish mechanics.
+
+## Preconditions
+
+Confirm before starting:
+- `git status` is clean on `main` (or the version bump is staged deliberately).
+- The user named a target version, e.g. `1.0.0-alpha.14` (prerelease) or `1.0.0` (stable). If not, ask. See [Choosing the next version](#choosing-the-next-version).
+- A **trusted publisher** for `@subsquid/pipes` is configured on npmjs.com pointing at `subsquid-labs/pipes-sdk` → `.github/workflows/release-subsquid-pipes.yml`. This is a one-time setup on npm (Package → Settings → Trusted Publishing). Without it, the `publish` job 404s. See [First-time setup](#first-time-setup-trusted-publishing).
+
+## Steps
+
+### 1. Bump the version
+
+Set the target version in `packages/subsquid-pipes/package.json`.
+
+The workflow's `Verify version` step compares the exact string — including any prerelease suffix — against the tag and refuses to publish on a mismatch. So `1.0.0-alpha.14` in the tag must equal `1.0.0-alpha.14` in `package.json`.
+
+### 2. Commit and tag
+
+```sh
+git add packages/subsquid-pipes/package.json
+git commit -m "chore(release): @subsquid/pipes <version>"
+git tag pipes-v<version>
+git push origin main
+git push origin pipes-v<version>
+```
+
+Both pushes are required — the workflow triggers on `tags: ['pipes-v*']`. The tag prefix (`pipes-v`) is what scopes this release to the core package and keeps it distinct from `pipes-cli-v*`.
+
+### 3. Watch the workflow
+
+```sh
+gh run watch --repo subsquid-labs/pipes-sdk --exit-status
+```
+
+Or list + tail the latest:
+
+```sh
+RUN_ID=$(gh run list --repo subsquid-labs/pipes-sdk --workflow=release-subsquid-pipes.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo subsquid-labs/pipes-sdk --exit-status
+```
+
+Three jobs: `check` → `publish` → `github-release`. If `publish` fails on npm Trusted Publishing, the trusted publisher config on npmjs.com may be missing or misconfigured — surface the error to the user, don't retry blindly.
+
+### 4. Rewrite release notes
+
+**Stable releases only.** For a prerelease, skip this step — the workflow already flags it as a pre-release and its auto-generated notes stay as-is. See [Prereleases (alpha/beta)](#prereleases-alphabeta).
+
+The `github-release` job creates the release with `generate_release_notes: true` (auto-generated bullet list). Replace it with the standardized format from [release-template.md](release-template.md).
+
+Source the highlights from the commits since the previous release; pick the user-visible changes rather than restating every commit.
+
+```sh
+gh release edit pipes-v<version> --repo subsquid-labs/pipes-sdk --notes "$(cat <<'EOF'
+...standardized notes...
+EOF
+)"
+```
+
+### 5. Confirm
+
+Print the release URL and verify the dist-tag landed where you expect:
+
+```sh
+echo "https://github.com/subsquid-labs/pipes-sdk/releases/tag/pipes-v<version>"
+npm view @subsquid/pipes dist-tags
+```
+
+## Prereleases (alpha/beta)
+
+Cut a prerelease exactly like a stable release (steps 1–3), but name a prerelease version: `1.0.0-alpha.14`, `1.0.0-beta.1`, `1.0.0-rc.1`. Bump `package.json` to that string, tag `pipes-v1.0.0-alpha.14`, push. The workflow handles the rest — no extra inputs:
+
+- **npm dist-tag** — the `Resolve npm dist-tag` step maps the identifier to a channel: `alpha` → `@alpha`, `beta` → `@beta`, `rc` → `@rc` (any other suffix → `@next`). Stable `X.Y.Z` stays on `@latest`. So a plain `npm i @subsquid/pipes` never serves a prerelease; testers opt in with `npm i @subsquid/pipes@alpha`. This matches the package's existing convention (alphas already live on the `alpha` dist-tag).
+- **GitHub release** — the `github-release` job flags it `prerelease: true` and `make_latest: false`, so it stays out of the "Latest release" slot automatically. No manual step.
+
+### Release notes for prereleases
+
+Keep it light. **Do not** run the standardized template — leave the workflow's auto-generated notes in place. Optionally prepend a 1–2 sentence "what to test" lead so testers know where to focus:
+
+```sh
+BODY=$(gh release view pipes-v1.0.0-alpha.14 --repo subsquid-labs/pipes-sdk --json body --jq '.body')
+gh release edit pipes-v1.0.0-alpha.14 --repo subsquid-labs/pipes-sdk --notes "$(cat <<EOF
+Prerelease for testing <feature>. Install with \`npm i @subsquid/pipes@alpha\`. Please report issues against <area>.
+
+$BODY
+EOF
+)"
+```
+
+Save the polished, sectioned notes (step 4 + [release-template.md](release-template.md)) for the stable release that follows.
+
+## Choosing the next version
+
+Numbering is manual (the user names the version). Check what's already published before picking one:
+
+```sh
+npm view @subsquid/pipes dist-tags
+npm view @subsquid/pipes versions --json | tail -20
+```
+
+Increment within a channel: `1.0.0-alpha.14` → `1.0.0-alpha.15`. Move channels when stabilizing: `…-alpha.N` → `…-beta.1` → `…-rc.1` → `1.0.0` (drop the suffix for the stable cut). The first stable `1.0.0` will take over the `latest` dist-tag from the legacy `0.1.0-beta.17` currently sitting there.
+
+## First-time setup (Trusted Publishing)
+
+Publishing uses OIDC — there is no `NPM_TOKEN` secret. Once, before the first automated release, a maintainer with publish rights on `@subsquid/pipes` configures a trusted publisher on npmjs.com:
+
+- Package → **Settings** → **Trusted Publishing** → add a GitHub Actions publisher.
+- Repository: `subsquid-labs/pipes-sdk`
+- Workflow filename: `release-subsquid-pipes.yml`
+
+The workflow requests `id-token: write` and publishes with `--provenance`, so releases carry a verifiable provenance attestation. If this config is missing, the `Publish @subsquid/pipes` step fails with a 404/401 — that's the signal it hasn't been set up (or the repo/workflow name doesn't match).
+
+## Failure modes
+
+- **Tag exists**: `git tag pipes-v<version>` fails. Either the release was already started or a previous attempt didn't finish. Check `gh release view pipes-v<version>` and `gh run list --workflow=release-subsquid-pipes.yml`. Don't force-delete tags without confirming.
+- **`Verify version` fails in CI**: `packages/subsquid-pipes/package.json` doesn't match the tag. Fix locally, commit, retag, repush. Don't reuse a tag that already published.
+- **Publish fails on Trusted Publishing**: the trusted publisher for `@subsquid/pipes` is missing or points at the wrong repo/workflow. See [First-time setup](#first-time-setup-trusted-publishing). Don't fall back to a manual `npm publish` with a token unless the user explicitly asks — that bypasses provenance.
+- **Prerelease served to a plain `npm i`**: shouldn't happen — the `Resolve npm dist-tag` step routes alpha/beta/rc off `latest`. If a tester reports a bare install pulling a prerelease, inspect the tags: `npm view @subsquid/pipes dist-tags`. `latest` must point at the newest *stable*; if it drifted, repoint it with `npm dist-tag add @subsquid/pipes@<stable> latest` (requires npm auth — this recovery is manual, outside the OIDC workflow).
+- **Wrong package**: if the user meant the CLI (`@subsquid/pipes-cli`), stop and use the `deploy-pipes-cli` skill instead — different tag prefix and publish path.

--- a/.claude/skills/subsquid-pipes-release/release-template.md
+++ b/.claude/skills/subsquid-pipes-release/release-template.md
@@ -1,0 +1,65 @@
+# Release notes template
+
+For **stable** `@subsquid/pipes` releases. Prereleases keep the workflow's auto-generated notes — see the "Prereleases" section in [SKILL.md](SKILL.md).
+
+Two shapes — pick by version delta.
+
+## Patch release (X.Y.Z → X.Y.Z+1)
+
+Flat bullet list, no area sections.
+
+```markdown
+## <Headline>
+
+<1-2 sentence lead — what the user notices.>
+
+- Bullet 1
+- Bullet 2
+- Bullet 3
+
+**Full Changelog**: https://github.com/subsquid-labs/pipes-sdk/compare/<PREV_TAG>...pipes-v<NEW>
+```
+
+## Minor / major release (X.Y.Z → X.Y+1.0 or X+1.0.0)
+
+Sectioned. Use only the sections that apply — `@subsquid/pipes` ships across several surfaces, so group by the ones that changed.
+
+```markdown
+## <Headline>
+
+<1-3 sentence lead — what changed for the user, not the implementation.>
+
+### Highlights
+- **Bold lede** — short explanation.
+- **Bold lede** — short explanation.
+
+### Core
+- Stream/pipeline behavior, forks, watermarks, cursor handling.
+
+### Targets
+- ClickHouse / Postgres (Drizzle) / Parquet / BigQuery changes. Name the target.
+
+### Portal client
+- Query, caching, or portal-client API changes.
+
+### Chains
+- EVM / Solana / Hyperliquid / Bitcoin decoder or helper changes.
+
+### API
+- `<new export or option>` — short description.
+- Breaking: `<what changed>` — migration note.
+
+**Full Changelog**: https://github.com/subsquid-labs/pipes-sdk/compare/<PREV_TAG>...pipes-v<NEW>
+```
+
+## Style rules
+
+- **No emoji** — neither in the title nor in section headers or bullets.
+- **No version in the title** — GitHub renders the tag separately.
+- **Lead with user-visible impact**, not internal mechanism.
+- **Bold the lede of each highlight bullet** so the page scans in 5 seconds.
+- **Don't restate the commit message verbatim.** The commit body is the engineer's view; release notes are the user's.
+- **Call out breaking changes explicitly** with a migration note — this is a `1.0.0`-track library and consumers pin on it.
+- **Skip "Tests" / internal-only churn** unless the headline is *about* it.
+- **End with the compare link.** Resolve `<PREV_TAG>` as the previous `pipes-v*` tag if one exists, otherwise the parent commit SHA: `git rev-parse pipes-v<NEW>^ | cut -c1-7`. Don't blindly write a `pipes-v*` tag that may not exist — early releases predate the tag scheme and the link would 404.
+- **No install block.** Install instructions live in the README. Release notes are for *what changed*.

--- a/.github/workflows/release-subsquid-pipes.yml
+++ b/.github/workflows/release-subsquid-pipes.yml
@@ -1,0 +1,192 @@
+name: Release @subsquid/pipes
+
+# Publishes @subsquid/pipes to npm via Trusted Publishing (OIDC, no NPM_TOKEN).
+# Trigger by pushing a `pipes-v<version>` tag, or run manually with a version.
+# Prereleases (…-alpha.N / -beta.N / -rc.N) publish to a matching dist-tag
+# instead of `latest` and are flagged as GitHub pre-releases.
+
+on:
+  push:
+    tags: ['pipes-v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.0.0-alpha.14, or a stable 1.0.0)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      # Build is the publish gate — the package must compile before we ship.
+      # The full test suite (ClickHouse + Postgres services) runs in
+      # test-subsquid-pipes.yml on push to main/develop, so the tagged commit
+      # has already been tested; re-running the services here would only add
+      # flakiness to the release path.
+      - run: pnpm --filter @subsquid/pipes build
+
+  publish:
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance + Trusted Publishing OIDC
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm 10+ is required for Trusted Publishing's OIDC auth — pnpm 9
+      # delegates auth to the bundled npm, which can sign provenance but can't
+      # exchange the OIDC token for a publish credential.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      # Node 24 ships with npm 11+, required for the OIDC token-exchange that
+      # backs Trusted Publishing. Node 22 (npm 10.x) signs provenance fine but
+      # 404s on the publish PUT because it can't mint a publish credential.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @subsquid/pipes build
+
+      # Resolve the version from the tag (pipes-v1.0.0-alpha.14 → 1.0.0-alpha.14)
+      # or manual input. User-controlled values flow through env: — never
+      # interpolated into the run: script.
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF_NAME#pipes-v}"
+          fi
+          # Strict semver-ish validation — reject anything that could smuggle
+          # shell metacharacters into later steps.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid version: $VERSION" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Require the package version to already be committed in source so the
+      # tagged commit is the source of truth for what was published.
+      - name: Verify version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          PACKAGE_VERSION=$(jq -r '.version' packages/subsquid-pipes/package.json)
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "packages/subsquid-pipes/package.json is $PACKAGE_VERSION, expected $VERSION."
+            echo "Bump and commit the version before tagging the release."
+            exit 1
+          fi
+
+      # Prereleases must not land on the default `latest` dist-tag, or a plain
+      # `npm i @subsquid/pipes` would serve an alpha. Derive the channel from
+      # the prerelease identifier: 1.0.0-alpha.14 → alpha, -beta.1 → beta,
+      # -rc.1 → rc; stable X.Y.Z → latest; any other suffix → next.
+      - name: Resolve npm dist-tag
+        id: disttag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # `case` globbing (not grep) so the hyphen test can't be mistaken for
+          # a grep option across grep implementations.
+          case "$VERSION" in
+            *-*)
+              LABEL="${VERSION#*-}"   # strip up to the first dash → alpha.14
+              LABEL="${LABEL%%.*}"    # strip the numeric suffix    → alpha
+              case "$LABEL" in
+                alpha|beta|rc) TAG="$LABEL" ;;
+                *) TAG="next" ;;
+              esac
+              ;;
+            *)
+              TAG="latest"
+              ;;
+          esac
+          echo "Publishing to dist-tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # Auth happens via npm Trusted Publishing (OIDC) — no NPM_TOKEN.
+      # @subsquid/pipes must have a trusted publisher configured on npmjs.com
+      # pointing at this workflow
+      # (subsquid-labs/pipes-sdk → .github/workflows/release-subsquid-pipes.yml).
+      #
+      # DIST_TAG flows through env: (never interpolated into run:) to preserve
+      # the "derived/user values never touch the shell" invariant.
+      - name: Publish @subsquid/pipes
+        env:
+          DIST_TAG: ${{ steps.disttag.outputs.tag }}
+        run: pnpm publish packages/subsquid-pipes --access public --provenance --no-git-checks --tag "$DIST_TAG"
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF_NAME#pipes-v}"
+          fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid version: $VERSION" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=pipes-v$VERSION" >> "$GITHUB_OUTPUT"
+          # A hyphen only appears in the prerelease part (the version regex
+          # keeps it out of the X.Y.Z core), so it cleanly flags alpha/beta/rc.
+          # Prereleases are marked pre-release and kept off the "Latest" slot.
+          case "$VERSION" in
+            *-*)
+              echo "prerelease=true" >> "$GITHUB_OUTPUT"
+              echo "make_latest=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "prerelease=false" >> "$GITHUB_OUTPUT"
+              echo "make_latest=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: '@subsquid/pipes v${{ steps.version.outputs.version }}'
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ steps.version.outputs.prerelease }}
+          make_latest: ${{ steps.version.outputs.make_latest }}


### PR DESCRIPTION
## Summary
Puts the `@subsquid/pipes` release automation on the **default branch (`main`)**, where release workflows belong: `workflow_dispatch` (manual "Run workflow") only works from the default branch, and npm trusted publishing / tag-triggered runs read the workflow from the ref they run on.

- Add `.github/workflows/release-subsquid-pipes.yml`: publishes `@subsquid/pipes` via **npm Trusted Publishing** (OIDC + provenance, no `NPM_TOKEN`), on `pipes-v*` tags or manual dispatch. Jobs: `check` → `publish` → `github-release`.
- **Prerelease support**: `-alpha.N` / `-beta.N` / `-rc.N` → matching npm dist-tags (`@alpha` / `@beta` / `@rc`) instead of `@latest`, flagged as GitHub pre-releases. Stable `X.Y.Z` → `@latest`.
- Add the `subsquid-pipes-release` skill (mirrors `deploy-pipes-cli`).

Same commit already merged into `design/sdk1` via #99; this PR brings the identical files onto `main`.

## Coverage
N/A — only a GitHub Actions workflow and skill markdown; no `packages/subsquid-pipes/src/**` TypeScript touched (`pr-quality-gate` Step 1 / Step 4 N/A).

## Test plan
- Workflow YAML validated (parses; `check → publish → github-release`).
- dist-tag + prerelease derivation unit-tested across `1.0.0`, `2.0.0`, `1.0.0-alpha.14`, `-beta.1`, `-rc.2`, `-beta`, `-canary.3`.
- `pipes-v*` tag → version parsing verified.
- `@subsquid/pipes` has no `workspace:` deps → plain `pnpm publish` won't leak the protocol.

## Note on release branch
`design/sdk1` is ~242 commits ahead of `main`, and the alpha line (`1.0.0-alpha.*`) lives there. Tag-triggered publishing reads the workflow from **the tagged commit**, so:
- Cutting `pipes-v*` tags from `design/sdk1` works today (it has the workflow via #99 + the alpha code).
- Cutting from `main` requires `design/sdk1` to be merged into `main` first (so `main` carries both the workflow and the code being shipped).

## Follow-up
One-time trusted-publisher registration (owner + 2FA + `npm login`):

```sh
npm trust github @subsquid/pipes --file release-subsquid-pipes.yml --repository subsquid-labs/pipes-sdk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
