### PR TITLE
fix(portal-source): stop double stop() invocation on normal completion

### DIFF
--- a/packages/subsquid-pipes/src/core/portal-source.test.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, expectTypeOf, it } from 'vitest'
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import { createTarget } from '~/core/target.js'
 import { Target } from '~/core/target.js'
-import { TransformerArgs } from '~/core/transformer.js'
+import { TransformerArgs, createTransformer } from '~/core/transformer.js'
 import { evmPortalStream } from '~/evm/index.js'
 import {
   MockPortal,
@@ -474,6 +474,81 @@ describe('Portal abstract stream', () => {
       // Floor is never seeded (only from a real finalized head), so it stays undefined.
       expect(finalizedPerBatch).toEqual([undefined])
     })
+  })
+})
+
+describe('stop lifecycle', () => {
+  let mockPortal: MockPortal
+
+  afterEach(async () => {
+    await mockPortal?.close()
+  })
+
+  it('invokes transformer stop hook exactly once on normal completion', async () => {
+    mockPortal = await createMockPortal([
+      {
+        statusCode: 200,
+        data: [
+          { header: { number: 1, hash: '0x123', timestamp: 1000 } },
+          { header: { number: 2, hash: '0x456', timestamp: 2000 } },
+        ],
+      },
+    ])
+
+    const stopSpy = vi.fn()
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: mockPortal.url,
+      outputs: blockDecoder({ from: 0, to: 2 }),
+    }).pipe(
+      createTransformer({
+        profiler: { name: 'spy' },
+        transform: (data) => data,
+        stop: stopSpy,
+      }),
+    )
+
+    await readAll(stream)
+
+    expect(stopSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs stop hook cleanup when a transformer start hook fails', async () => {
+    mockPortal = await createMockPortal([
+      {
+        statusCode: 200,
+        data: [{ header: { number: 1, hash: '0x123', timestamp: 1000 } }],
+      },
+    ])
+
+    const stopSpy = vi.fn()
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: mockPortal.url,
+      outputs: blockDecoder({ from: 0, to: 1 }),
+    })
+      .pipe(
+        createTransformer({
+          profiler: { name: 'cleanup' },
+          transform: (data) => data,
+          stop: stopSpy,
+        }),
+      )
+      .pipe(
+        createTransformer({
+          profiler: { name: 'boom' },
+          transform: (data) => data,
+          start: () => {
+            throw new Error('start failed')
+          },
+        }),
+      )
+
+    await expect(readAll(stream)).rejects.toThrow('start failed')
+
+    expect(stopSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/subsquid-pipes/src/core/portal-source.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.ts
@@ -290,7 +290,9 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
       }
     }
 
-    await this.stop()
+    // Cleanup is owned by the callers (pipeTo/[Symbol.asyncIterator]), which run stop() in a
+    // finally on every exit path. Calling it here too is what caused the double stop() on normal
+    // completion; the idempotency guard in stop() remains as a safety net.
   }
 
   pipe<Out>(options: TransformerArgs<T, Out>): PortalSource<Q, Out> {
@@ -369,6 +371,11 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
       return
     }
 
+    // Mark the stream as started before invoking user start hooks. If a transformer `start`
+    // hook rejects, the outer finally still calls stop(), and the idempotency guard there must
+    // let cleanup run for the partially-started stream instead of skipping it.
+    this.#started = true
+
     this.#logger.debug(`invoking <start> hook...`)
 
     const profiler = Span.root('start', this.#options.profiler).addLabels('core')
@@ -388,11 +395,14 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
     profiler.end()
 
     this.#logger.debug(`<start> hook invoked`)
-    this.#started = true
   }
 
   /** @internal */
   async stop() {
+    if (!this.#started) {
+      this.#logger.debug(`stream is not started, skipping "stop" hook...`)
+      return
+    }
     this.#started = false
 
     const profiler = Span.root('stop', this.#options.profiler).addLabels('core')


### PR DESCRIPTION
## Summary
- On a normally-completing bounded stream, `PortalSource.stop()` ran **twice**: once at the tail of `read()`, and again from the outer `finally` in `pipeTo()` / `[Symbol.asyncIterator]` (which run `stop()` on every exit path). Non-idempotent user cleanup (`pg.end`, `sqlite.close`, `redis.quit`, `server.close`) would throw on the second call.
- **Root cause fix:** `read()`'s tail `stop()` is redundant because the callers own cleanup, so it's removed.
- **Safety net:** an idempotency guard remains in `stop()`, and the stream is now marked started *before* running start hooks so a partial start failure still cleans up via the outer `finally` (rather than being skipped by the guard).

This supersedes #72 — it drops the unrelated transformer-ID de-duplication change flagged in review and fixes the double-call at its source instead of only guarding against it.

## Coverage

`src/core/portal-source.ts` (via `portal-source.test.ts`):

| Metric | Base | Head | Δ |
|--------|------|------|---|
| Statements | 86.13% | 86.27% | +0.14 |
| Branches | 79.68% | 83.33% | +3.65 |

## Test plan
- [x] `pnpm vitest run src/core/portal-source.test.ts` (18 tests pass)
- [x] New: transformer `stop` hook is invoked exactly once on normal completion (fails without the fix — called twice)
- [x] New: `stop` cleanup still runs when a transformer `start` hook rejects (fails without the early-started guard — called zero times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)