### PR TITLE
fix(ci): drop duplicate pnpm version in release workflow on main

### DIFF
--- a/.github/workflows/release-subsquid-pipes.yml
+++ b/.github/workflows/release-subsquid-pipes.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` here — the root package.json pins pnpm via the
+      # "packageManager" field (pnpm@10.17.0). Setting both makes
+      # pnpm/action-setup error on the duplicate.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -51,10 +52,10 @@ jobs:
 
       # pnpm 10+ is required for Trusted Publishing's OIDC auth — pnpm 9
       # delegates auth to the bundled npm, which can sign provenance but can't
-      # exchange the OIDC token for a publish credential.
+      # exchange the OIDC token for a publish credential. The version is pinned
+      # by the root package.json "packageManager" field (pnpm@10.17.0) — don't
+      # add a `version:` here or action-setup errors on the duplicate.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       # Node 24 ships with npm 11+, required for the OIDC token-exchange that
       # backs Trusted Publishing. Node 22 (npm 10.x) signs provenance fine but


### PR DESCRIPTION
## Summary
`main` received the release workflow via #100, but that PR merged **before** the pnpm setup bug was fixed on `design/sdk1`. As-is, any run of the workflow on `main` fails immediately:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.17.0 in the package.json with the key "packageManager"
```

This drops the explicit `version:` from both `pnpm/action-setup` steps so it reads the pinned pnpm from the root `packageManager`. Brings `main`'s workflow byte-for-byte in line with the working copy on `design/sdk1` (which just published `@subsquid/pipes@1.0.0-alpha.14` to the `@alpha` tag successfully).

## Coverage
N/A — GitHub Actions workflow only; no `src/**` changes.

## Test plan
- Verified against a real run on `design/sdk1`: `check → publish → github-release` all green, published `1.0.0-alpha.14` to `@alpha` with provenance.

## Heads-up (not fixed here)
`main`'s `packages/subsquid-pipes/package.json` has **no `repository` field**, which `--provenance` requires (else publish fails E422). That field already exists on `design/sdk1` and will reach `main` when `design/sdk1` merges. Until then, releases should be cut from `design/sdk1`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
