### PR TITLE
feat(parquet): modern column types — TIMESTAMP, DATE, JSON, STRUCT, LIST

### DIFF
--- a/docs/examples/evm/17.parquet.example.ts
+++ b/docs/examples/evm/17.parquet.example.ts
@@ -68,7 +68,11 @@ async function main() {
             blockNumber: { type: 'INT64' },
             logIndex: { type: 'INT32' },
             txIndex: { type: 'INT32' },
-            timestamp: { type: 'TIMESTAMP_MILLIS', optional: true },
+            timestamp: { type: 'TIMESTAMP', optional: true },
+            // The same instant stored as its UTC calendar day (int32) — cheap day-partitioned scans.
+            day: { type: 'DATE', optional: true },
+            // Raw log topics as a Parquet LIST — declare the element type, insert a plain array.
+            topics: { type: 'LIST', element: { type: 'UTF8' } },
             token: { type: 'UTF8' },
             from: { type: 'UTF8' },
             to: { type: 'UTF8' },
@@ -82,7 +86,7 @@ async function main() {
             blockNumber: { type: 'INT64' },
             logIndex: { type: 'INT32' },
             txIndex: { type: 'INT32' },
-            timestamp: { type: 'TIMESTAMP_MILLIS', optional: true },
+            timestamp: { type: 'TIMESTAMP', optional: true },
             token: { type: 'UTF8' },
             owner: { type: 'UTF8' },
             spender: { type: 'UTF8' },
@@ -101,8 +105,9 @@ async function main() {
         ctx.logger.debug(`batch: ${data.transfers.length} transfers, ${data.approvals.length} approvals`)
 
         // Rows are staged per table; the finalized ones flush to the open Parquet writer after
-        // `onData` returns. The JS → Parquet input contract: INT64 ← number/bigint,
-        // TIMESTAMP_MILLIS ← Date (or null for an optional column), UTF8 ← string.
+        // `onData` returns. The JS → Parquet input contract: INT64 ← number/bigint, TIMESTAMP ←
+        // Date (or null for an optional column), DATE ← Date truncated to its UTC day, LIST ←
+        // plain array, UTF8 ← string.
         store.insert(
           'transfers',
           data.transfers.map((t) => ({
@@ -110,6 +115,8 @@ async function main() {
             logIndex: t.rawEvent.logIndex,
             txIndex: t.rawEvent.transactionIndex,
             timestamp: t.timestamp ?? null,
+            day: t.timestamp ?? null,
+            topics: t.rawEvent.topics,
             token: t.rawEvent.address,
             from: t.event.from,
             to: t.event.to,

--- a/packages/subsquid-pipes/MIGRATION.md
+++ b/packages/subsquid-pipes/MIGRATION.md
@@ -366,6 +366,32 @@ Recommended follow-ups:
 
 ---
 
+## 15. Parquet: rename `TIMESTAMP_MILLIS` to `TIMESTAMP`
+
+The Parquet format spec deprecates the `TIMESTAMP_MILLIS` converted type in favor of the `TIMESTAMP` logical type. The column type is renamed accordingly; the old name still works as a deprecated alias and both write byte-identical files (int64 epoch-ms, readable by every Parquet reader as `TIMESTAMP(isAdjustedToUTC=true, unit=MILLIS)`), so existing data needs no migration.
+
+```ts
+// before
+schema: { timestamp: { type: 'TIMESTAMP_MILLIS', optional: true } }
+
+// after
+schema: { timestamp: { type: 'TIMESTAMP', optional: true } }
+```
+
+New column types are also available: `DATE` (int32 days since the Unix epoch), `JSON` (stringified into an annotated BYTE_ARRAY), `STRUCT` (nested groups — insert plain nested objects) and `LIST` (canonical 3-level lists — insert plain arrays):
+
+```ts
+schema: {
+  blockNumber: { type: 'INT64' },
+  day: { type: 'DATE' },
+  meta: { type: 'JSON', optional: true },
+  user: { type: 'STRUCT', fields: { name: { type: 'UTF8' } } },
+  topics: { type: 'LIST', element: { type: 'UTF8' } },
+}
+```
+
+---
+
 ## Quick checklist
 
 - [ ] `evmPortalSource` → `evmPortalStream`
@@ -388,3 +414,4 @@ Recommended follow-ups:
 - [ ] Custom `.build({ transform })` → `.build().pipe()`
 - [ ] `StartState` → `StartEvent`, `ProgressState` → `ProgressEvent`
 - [ ] ClickHouse rollbacks: nothing to do for CollapsingMergeTree tables (optionally call `store.ensureRollbackIndex` in `onStart` on large tables); non-collapsing tables now roll back via `DELETE` (needs ClickHouse ≥ 23.3) and their MVs keep rolled-back data
+- [ ] Parquet schemas: `TIMESTAMP_MILLIS` → `TIMESTAMP` (deprecated alias still accepted; files unchanged)

--- a/packages/subsquid-pipes/src/targets/parquet/errors.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/errors.ts
@@ -25,7 +25,7 @@ export const PQ_ERR = {
   EMPTY_SCHEMA: 'E1203',
   /** Table schema is missing the declared block-number column. */
   BLOCK_COLUMN_MISSING: 'E1204',
-  /** Block-number column is not an integer type (must be INT64/INT32/TIMESTAMP_MILLIS). */
+  /** Block-number column is not an integer type (must be INT64/INT32). */
   BLOCK_COLUMN_TYPE: 'E1205',
   /** A column declared an unsupported compression codec. */
   UNSUPPORTED_COMPRESSION: 'E1206',
@@ -45,4 +45,6 @@ export const PQ_ERR = {
   VALUE_INVALID: 'E1213',
   /** Crash recovery could not delete an over-cursor data file (leaving it would duplicate data). */
   RECOVERY_DELETE_FAILED: 'E1214',
+  /** A nested column declaration is malformed (empty STRUCT fields, LIST without element, over-deep nesting). */
+  NESTED_SCHEMA_INVALID: 'E1215',
 } as const

--- a/packages/subsquid-pipes/src/targets/parquet/index.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/index.ts
@@ -6,5 +6,6 @@ export {
   type ParquetColumn,
   type ParquetColumnType,
   type ParquetColumns,
+  type ParquetLeafType,
   type ParquetTable,
 } from './schema.js'

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-store.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-store.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { ParquetStore } from './parquet-store.js'
+import type { ParquetTable } from './schema.js'
+
+const BLOCKS_TABLE: ParquetTable = {
+  table: 'blocks',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+describe('ParquetStore', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'sqd-parquet-store-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  describe('dev-mode value validation', () => {
+    const bytesTable: ParquetTable = {
+      table: 't',
+      schema: { blockNumber: { type: 'INT64' }, raw: { type: 'BYTE_ARRAY' } },
+    }
+
+    it('rejects a hex string handed to a BYTE_ARRAY column', () => {
+      const store = new ParquetStore({ dir, tables: [bytesTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      expect.assertions(1)
+      try {
+        store.insert('t', [{ blockNumber: 1, raw: '0xdeadbeef' }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+      }
+    })
+
+    it('rejects an INT64 number above 2^53 (precision already lost)', () => {
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      expect.assertions(1)
+      try {
+        store.insert('blocks', [{ blockNumber: 2 ** 53, hash: '0x1', timestamp: 1 }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+      }
+    })
+
+    it('accepts a Buffer for BYTE_ARRAY and a bigint for INT64', () => {
+      const store = new ParquetStore({ dir, tables: [bytesTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      expect(() => store.insert('t', [{ blockNumber: 1n, raw: Buffer.from('deadbeef', 'hex') }])).not.toThrow()
+    })
+
+    const stampsTable: ParquetTable = {
+      table: 'stamps',
+      schema: {
+        blockNumber: { type: 'INT64' },
+        at: { type: 'TIMESTAMP' },
+        day: { type: 'DATE', optional: true },
+        meta: { type: 'JSON', optional: true },
+      },
+    }
+
+    it('accepts Date/epoch-millis TIMESTAMP, Date/integer-days/null DATE and JSON-serializable values', () => {
+      const store = new ParquetStore({ dir, tables: [stampsTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      expect(() =>
+        store.insert('stamps', [
+          {
+            blockNumber: 1,
+            at: new Date('2024-01-01T15:30:00Z'),
+            day: new Date('2024-01-01T15:30:00Z'),
+            meta: { a: [1, 'x'] },
+          },
+          { blockNumber: 2, at: 1704122400000, day: 19723, meta: 'plain string is valid JSON' },
+          { blockNumber: 3, at: new Date('2024-01-01T15:30:00Z'), day: null, meta: null },
+        ]),
+      ).not.toThrow()
+    })
+
+    it('rejects fractional, negative, epoch-millis-magnitude and pre-1970 DATE values', () => {
+      const store = new ParquetStore({ dir, tables: [stampsTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      // 19723.5: not whole days; -1: the library rejects negatives; 1704067200000: epoch millis
+      // passed by mistake (would crash the int32 encoder at flush time); pre-1970 Date: the
+      // library truncates toward zero, landing on the wrong day.
+      const bad = [19723.5, -1, 1704067200000, new Date('1969-12-31T12:00:00Z')]
+      expect.assertions(4)
+      for (const day of bad) {
+        try {
+          store.insert('stamps', [{ blockNumber: 1, at: new Date(0), day }])
+        } catch (e) {
+          expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+        }
+      }
+    })
+
+    it('rejects JSON values the writer cannot serialize (bigint, circular)', () => {
+      const store = new ParquetStore({ dir, tables: [stampsTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      const circular: Record<string, unknown> = {}
+      circular['self'] = circular
+      // The library would crash mid-flush with a context-free "Do not know how to serialize a
+      // BigInt" — the dev check surfaces the table/column instead.
+      const bad = [{ amount: 5n }, circular]
+      expect.assertions(2)
+      for (const meta of bad) {
+        try {
+          store.insert('stamps', [{ blockNumber: 1, at: new Date(0), meta }])
+        } catch (e) {
+          expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+        }
+      }
+    })
+
+    const nestedTable: ParquetTable = {
+      table: 'n',
+      schema: {
+        blockNumber: { type: 'INT64' },
+        user: { type: 'STRUCT', fields: { name: { type: 'UTF8' }, age: { type: 'INT32', optional: true } } },
+        tags: { type: 'LIST', element: { type: 'UTF8' }, optional: true },
+      },
+    }
+
+    it('accepts plain nested objects for STRUCT and plain arrays for LIST', () => {
+      const store = new ParquetStore({ dir, tables: [nestedTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      expect(() =>
+        store.insert('n', [
+          { blockNumber: 1, user: { name: 'alice', age: 30 }, tags: ['a', 'b'] },
+          { blockNumber: 2, user: { name: 'bob', age: null }, tags: [] },
+          { blockNumber: 3, user: { name: 'eve' }, tags: null },
+        ]),
+      ).not.toThrow()
+    })
+
+    it('rejects bad nested values with the offending path in the message', () => {
+      const store = new ParquetStore({ dir, tables: [nestedTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      // [row, expected message fragment]: scalar where a struct object is expected; missing
+      // required nested field; non-array LIST; null element under a required element decl;
+      // wrong element type.
+      const cases: [Record<string, unknown>, RegExp][] = [
+        [{ blockNumber: 1, user: 'oops', tags: null }, /user.*expects a plain object/],
+        [{ blockNumber: 1, user: { age: 1 }, tags: null }, /user\.name.*required/],
+        [{ blockNumber: 1, user: { name: 'a' }, tags: 'x,y' }, /tags.*expects an array/],
+        [{ blockNumber: 1, user: { name: 'a' }, tags: ['ok', null] }, /tags\[1\].*required/],
+        [{ blockNumber: 1, user: { name: 'a' }, tags: [42] }, /tags\[0\].*expects a string/],
+      ]
+      expect.assertions(2 * cases.length)
+      for (const [row, fragment] of cases) {
+        try {
+          store.insert('n', [row])
+        } catch (e) {
+          expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+          expect((e as ParquetTargetError).message).toMatch(fragment)
+        }
+      }
+    })
+
+    it('rejects Map and Set STRUCT values (entries are invisible to property access)', () => {
+      const store = new ParquetStore({ dir, tables: [nestedTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      // The writer shreds structs via `value[field]`, so Map/Set entries read as undefined:
+      // required fields fail with a misleading "required but undefined" and optional fields
+      // silently write null — reject the container itself instead.
+      const cases: unknown[] = [new Map([['name', 'alice']]), new Set(['alice'])]
+      expect.assertions(2 * cases.length)
+      for (const user of cases) {
+        try {
+          store.insert('n', [{ blockNumber: 1, user, tags: null }])
+        } catch (e) {
+          expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
+          expect((e as ParquetTargetError).message).toMatch(/user.*expects a plain object/)
+        }
+      }
+    })
+
+    it('accepts class instances and null-prototype objects for STRUCT', () => {
+      const store = new ParquetStore({ dir, tables: [nestedTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      // Both expose their fields to property access, so they write correctly — the STRUCT
+      // check must not tighten to a prototype test that would reject them.
+      class User {
+        name = 'alice'
+      }
+      const nullProto = Object.assign(Object.create(null), { name: 'bob' })
+
+      expect(() =>
+        store.insert('n', [
+          { blockNumber: 1, user: new User(), tags: null },
+          { blockNumber: 2, user: nullProto, tags: null },
+        ]),
+      ).not.toThrow()
+    })
+  })
+})

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-store.ts
@@ -5,7 +5,16 @@ import { ParquetSchema } from '@dsnp/parquetjs'
 import { type BlockCursor, type Finalization, type FinalizationBuffer, createFinalizationBuffer } from '~/core/index.js'
 
 import { PQ_ERR, ParquetTargetError } from './errors.js'
-import { type Codec, type ParquetColumns, type ParquetTable, blockColumnOf, toParquetSchemaShape } from './schema.js'
+import {
+  type Codec,
+  type ParquetColumn,
+  type ParquetColumns,
+  type ParquetLeafType,
+  type ParquetTable,
+  blockColumnOf,
+  buildRowWrapper,
+  toParquetSchemaShape,
+} from './schema.js'
 import { ParquetSegmentWriter, type PublishedSegment } from './writer.js'
 
 type Row = Record<string, unknown>
@@ -19,6 +28,8 @@ type TableConfig = {
   columns: ParquetColumns
   schema: ParquetSchema
   dir: string
+  /** Rewrites plain-array LIST values into the library's row shape; unset for list-free tables. */
+  wrapRow?: (row: Row) => Row
 }
 
 /** Rotation thresholds checked at each batch boundary. */
@@ -65,6 +76,7 @@ export class ParquetStore {
         columns: table.schema,
         schema: new ParquetSchema(toParquetSchemaShape(table, options.defaultCodec)),
         dir: path.join(options.dir, table.table),
+        wrapRow: buildRowWrapper(table.schema),
       })
       this.#buffers.set(table.table, createFinalizationBuffer<Row>({ getBlockNumber }))
     }
@@ -114,7 +126,7 @@ export class ParquetStore {
       if (released.length > 0) {
         const writer = this.#getOrCreateWriter(table, config)
         for (const row of released) {
-          await writer.appendRow(row, config.getBlockNumber(row))
+          await writer.appendRow(config.wrapRow ? config.wrapRow(row) : row, config.getBlockNumber(row))
         }
         stats.push({ table, rows: released.length })
       }
@@ -231,35 +243,82 @@ function readBlockNumber(table: string, blockColumn: string, row: Row): number {
  * Dev-mode (non-production) check that each cell matches its declared column type, catching silent
  * corruption the Parquet encoder would otherwise wave through — most notably a hex *string* handed
  * to a `BYTE_ARRAY` column (stored as the ASCII bytes of `"0x…"`, not the decoded bytes) and a
- * `number` above 2^53 for an `INT64` column (precision already lost before the write).
+ * `number` above 2^53 for an `INT64` column (precision already lost before the write). Recurses
+ * into STRUCT/LIST declarations so errors carry the offending path — the writer library's own
+ * errors for nested data name a bare field with no table/row context.
  */
 function validateRowValues(table: string, columns: ParquetColumns, row: Row): void {
   for (const [name, column] of Object.entries(columns)) {
-    const value = row[name]
-
-    if (value == null) {
-      if (!column.optional) {
-        throw new ParquetTargetError(
-          PQ_ERR.VALUE_INVALID,
-          `Table '${table}' column '${name}' is required but the row value is ${describe(value)}.`,
-        )
-      }
-
-      continue
-    }
-
-    const problem = checkValueType(column.type, value)
-    if (problem) {
-      throw new ParquetTargetError(
-        PQ_ERR.VALUE_INVALID,
-        `Table '${table}' column '${name}' (declared ${column.type}) ${problem}, got ${describe(value)}.`,
-      )
-    }
+    validateValue(table, name, column, row[name])
   }
 }
 
-/** Returns a human description of why `value` is wrong for `type`, or `undefined` if it is fine. */
-function checkValueType(type: string, value: unknown): string | undefined {
+function validateValue(table: string, path: string, column: ParquetColumn, value: unknown): void {
+  if (value == null) {
+    if (!column.optional) {
+      throw new ParquetTargetError(
+        PQ_ERR.VALUE_INVALID,
+        `Table '${table}' column '${path}' is required but the row value is ${describe(value)}.`,
+      )
+    }
+
+    return
+  }
+
+  if (column.type === 'STRUCT') {
+    // Map/Set are rejected because their entries are invisible to the property access the
+    // writer shreds with (`value[field]`) — required fields would fail as "undefined" and
+    // optional ones silently write null. Class instances stay accepted: their fields ARE
+    // readable as properties, so they write correctly.
+    if (
+      typeof value !== 'object' ||
+      Array.isArray(value) ||
+      value instanceof Date ||
+      value instanceof Uint8Array ||
+      value instanceof Map ||
+      value instanceof Set
+    ) {
+      throw new ParquetTargetError(
+        PQ_ERR.VALUE_INVALID,
+        `Table '${table}' column '${path}' (declared STRUCT) expects a plain object, got ${describe(value)}.`,
+      )
+    }
+    for (const [name, child] of Object.entries(column.fields)) {
+      validateValue(table, `${path}.${name}`, child, (value as Row)[name])
+    }
+
+    return
+  }
+
+  if (column.type === 'LIST') {
+    if (!Array.isArray(value)) {
+      throw new ParquetTargetError(
+        PQ_ERR.VALUE_INVALID,
+        `Table '${table}' column '${path}' (declared LIST) expects an array, got ${describe(value)}.`,
+      )
+    }
+    for (let i = 0; i < value.length; i++) {
+      validateValue(table, `${path}[${i}]`, column.element, value[i])
+    }
+
+    return
+  }
+
+  const problem = checkValueType(column.type, value)
+  if (problem) {
+    throw new ParquetTargetError(
+      PQ_ERR.VALUE_INVALID,
+      `Table '${table}' column '${path}' (declared ${column.type}) ${problem}, got ${describe(value)}.`,
+    )
+  }
+}
+
+/**
+ * Returns a human description of why `value` is wrong for `type`, or `undefined` if it is fine.
+ * Exhaustive over {@link ParquetLeafType} with no `default` on purpose: adding a leaf type
+ * without deciding its dev-mode check here fails to compile (`noImplicitReturns`).
+ */
+function checkValueType(type: ParquetLeafType, value: unknown): string | undefined {
   switch (type) {
     case 'BYTE_ARRAY':
       if (!(value instanceof Uint8Array)) {
@@ -291,11 +350,37 @@ function checkValueType(type: string, value: unknown): string | undefined {
     case 'UTF8':
       return typeof value === 'string' ? undefined : 'expects a string'
 
+    case 'TIMESTAMP':
     case 'TIMESTAMP_MILLIS':
       return value instanceof Date || typeof value === 'number' ? undefined : 'expects a Date or epoch-millis number'
 
-    default:
-      return undefined
+    case 'DATE': {
+      // The writer library divides a Date's epoch-ms by 86,400,000 and the int32 encoder
+      // truncates toward zero — the correct calendar day for 1970+, the *wrong* day before
+      // 1970 — and it rejects negative day numbers outright, so pre-1970 input is refused here.
+      if (value instanceof Date) {
+        return value.getTime() >= 0 ? undefined : 'does not support pre-1970 Dates'
+      }
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        return 'expects a Date or a non-negative integer of whole days since the Unix epoch'
+      }
+
+      return value > INT32_MAX
+        ? 'is out of INT32 range for days since the Unix epoch — this looks like epoch millis; pass a Date instead'
+        : undefined
+    }
+
+    case 'JSON': {
+      // The writer does Buffer.from(JSON.stringify(value)) at flush time; a bigint or circular
+      // reference crashes there without table/column context, and a function/symbol/undefined
+      // stringifies to undefined and crashes Buffer.from. Serialize once here (dev-only) to
+      // fail early with context.
+      try {
+        return JSON.stringify(value) === undefined ? 'expects a JSON-serializable value' : undefined
+      } catch {
+        return 'expects a JSON-serializable value (bigints and circular references are not)'
+      }
+    }
   }
 }
 

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
@@ -19,7 +19,7 @@ import { PQ_ERR, ParquetTargetError } from './errors.js'
 import { ParquetState } from './parquet-state.js'
 import { ParquetStore } from './parquet-store.js'
 import { parquetTarget } from './parquet-target.js'
-import { type ParquetTable, validateTables } from './schema.js'
+import type { ParquetTable } from './schema.js'
 import { ParquetSegmentWriter } from './writer.js'
 
 // ---------------------------------------------------------------------------------------------
@@ -141,92 +141,6 @@ describe('parquetTarget', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  describe('schema validation', () => {
-    it('rejects an empty tables list', () => {
-      expect.assertions(1)
-      try {
-        validateTables([])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.NO_TABLES)
-      }
-    })
-
-    it('rejects a schema missing the block-number column', () => {
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: { hash: { type: 'UTF8' } } }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_MISSING)
-      }
-    })
-
-    it('rejects a non-integer block-number column', () => {
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: { blockNumber: { type: 'UTF8' } } }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
-      }
-    })
-
-    it('rejects duplicate table names', () => {
-      expect.assertions(1)
-      try {
-        validateTables([BLOCKS_TABLE, BLOCKS_TABLE])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.DUPLICATE_TABLE)
-      }
-    })
-
-    it('rejects an empty schema', () => {
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: {} }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.EMPTY_SCHEMA)
-      }
-    })
-
-    it('rejects an unsupported column type', () => {
-      expect.assertions(1)
-      try {
-        validateTables([
-          { table: 't', schema: { blockNumber: { type: 'INT64' }, amount: { type: 'DECIMAL' as never } } },
-        ])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_TYPE)
-      }
-    })
-
-    it('rejects an unsupported compression codec', () => {
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64', compression: 'ZSTD' as never } } }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_COMPRESSION)
-      }
-    })
-
-    it('rejects TIMESTAMP_MILLIS as the block-number column', () => {
-      // A timestamp is epoch-ms, not a block number, so finalization comparisons never release rows.
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: { blockNumber: { type: 'TIMESTAMP_MILLIS' } } }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
-      }
-    })
-
-    it('rejects an optional block-number column', () => {
-      expect.assertions(1)
-      try {
-        validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64', optional: true } } }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_OPTIONAL)
-      }
-    })
-  })
-
   describe('block-number value guard', () => {
     it('fails loudly instead of coercing a null block number to 0, even in production', async () => {
       // Disable the dev-mode value check so the always-on block guard is what trips.
@@ -253,38 +167,6 @@ describe('parquetTarget', () => {
 
       // No bogus block-0 file was published.
       expect(await listDataFiles(dir, 'blocks')).toEqual([])
-    })
-  })
-
-  describe('dev-mode value validation', () => {
-    const bytesTable: ParquetTable = {
-      table: 't',
-      schema: { blockNumber: { type: 'INT64' }, raw: { type: 'BYTE_ARRAY' } },
-    }
-
-    it('rejects a hex string handed to a BYTE_ARRAY column', () => {
-      const store = new ParquetStore({ dir, tables: [bytesTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
-      expect.assertions(1)
-      try {
-        store.insert('t', [{ blockNumber: 1, raw: '0xdeadbeef' }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
-      }
-    })
-
-    it('rejects an INT64 number above 2^53 (precision already lost)', () => {
-      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
-      expect.assertions(1)
-      try {
-        store.insert('blocks', [{ blockNumber: 2 ** 53, hash: '0x1', timestamp: 1 }])
-      } catch (e) {
-        expect((e as ParquetTargetError).code).toBe(PQ_ERR.VALUE_INVALID)
-      }
-    })
-
-    it('accepts a Buffer for BYTE_ARRAY and a bigint for INT64', () => {
-      const store = new ParquetStore({ dir, tables: [bytesTable], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
-      expect(() => store.insert('t', [{ blockNumber: 1n, raw: Buffer.from('deadbeef', 'hex') }])).not.toThrow()
     })
   })
 
@@ -344,6 +226,99 @@ describe('parquetTarget', () => {
       await reader.close()
       expect(typeof raw['blockNumber']).toBe('bigint')
       expect(raw['blockNumber']).toBe(1n)
+    })
+
+    it('round-trips TIMESTAMP, DATE, JSON, STRUCT and LIST columns with the expected footer annotations', async () => {
+      const kitchenSink: ParquetTable = {
+        table: 'sink',
+        schema: {
+          blockNumber: { type: 'INT64' },
+          at: { type: 'TIMESTAMP' },
+          legacyAt: { type: 'TIMESTAMP_MILLIS' },
+          day: { type: 'DATE' },
+          dayNum: { type: 'DATE' },
+          meta: { type: 'JSON', optional: true },
+          user: { type: 'STRUCT', fields: { name: { type: 'UTF8' }, age: { type: 'INT32', optional: true } } },
+          tags: { type: 'LIST', element: { type: 'UTF8', optional: true }, optional: true },
+          xfers: {
+            type: 'LIST',
+            element: { type: 'STRUCT', fields: { to: { type: 'UTF8' }, amt: { type: 'INT64' } } },
+          },
+          matrix: { type: 'LIST', element: { type: 'LIST', element: { type: 'INT32' } } },
+        },
+      }
+      const at = new Date('2024-01-01T15:30:45.123Z')
+
+      mockPortal = await createMockPortal([blocksResponse([1, 2], 2)])
+      await evmPortalStream({ id: 'test', portal: mockPortal.url, outputs: blockDecoder({ from: 0, to: 2 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [kitchenSink],
+          onData: ({ store, data }) => {
+            store.insert(
+              'sink',
+              data.map((b) => ({
+                blockNumber: b.number,
+                at,
+                legacyAt: at,
+                day: at, // non-midnight Date — must land on its UTC calendar day
+                dayNum: 19724, // whole days since epoch = 2024-01-02
+                meta: b.number === 1 ? { fee: 12, keys: ['k1', 'k2'] } : null,
+                user: { name: `user-${b.number}`, age: b.number === 1 ? 30 : null },
+                tags: b.number === 1 ? ['a', null, 'c'] : [],
+                xfers: [{ to: '0xa', amt: 5n }],
+                matrix: [[1, 2], [3]],
+              })),
+            )
+          },
+        }),
+      )
+
+      const [file] = await listDataFiles(dir, 'sink')
+      const reader = await ParquetReader.openFile(path.join(dir, 'sink', file))
+      const cursor = reader.getCursor()
+      const rows: Record<string, unknown>[] = []
+      let raw: Record<string, unknown> | null
+      while ((raw = (await cursor.next()) as Record<string, unknown> | null)) rows.push(raw)
+
+      // Legacy footer annotations (the pinned library never writes the modern LogicalType field;
+      // per the format spec readers map these to the corresponding logical types):
+      // TIMESTAMP_MILLIS=9 for both timestamp spellings, DATE=6, JSON=19, LIST=3 on the outer
+      // list groups; STRUCT groups carry children but no converted_type.
+      const annotations = new Map(reader.metadata!.schema.map((s) => [s.name, s.converted_type] as const))
+      const children = new Map(reader.metadata!.schema.map((s) => [s.name, s.num_children] as const))
+      await reader.close()
+      expect(annotations.get('at')).toBe(9)
+      expect(annotations.get('legacyAt')).toBe(9)
+      expect(annotations.get('day')).toBe(6)
+      expect(annotations.get('dayNum')).toBe(6)
+      expect(annotations.get('meta')).toBe(19)
+      expect(annotations.get('tags')).toBe(3)
+      expect(annotations.get('xfers')).toBe(3)
+      expect(annotations.get('matrix')).toBe(3)
+      expect(annotations.get('user')).toBeNull()
+      expect(Number(children.get('user'))).toBe(2)
+
+      rows.sort((a, b) => Number(a['blockNumber']) - Number(b['blockNumber']))
+      const [r1, r2] = rows
+      expect((r1['at'] as Date).toISOString()).toBe('2024-01-01T15:30:45.123Z')
+      expect((r1['legacyAt'] as Date).toISOString()).toBe('2024-01-01T15:30:45.123Z')
+      expect((r1['day'] as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z')
+      expect((r1['dayNum'] as Date).toISOString()).toBe('2024-01-02T00:00:00.000Z')
+      expect(r1['meta']).toEqual({ fee: 12, keys: ['k1', 'k2'] })
+      expect(r1['user']).toEqual({ name: 'user-1', age: 30 })
+      // This library's reader materializes the canonical layout verbatim: wrapped elements, an
+      // empty list as { list: null } (still distinct from a null column at the definition level).
+      expect(r1['tags']).toEqual({ list: [{ element: 'a' }, { element: null }, { element: 'c' }] })
+      expect(r1['xfers']).toEqual({ list: [{ element: { to: '0xa', amt: 5n } }] })
+      // Nested lists round-trip with each level in the canonical wrapped shape.
+      expect(r1['matrix']).toEqual({
+        list: [{ element: { list: [{ element: 1 }, { element: 2 }] } }, { element: { list: [{ element: 3 }] } }],
+      })
+
+      expect(r2['meta']).toBeNull()
+      expect(r2['user']).toEqual({ name: 'user-2', age: null })
+      expect(r2['tags']).toEqual({ list: null })
     })
   })
 

--- a/packages/subsquid-pipes/src/targets/parquet/schema.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/schema.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest'
+
+import { PQ_ERR, ParquetTargetError } from './errors.js'
+import { type ParquetTable, buildRowWrapper, toParquetSchemaShape, validateTables } from './schema.js'
+
+const BLOCKS_TABLE: ParquetTable = {
+  table: 'blocks',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+describe('schema validation', () => {
+  it('rejects an empty tables list', () => {
+    expect.assertions(1)
+    try {
+      validateTables([])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.NO_TABLES)
+    }
+  })
+
+  it('rejects a schema missing the block-number column', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { hash: { type: 'UTF8' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_MISSING)
+    }
+  })
+
+  it('rejects a non-integer block-number column', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'UTF8' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+    }
+  })
+
+  it('rejects duplicate table names', () => {
+    expect.assertions(1)
+    try {
+      validateTables([BLOCKS_TABLE, BLOCKS_TABLE])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.DUPLICATE_TABLE)
+    }
+  })
+
+  it('rejects an empty schema', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: {} }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.EMPTY_SCHEMA)
+    }
+  })
+
+  it('rejects an unsupported column type', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64' }, amount: { type: 'DECIMAL' as never } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_TYPE)
+    }
+  })
+
+  it('rejects an unsupported compression codec', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64', compression: 'ZSTD' as never } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.UNSUPPORTED_COMPRESSION)
+    }
+  })
+
+  it('rejects TIMESTAMP_MILLIS as the block-number column', () => {
+    // A timestamp is epoch-ms, not a block number, so finalization comparisons never release rows.
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'TIMESTAMP_MILLIS' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+    }
+  })
+
+  it('accepts TIMESTAMP, DATE, JSON and the deprecated TIMESTAMP_MILLIS alias as column types', () => {
+    expect(() =>
+      validateTables([
+        {
+          table: 't',
+          schema: {
+            blockNumber: { type: 'INT64' },
+            at: { type: 'TIMESTAMP' },
+            day: { type: 'DATE' },
+            meta: { type: 'JSON', optional: true },
+            legacyAt: { type: 'TIMESTAMP_MILLIS' },
+          },
+        },
+      ]),
+    ).not.toThrow()
+  })
+
+  it('rejects TIMESTAMP as the block-number column', () => {
+    // Epoch-ms, not a block number — same trap as the legacy TIMESTAMP_MILLIS alias.
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'TIMESTAMP' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+    }
+  })
+
+  it('rejects DATE as the block-number column', () => {
+    // Days-since-epoch, not a block number — finalization comparisons would never release rows.
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'DATE' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+    }
+  })
+
+  it('rejects JSON as the block-number column', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'JSON' } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+    }
+  })
+
+  it('rejects an optional block-number column', () => {
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64', optional: true } } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_OPTIONAL)
+    }
+  })
+
+  it('accepts STRUCT and LIST columns, nested arbitrarily', () => {
+    expect(() =>
+      validateTables([
+        {
+          table: 't',
+          schema: {
+            blockNumber: { type: 'INT64' },
+            user: { type: 'STRUCT', fields: { name: { type: 'UTF8' }, age: { type: 'INT32', optional: true } } },
+            tags: { type: 'LIST', element: { type: 'UTF8', optional: true }, optional: true },
+            xfers: {
+              type: 'LIST',
+              element: { type: 'STRUCT', fields: { to: { type: 'UTF8' }, amt: { type: 'INT64' } } },
+            },
+            wrapped: { type: 'STRUCT', fields: { inner: { type: 'LIST', element: { type: 'INT32' } } } },
+          },
+        },
+      ]),
+    ).not.toThrow()
+  })
+
+  it('rejects STRUCT and LIST as the block-number column', () => {
+    expect.assertions(2)
+    for (const decl of [
+      { type: 'STRUCT', fields: { x: { type: 'INT64' } } },
+      { type: 'LIST', element: { type: 'INT64' } },
+    ] as const) {
+      try {
+        validateTables([{ table: 't', schema: { blockNumber: decl as never } }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.BLOCK_COLUMN_TYPE)
+      }
+    }
+  })
+
+  it('rejects malformed nested declarations (empty STRUCT, LIST without element, bad nested leaf)', () => {
+    expect.assertions(3)
+    // Plain-JS configs can be malformed in ways TS would reject — validate at runtime.
+    const cases: { schema: Record<string, unknown>; code: string }[] = [
+      {
+        schema: { blockNumber: { type: 'INT64' }, u: { type: 'STRUCT', fields: {} } },
+        code: PQ_ERR.NESTED_SCHEMA_INVALID,
+      },
+      { schema: { blockNumber: { type: 'INT64' }, l: { type: 'LIST' } }, code: PQ_ERR.NESTED_SCHEMA_INVALID },
+      {
+        schema: { blockNumber: { type: 'INT64' }, u: { type: 'STRUCT', fields: { d: { type: 'DECIMAL' } } } },
+        code: PQ_ERR.UNSUPPORTED_TYPE,
+      },
+    ]
+    for (const { schema, code } of cases) {
+      try {
+        validateTables([{ table: 't', schema: schema as never }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(code)
+      }
+    }
+  })
+
+  it('rejects nullish and non-object column declarations with table/path context', () => {
+    // Without a shape guard these crash reading `column.type` on null/undefined — a bare
+    // TypeError with no error code, table name or column path.
+    const cases: { schema: Record<string, unknown>; at: string }[] = [
+      { schema: { blockNumber: { type: 'INT64' }, bad: null }, at: 'bad' },
+      { schema: { blockNumber: { type: 'INT64' }, u: { type: 'STRUCT', fields: { bad: null } } }, at: 'u.bad' },
+      { schema: { blockNumber: { type: 'INT64' }, u: { type: 'STRUCT', fields: { bad: undefined } } }, at: 'u.bad' },
+      { schema: { blockNumber: { type: 'INT64' }, l: { type: 'LIST', element: 'INT64' } }, at: 'l[]' },
+    ]
+    expect.assertions(2 * cases.length)
+    for (const { schema, at } of cases) {
+      try {
+        validateTables([{ table: 't', schema: schema as never }])
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PQ_ERR.NESTED_SCHEMA_INVALID)
+        expect((e as ParquetTargetError).message).toContain(`'${at}'`)
+      }
+    }
+  })
+
+  it('rejects schemas nested beyond the depth cap (cyclic declarations)', () => {
+    // A cyclic JS schema object would recurse forever without the depth cap.
+    const cyclic: Record<string, unknown> = { type: 'STRUCT' }
+    cyclic['fields'] = { self: cyclic }
+
+    expect.assertions(1)
+    try {
+      validateTables([{ table: 't', schema: { blockNumber: { type: 'INT64' }, u: cyclic as never } }])
+    } catch (e) {
+      expect((e as ParquetTargetError).code).toBe(PQ_ERR.NESTED_SCHEMA_INVALID)
+    }
+  })
+})
+
+describe('schema translation', () => {
+  it('emits the canonical 3-level LIST shape and maps TIMESTAMP to the library name', () => {
+    const table: ParquetTable = {
+      table: 't',
+      schema: {
+        blockNumber: { type: 'INT64' },
+        at: { type: 'TIMESTAMP' },
+        tags: { type: 'LIST', element: { type: 'UTF8', optional: true }, optional: true },
+        user: { type: 'STRUCT', fields: { name: { type: 'UTF8' } } },
+      },
+    }
+
+    expect(toParquetSchemaShape(table, 'SNAPPY')).toEqual({
+      blockNumber: { type: 'INT64', optional: false, compression: 'SNAPPY' },
+      at: { type: 'TIMESTAMP_MILLIS', optional: false, compression: 'SNAPPY' },
+      tags: {
+        type: 'LIST',
+        optional: true,
+        fields: {
+          list: {
+            repeated: true,
+            fields: { element: { type: 'UTF8', optional: true, compression: 'SNAPPY' } },
+          },
+        },
+      },
+      user: {
+        optional: false,
+        fields: { name: { type: 'UTF8', optional: false, compression: 'SNAPPY' } },
+      },
+    })
+  })
+})
+
+describe('list row wrapping', () => {
+  it('returns undefined for schemas without lists (zero-cost path)', () => {
+    expect(buildRowWrapper(BLOCKS_TABLE.schema)).toBeUndefined()
+    expect(
+      buildRowWrapper({
+        blockNumber: { type: 'INT64' },
+        user: { type: 'STRUCT', fields: { name: { type: 'UTF8' } } },
+      }),
+    ).toBeUndefined()
+  })
+
+  it('wraps plain arrays into { list: [{ element }] }, recursing into structs and nested lists', () => {
+    const wrap = buildRowWrapper({
+      blockNumber: { type: 'INT64' },
+      tags: { type: 'LIST', element: { type: 'UTF8', optional: true }, optional: true },
+      xfers: { type: 'LIST', element: { type: 'STRUCT', fields: { to: { type: 'UTF8' } } } },
+      wrapped: {
+        type: 'STRUCT',
+        fields: { inner: { type: 'LIST', element: { type: 'INT32' } }, keep: { type: 'INT32' } },
+      },
+    })!
+
+    const row = {
+      blockNumber: 1,
+      tags: ['a', null],
+      xfers: [{ to: '0xa' }],
+      wrapped: { inner: [7], keep: 3 },
+    }
+    expect(wrap(row)).toEqual({
+      blockNumber: 1,
+      tags: { list: [{ element: 'a' }, { element: null }] },
+      xfers: { list: [{ element: { to: '0xa' } }] },
+      wrapped: { inner: { list: [{ element: 7 }] }, keep: 3 },
+    })
+    // The input row must not be mutated — its objects belong to the caller.
+    expect(row.tags).toEqual(['a', null])
+    expect(row.wrapped).toEqual({ inner: [7], keep: 3 })
+  })
+
+  it('passes null/empty lists through in the shapes the writer expects', () => {
+    const wrap = buildRowWrapper({
+      blockNumber: { type: 'INT64' },
+      tags: { type: 'LIST', element: { type: 'UTF8' }, optional: true },
+    })!
+
+    expect(wrap({ blockNumber: 1, tags: null })).toEqual({ blockNumber: 1, tags: null })
+    expect(wrap({ blockNumber: 1, tags: [] })).toEqual({ blockNumber: 1, tags: { list: [] } })
+  })
+})

--- a/packages/subsquid-pipes/src/targets/parquet/schema.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/schema.ts
@@ -8,32 +8,83 @@ import { PQ_ERR, ParquetTargetError } from './errors.js'
 export type Codec = 'UNCOMPRESSED' | 'SNAPPY' | 'GZIP' | 'BROTLI'
 
 /**
- * Parquet primitive/logical types exposed by this target. This is our own union — the public
- * API carries **no compile-time dependency** on `@dsnp/parquetjs` types; the strings are
- * translated to the library's `ParquetSchema` internally by the writer.
+ * Parquet leaf (primitive/logical) column types exposed by this target. This is our own union —
+ * the public API carries **no compile-time dependency** on `@dsnp/parquetjs` types; the strings
+ * are translated to the library's `ParquetSchema` internally (see {@link toParquetSchemaShape}).
  *
  * JS → Parquet input contract (what `onData` must put in each row), per the Step 0 spike:
- * - `INT64`            ← `number` **or** `bigint` (reads back as `bigint`)
- * - `INT32`            ← `number`
- * - `DOUBLE`           ← `number`
- * - `BOOLEAN`          ← `boolean`
- * - `UTF8`             ← `string` (store hashes/addresses here for human-readable columns)
- * - `BYTE_ARRAY`       ← `Buffer` / `Uint8Array` (a hex string must be `Buffer.from(hex, 'hex')`)
- * - `TIMESTAMP_MILLIS` ← `Date` **or** `number` (epoch millis; reads back as `Date`)
+ * - `INT64`      ← `number` **or** `bigint` (reads back as `bigint`)
+ * - `INT32`      ← `number`
+ * - `DOUBLE`     ← `number`
+ * - `BOOLEAN`    ← `boolean`
+ * - `UTF8`       ← `string` (store hashes/addresses here for human-readable columns)
+ * - `BYTE_ARRAY` ← `Buffer` / `Uint8Array` (a hex string must be `Buffer.from(hex, 'hex')`)
+ * - `TIMESTAMP`  ← `Date` **or** `number` (epoch millis; reads back as `Date`)
+ * - `DATE`       ← `Date` (stored as its UTC calendar day, 1970+ only) **or** `number` (whole
+ *                  days since the Unix epoch, ≥ 0; reads back as `Date` at UTC midnight)
+ * - `JSON`       ← any `JSON.stringify`-able value (plain objects/arrays/strings/numbers —
+ *                  **not** `bigint`; reads back parsed)
  * - any column with `optional: true` may also be `null` / `undefined`
+ *
+ * On the wire (verified by spike against the pinned writer library) `TIMESTAMP` is an `int64`
+ * annotated with the legacy `TIMESTAMP_MILLIS` converted type, `DATE` an `int32` annotated
+ * `DATE`, and `JSON` a `BYTE_ARRAY` annotated `JSON` — the library predates the modern
+ * LogicalType footer field, and the format spec's backward-compatibility rules make readers
+ * interpret these as `TIMESTAMP(isAdjustedToUTC = true, unit = MILLIS)`, `DATE` and `JSON`
+ * logical types respectively.
  *
  * `DECIMAL` is intentionally unsupported — use `UTF8` or a scaled `INT64` instead.
  */
-export type ParquetColumnType = 'INT64' | 'INT32' | 'UTF8' | 'BYTE_ARRAY' | 'BOOLEAN' | 'DOUBLE' | 'TIMESTAMP_MILLIS'
+export type ParquetLeafType =
+  | 'INT64'
+  | 'INT32'
+  | 'UTF8'
+  | 'BYTE_ARRAY'
+  | 'BOOLEAN'
+  | 'DOUBLE'
+  | 'TIMESTAMP'
+  | 'DATE'
+  | 'JSON'
+  /** @deprecated Legacy converted-type name — use `'TIMESTAMP'` instead (identical wire format). */
+  | 'TIMESTAMP_MILLIS'
 
-/** Declaration for a single Parquet column. */
-export type ParquetColumn = {
-  type: ParquetColumnType
-  /** Allow `null`/`undefined` for this column. Defaults to `false` (required). */
-  optional?: boolean
-  /** Per-column compression codec. Defaults to the target's `settings.compression` (`'SNAPPY'`). */
-  compression?: Codec
-}
+/** Every string accepted in a column's `type` field, including the nested kinds. */
+export type ParquetColumnType = ParquetLeafType | 'LIST' | 'STRUCT'
+
+/**
+ * Leaf type strings as `@dsnp/parquetjs` expects them: the public union minus `'TIMESTAMP'`,
+ * which the pinned library only knows by its legacy `TIMESTAMP_MILLIS` name.
+ */
+export type LibraryLeafType = Exclude<ParquetLeafType, 'TIMESTAMP'>
+
+/**
+ * Declaration for a single Parquet column: a leaf, a `LIST` (spec-canonical 3-level layout;
+ * rows carry a plain JS array) or a `STRUCT` group (rows carry a plain nested object).
+ * `LIST` and `STRUCT` nest arbitrarily; `compression` applies to leaves only (groups are
+ * structural and carry no data pages).
+ */
+export type ParquetColumn =
+  | {
+      type: ParquetLeafType
+      /** Allow `null`/`undefined` for this column. Defaults to `false` (required). */
+      optional?: boolean
+      /** Per-column compression codec. Defaults to the target's `settings.compression` (`'SNAPPY'`). */
+      compression?: Codec
+    }
+  | {
+      type: 'LIST'
+      /** Declaration of the list's element (a leaf, STRUCT, or another LIST). */
+      element: ParquetColumn
+      /** Allow `null`/`undefined` for the whole list. An empty array is always allowed. */
+      optional?: boolean
+    }
+  | {
+      type: 'STRUCT'
+      /** Nested field declarations. Must be non-empty. */
+      fields: ParquetColumns
+      /** Allow `null`/`undefined` for the whole group. */
+      optional?: boolean
+    }
 
 /** Map of column name → column declaration. */
 export type ParquetColumns = Record<string, ParquetColumn>
@@ -52,27 +103,50 @@ export type ParquetTable = {
   blockNumberColumn?: string
 }
 
-/** The library-shaped schema object (our type) handed to `new ParquetSchema(...)` by the writer. */
-export type ParquetSchemaShape = Record<string, { type: ParquetColumnType; optional: boolean; compression: Codec }>
+/**
+ * The library-shaped schema tree (our type) handed to `new ParquetSchema(...)` by the writer.
+ * Groups have `fields` (and `type: 'LIST'` for list annotations); leaves have a `type` and
+ * `compression`; the `list`/`element` inner nodes of a LIST follow the canonical 3-level
+ * layout the Parquet spec mandates for list annotations.
+ */
+export type ParquetFieldShape = {
+  type?: LibraryLeafType | 'LIST'
+  optional?: boolean
+  repeated?: boolean
+  compression?: Codec
+  fields?: Record<string, ParquetFieldShape>
+}
+
+export type ParquetSchemaShape = Record<string, ParquetFieldShape>
 
 export const DEFAULT_BLOCK_COLUMN = 'blockNumber'
 export const DEFAULT_CODEC: Codec = 'SNAPPY'
 
 const SUPPORTED_CODECS = new Set<string>(['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'BROTLI'])
-const SUPPORTED_TYPES = new Set<string>([
-  'INT64',
-  'INT32',
-  'UTF8',
-  'BYTE_ARRAY',
-  'BOOLEAN',
-  'DOUBLE',
-  'TIMESTAMP_MILLIS',
-])
+
+// Public → library leaf type names. Single source of truth for which leaf types are supported:
+// validation checks membership of its keys, and `toParquetSchemaShape` applies the mapping.
+const LIBRARY_TYPE: Record<ParquetLeafType, LibraryLeafType> = {
+  INT64: 'INT64',
+  INT32: 'INT32',
+  UTF8: 'UTF8',
+  BYTE_ARRAY: 'BYTE_ARRAY',
+  BOOLEAN: 'BOOLEAN',
+  DOUBLE: 'DOUBLE',
+  TIMESTAMP: 'TIMESTAMP_MILLIS',
+  DATE: 'DATE',
+  JSON: 'JSON',
+  TIMESTAMP_MILLIS: 'TIMESTAMP_MILLIS',
+}
+
+const SUPPORTED_TYPES = new Set<string>(Object.keys(LIBRARY_TYPE))
+
 // The block column's value is compared directly against the portal's finalized block NUMBER
 // (`Number(row[col]) <= finalized.number`) and used for `<min>-<max>` file naming and the
-// `maxBlock > cursor` recovery check, so it must hold the block number itself. TIMESTAMP_MILLIS
-// is int64-backed but carries epoch-ms, not a block number — comparing ~1.7e12 against a block
-// number is always false, so no row ever finalizes (silent loss). It is therefore excluded.
+// `maxBlock > cursor` recovery check, so it must hold the block number itself. TIMESTAMP (and
+// its TIMESTAMP_MILLIS alias) is int64-backed but carries epoch-ms, and DATE is int32-backed
+// but carries days-since-epoch — comparing either against a block number silently never (or
+// always) finalizes, so both are excluded, as is everything non-numeric.
 const INTEGER_BLOCK_TYPES = new Set<ParquetColumnType>(['INT64', 'INT32'])
 
 /** The block-number column name for a table, applying the default. */
@@ -122,20 +196,7 @@ export function validateTable(table: ParquetTable): void {
   }
 
   for (const [name, column] of columns) {
-    if (!SUPPORTED_TYPES.has(column.type)) {
-      throw new ParquetTargetError(
-        PQ_ERR.UNSUPPORTED_TYPE,
-        `parquetTarget: table '${table.table}' column '${name}' has unsupported type '${column.type}'. ` +
-          `Supported types: ${[...SUPPORTED_TYPES].join(', ')}.`,
-      )
-    }
-    if (column.compression && !SUPPORTED_CODECS.has(column.compression)) {
-      throw new ParquetTargetError(
-        PQ_ERR.UNSUPPORTED_COMPRESSION,
-        `parquetTarget: table '${table.table}' column '${name}' declares unsupported compression ` +
-          `'${column.compression}'. Supported codecs: ${[...SUPPORTED_CODECS].join(', ')}.`,
-      )
-    }
+    validateColumn(table.table, name, column, 0)
   }
 
   const blockColumn = blockColumnOf(table)
@@ -166,19 +227,164 @@ export function validateTable(table: ParquetTable): void {
   }
 }
 
+// Deep nesting is legal in Parquet, but a runaway/cyclic JS config would recurse forever —
+// cap well above any sane schema.
+const MAX_NESTING_DEPTH = 32
+
+/** Recursively validates one column declaration (leaf, LIST or STRUCT) at `path`. */
+function validateColumn(table: string, path: string, column: ParquetColumn, depth: number): void {
+  if (depth > MAX_NESTING_DEPTH) {
+    throw new ParquetTargetError(
+      PQ_ERR.NESTED_SCHEMA_INVALID,
+      `parquetTarget: table '${table}' column '${path}' exceeds ${MAX_NESTING_DEPTH} nesting levels — ` +
+        `is the schema object cyclic?`,
+    )
+  }
+
+  // A nullish or primitive declaration (possible in plain-JS configs) would otherwise crash
+  // on `column.type` below with a context-free TypeError.
+  if (column == null || typeof column !== 'object') {
+    throw new ParquetTargetError(
+      PQ_ERR.NESTED_SCHEMA_INVALID,
+      `parquetTarget: table '${table}' column '${path}' declaration must be an object like ` +
+        `{ type: 'INT64' }, got ${typeof column === 'string' ? `'${column}'` : String(column)}.`,
+    )
+  }
+
+  if (column.type === 'STRUCT') {
+    const fields = Object.entries(column.fields ?? {})
+    if (fields.length === 0) {
+      throw new ParquetTargetError(
+        PQ_ERR.NESTED_SCHEMA_INVALID,
+        `parquetTarget: table '${table}' STRUCT column '${path}' must declare at least one field.`,
+      )
+    }
+    for (const [name, child] of fields) {
+      validateColumn(table, `${path}.${name}`, child, depth + 1)
+    }
+
+    return
+  }
+
+  if (column.type === 'LIST') {
+    if (!column.element) {
+      throw new ParquetTargetError(
+        PQ_ERR.NESTED_SCHEMA_INVALID,
+        `parquetTarget: table '${table}' LIST column '${path}' must declare an 'element'.`,
+      )
+    }
+    validateColumn(table, `${path}[]`, column.element, depth + 1)
+
+    return
+  }
+
+  if (!SUPPORTED_TYPES.has(column.type)) {
+    throw new ParquetTargetError(
+      PQ_ERR.UNSUPPORTED_TYPE,
+      `parquetTarget: table '${table}' column '${path}' has unsupported type '${column.type}'. ` +
+        `Supported leaf types: ${[...SUPPORTED_TYPES].join(', ')}, plus 'LIST' and 'STRUCT'.`,
+    )
+  }
+  if (column.compression && !SUPPORTED_CODECS.has(column.compression)) {
+    throw new ParquetTargetError(
+      PQ_ERR.UNSUPPORTED_COMPRESSION,
+      `parquetTarget: table '${table}' column '${path}' declares unsupported compression ` +
+        `'${column.compression}'. Supported codecs: ${[...SUPPORTED_CODECS].join(', ')}.`,
+    )
+  }
+}
+
 /**
- * Translates a validated {@link ParquetTable} schema into the library-shaped object handed to
- * `new ParquetSchema(...)`, filling in the per-column compression default.
+ * Translates a validated {@link ParquetTable} schema into the library-shaped tree handed to
+ * `new ParquetSchema(...)`, filling in the per-leaf compression default. LIST columns expand
+ * to the spec-canonical 3-level layout (`LIST` group → repeated `list` → `element`), which is
+ * why rows must be wrapped before writing (see {@link buildRowWrapper}).
  */
 export function toParquetSchemaShape(table: ParquetTable, defaultCodec: Codec): ParquetSchemaShape {
   const shape: ParquetSchemaShape = {}
   for (const [name, column] of Object.entries(table.schema)) {
-    shape[name] = {
-      type: column.type,
-      optional: column.optional ?? false,
-      compression: column.compression ?? defaultCodec,
-    }
+    shape[name] = toFieldShape(column, defaultCodec)
   }
 
   return shape
+}
+
+function toFieldShape(column: ParquetColumn, defaultCodec: Codec): ParquetFieldShape {
+  if (column.type === 'STRUCT') {
+    const fields: Record<string, ParquetFieldShape> = {}
+    for (const [name, child] of Object.entries(column.fields)) {
+      fields[name] = toFieldShape(child, defaultCodec)
+    }
+
+    return { optional: column.optional ?? false, fields }
+  }
+
+  if (column.type === 'LIST') {
+    return {
+      type: 'LIST',
+      optional: column.optional ?? false,
+      fields: {
+        list: {
+          repeated: true,
+          fields: { element: toFieldShape(column.element, defaultCodec) },
+        },
+      },
+    }
+  }
+
+  return {
+    type: LIBRARY_TYPE[column.type],
+    optional: column.optional ?? false,
+    compression: column.compression ?? defaultCodec,
+  }
+}
+
+type Row = Record<string, unknown>
+
+/**
+ * {@link toParquetSchemaShape} expands every LIST to the spec-canonical 3-level layout, so the
+ * rows handed to the writer must nest list values as `{ list: [{ element: v }] }` — a plain JS
+ * array is rejected by the library ("too many values for field"). Rather than leak that shape
+ * into `onData`, rows keep plain arrays and this wrapper (compiled once per table) rewrites them
+ * right before the write. Returns `undefined` when the schema declares no LIST anywhere, so
+ * list-free tables keep the zero-copy path.
+ */
+export function buildRowWrapper(columns: ParquetColumns): ((row: Row) => Row) | undefined {
+  const wrappers = new Map<string, (value: unknown) => unknown>()
+  for (const [name, column] of Object.entries(columns)) {
+    const wrap = buildValueWrapper(column)
+    if (wrap) wrappers.set(name, wrap)
+  }
+  if (wrappers.size === 0) return undefined
+
+  return (row) => {
+    const out: Row = { ...row }
+    for (const [name, wrap] of wrappers) {
+      const value = out[name]
+      if (value != null) out[name] = wrap(value)
+    }
+
+    return out
+  }
+}
+
+/** Wrapper for one declaration's values, or `undefined` if its subtree contains no LIST. */
+function buildValueWrapper(column: ParquetColumn): ((value: unknown) => unknown) | undefined {
+  if (column.type === 'LIST') {
+    const wrapElement = buildValueWrapper(column.element)
+
+    return (value) => ({
+      list: (value as unknown[]).map((element) =>
+        element != null && wrapElement ? { element: wrapElement(element) } : { element },
+      ),
+    })
+  }
+
+  if (column.type === 'STRUCT') {
+    const inner = buildRowWrapper(column.fields)
+
+    return inner ? (value) => inner(value as Row) : undefined
+  }
+
+  return undefined
 }


### PR DESCRIPTION
## Summary

- Replace the deprecated `TIMESTAMP_MILLIS` column-type name with canonical `TIMESTAMP` — the old name remains a **deprecated alias** (it shipped in `1.0.0-alpha.15`) and both write byte-identical files (int64 epoch-ms annotated with legacy ConvertedType `TIMESTAMP_MILLIS`, which the Parquet spec's backward-compat rules define as `TIMESTAMP(isAdjustedToUTC=true, unit=MILLIS)`).
- New leaf types: **`DATE`** (int32 days since the Unix epoch; accepts a 1970+ `Date` or a whole-day number) and **`JSON`** (value stringified into an annotated BYTE_ARRAY; reads back parsed).
- New nested types: **`STRUCT`** (nested groups — rows carry plain nested objects) and **`LIST`** (spec-canonical 3-level layout — rows carry plain JS arrays; a per-table precompiled wrapper rewrites them into the library's `{ list: [{ element }] }` shape at write time, with zero cost for list-free tables).
- `ParquetColumn` is now a discriminated union (leaf | LIST | STRUCT), recursively validated (new error `E1215`, depth-capped) and recursively translated to the writer library's schema shape. The public API keeps **no compile-time dependency** on `@dsnp/parquetjs`.
- Dev-mode row validation recurses with dotted-path context (`user.name`, `tags[2]`) — the writer library's own errors for nested data are context-free. DATE/JSON checks fence the library's silent foot-guns (pre-1970 `Date` truncation, epoch-millis passed as days, bigint/circular JSON).
- End-to-end round-trip test pins the footer annotations (`TIMESTAMP_MILLIS`=9 for both spellings, `DATE`=6, `JSON`=19, `LIST`=3) and read-back values, including LIST-of-LIST.
- Docs: EVM parquet example showcases the new types; `MIGRATION.md` §15 documents the rename (existing files need no migration) and the new types.

Existing flat column declarations remain source-compatible; no wire-format change for existing data.

## Coverage diff (base `ea6b252` → head, `src/targets/parquet/`; base measured over `parquet-target.test.ts`, head over the split `parquet-target` / `parquet-store` / `schema` test files)

| File | Lines (base → head) | Branches (base → head) |
|---|---|---|
| errors.ts | 100% (22/22) → 100% (23/23) | 100% (1/1) → 100% (1/1) |
| fs-durable.ts | 93.02% → 93.02% | 88.88% → 88.88% |
| index.ts | 100% → 100% | 100% → 100% |
| parquet-state.ts | 98.24% → 98.24% | 86.48% → 86.48% |
| parquet-store.ts | 92.17% (165/179) → 98.26% (226/230) | 78.08% (57/73) → 88.98% (105/118) |
| parquet-target.ts | 98.27% → 98.27% | 88.63% → 88.63% |
| schema.ts | 100% (91/91) → 100% (188/188) | 100% (24/24) → 98.63% (72/73) |
| writer.ts | 90.38% → 90.38% | 89.28% → 89.28% |
| **total** | **95.38% (641/672) → 97.44% (800/821)** | **86.11% (186/216) → 90.96% (282/310)** |

## Test plan

- 61/61 parquet tests green (21 new), TDD per task with red/green evidence; the pure unit suites are split into colocated `schema.test.ts` and `parquet-store.test.ts` per the tests-next-to-source convention, keeping `parquet-target.test.ts` pipeline-level
- `tsc --noEmit` clean; `pnpm build` green (turbo builds the package and type-checks every docs example against it); changed files biome-clean
- All new tests use the internal testing framework (`createMockPortal` + tmpdir; no ad-hoc HTTP mocks; cleanup in the existing `afterEach`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

