### PR TITLE
UI: finish exemplar→preview rename in the dashboard

### DIFF
--- a/packages/pipe-ui/app/dashboard/pipeline.tsx
+++ b/packages/pipe-ui/app/dashboard/pipeline.tsx
@@ -12,8 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { humanBytes } from '~/dashboard/formatters'
 import { PipelineDisconnected } from '~/dashboard/pipeline-disconnected'
 import { Profiler } from '~/dashboard/profiler'
-import { QueryExemplar } from '~/dashboard/query-exemplar'
-import { TransformationExemplar } from '~/dashboard/transformation-exemplar'
+import { QueryPreview } from '~/dashboard/query-preview'
+import { TransformationPreview } from '~/dashboard/transformation-preview'
 import { PipeStatus, useStats } from '~/hooks/use-metrics'
 import { useServerIndex } from '~/hooks/use-server-context'
 import { useUrlParam } from '~/hooks/use-url-param'
@@ -100,10 +100,10 @@ export function Pipeline({ pipeId }: { pipeId: string }) {
             <Profiler pipeId={pipeId} />
           </TabsContent>
           <TabsContent value="data-flow">
-            <TransformationExemplar pipeId={pipeId} />
+            <TransformationPreview pipeId={pipeId} />
           </TabsContent>
           <TabsContent value="query">
-            <QueryExemplar pipeId={pipeId} />
+            <QueryPreview pipeId={pipeId} />
           </TabsContent>
         </Tabs>
 

--- a/packages/pipe-ui/app/dashboard/query-preview.tsx
+++ b/packages/pipe-ui/app/dashboard/query-preview.tsx
@@ -8,7 +8,7 @@ import { useServerIndex } from '~/hooks/use-server-context'
 
 type QueryView = 'json' | 'curl'
 
-export function QueryExemplar({ pipeId }: { pipeId: string }) {
+export function QueryPreview({ pipeId }: { pipeId: string }) {
   const { serverIndex } = useServerIndex()
   const data = usePipe(serverIndex, pipeId)
   const [view, setView] = useState<QueryView>('json')

--- a/packages/pipe-ui/app/dashboard/transformation-preview.tsx
+++ b/packages/pipe-ui/app/dashboard/transformation-preview.tsx
@@ -135,7 +135,7 @@ type Snapshot = {
 
 const MAX_SNAPSHOTS = 20
 
-function useExemplarHistory(current: ApiPreviewResult | undefined, batch: BatchInfo | undefined) {
+function usePreviewHistory(current: ApiPreviewResult | undefined, batch: BatchInfo | undefined) {
   const historyRef = useRef<Snapshot[]>([])
   const prevDataRef = useRef<string | undefined>(undefined)
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
@@ -681,7 +681,7 @@ function FlowStageNode({
 // Main component
 // ---------------------------------------------------------------------------
 
-export function TransformationExemplar({ pipeId }: { pipeId: string }) {
+export function TransformationPreview({ pipeId }: { pipeId: string }) {
   const { serverIndex } = useServerIndex()
   const [expandAll, setExpandAll] = useState(false)
   const { data, isLoading } = useTransformationPreview({ serverIndex, pipeId })
@@ -702,7 +702,7 @@ export function TransformationExemplar({ pipeId }: { pipeId: string }) {
     goLatest,
     freeze,
     toggleFreeze,
-  } = useExemplarHistory(data?.transformation, data?.batch)
+  } = usePreviewHistory(data?.transformation, data?.batch)
 
   return (
     <div className={fullscreen ? 'fixed inset-0 z-50 bg-gray-950 p-6 overflow-auto' : 'relative space-y-1'}>


### PR DESCRIPTION
## Summary

The metrics-server `exemplar → preview` rename (naming reform, row 20) had landed on the **API-facing** half of `@subsquid/pipes-ui` — the endpoint (`GET /preview/transformation`), the hook (`useTransformationPreview`), and the type (`ApiPreviewResult`) — but the **presentation layer** still said "exemplar". This finishes it so the whole feature speaks one vocabulary.

- `app/dashboard/query-exemplar.tsx` → `query-preview.tsx` (`QueryExemplar` → `QueryPreview`)
- `app/dashboard/transformation-exemplar.tsx` → `transformation-preview.tsx` (`TransformationExemplar` → `TransformationPreview`, internal `useExemplarHistory` → `usePreviewHistory`)
- `app/dashboard/pipeline.tsx` — imports + JSX updated

Purely mechanical, naming-only; no runtime behavior change (these components already consumed `useTransformationPreview`/`ApiPreviewResult`). Confirmed the UI is otherwise up to date with the reformed SDK contract — endpoints (`/stats`, `/profiler`, `/preview/transformation`), `/stats` JSON fields, and no stale `sqd_*` metric names or `sink`/`source`/`fork`/`rollback` leaks.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Biome clean on changed files
- [x] `grep -ri exemplar app/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sx7Ca3ztx8b5Ptt1ruYdfj