### PR TITLE
CLI: --config regenerates an existing project instead of erroring

### DIFF
--- a/packages/pipes-cli/src/commands/init/builders/target-builder/clickhouse-target-builder.ts
+++ b/packages/pipes-cli/src/commands/init/builders/target-builder/clickhouse-target-builder.ts
@@ -94,7 +94,7 @@ export function buildClickhouseTarget(config: Config<NetworkType>): TargetArtifa
   return {
     targetCode: renderTargetCode(rendered),
     envSchema,
-    files: [{ path: '.env', content: envFileContent }, ...renderMigrationFiles(rendered)],
+    files: [{ path: '.env', content: envFileContent, preserveExisting: true }, ...renderMigrationFiles(rendered)],
     postSteps: [],
   }
 }

--- a/packages/pipes-cli/src/commands/init/builders/target-builder/postgres-target-builder.ts
+++ b/packages/pipes-cli/src/commands/init/builders/target-builder/postgres-target-builder.ts
@@ -64,7 +64,7 @@ export function buildPostgresTarget(config: Config<NetworkType>): TargetArtifact
     targetCode: renderTargetCode(rendered),
     envSchema,
     files: [
-      { path: '.env', content: renderEnvFile() },
+      { path: '.env', content: renderEnvFile(), preserveExisting: true },
       { path: 'src/schemas.ts', content: renderSchemasFile(rendered) },
       { path: 'drizzle.config.ts', content: drizzleConfigTemplate },
     ],

--- a/packages/pipes-cli/src/commands/init/builders/target-builder/target-artifacts.ts
+++ b/packages/pipes-cli/src/commands/init/builders/target-builder/target-artifacts.ts
@@ -3,6 +3,12 @@ import type { Config, NetworkType } from '~/types/init.js'
 export interface TargetFile {
   path: string
   content: string
+  /**
+   * Keep the user's copy on regeneration instead of overwriting it. Used for
+   * files that carry user state (e.g. `.env` secrets); on a fresh init the file
+   * is absent, so it's still written.
+   */
+  preserveExisting?: boolean
 }
 
 export interface TargetPostStep {

--- a/packages/pipes-cli/src/commands/init/init.handler.ts
+++ b/packages/pipes-cli/src/commands/init/init.handler.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
 import chalk from 'chalk'
@@ -27,11 +27,15 @@ export class InitHandler {
     const spinner = createSpinner('Setting up new Pipes SDK project...')
     spinner.start()
 
+    const projectPath = this.projectWriter.getAbsolutePath()
     const ctx: InitContext = {
       config: this.config,
       projectName: this.projectName,
-      projectPath: this.projectWriter.getAbsolutePath(),
+      projectPath,
       projectWriter: this.projectWriter,
+      // A re-run against an existing pipes project (identified by its saved
+      // config) regenerates in place rather than erroring on the existing folder.
+      regenerate: existsSync(path.join(projectPath, PIPE_CONFIG_FILENAME)),
     }
 
     let failures: StageFailure[]
@@ -80,7 +84,7 @@ export class InitHandler {
       : ''
 
     const configNote = `  ${chalk.gray('Config saved to')} ${chalk.cyan(configPath)}${chalk.gray('.')}
-  ${chalk.gray('To change the generated code, edit it and re-run')} ${chalk.gray.italic(`pipes init --config ${configPath}`)}
+  ${chalk.gray('To change the generated code, edit this config and re-run')} ${chalk.gray.italic(`pipes init --config ${configPath}`)}
 `
 
     const pgMessage = `3) Apply migrations

--- a/packages/pipes-cli/src/commands/init/pipeline/run-stages.test.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/run-stages.test.ts
@@ -181,6 +181,28 @@ describe('runStages', () => {
     await expect(pathExists(projectPath)).resolves.toBe(false)
   })
 
+  it('does not delete a pre-existing project when regenerating fails', async () => {
+    await fsPromises.mkdir(projectPath, { recursive: true })
+    await writeFile(path.join(projectPath, 'file.txt'), 'hello')
+
+    const stages: InitStage[] = [
+      { id: 'check-project-path', label: 'Check', run: async () => {} },
+      {
+        id: 'write-static-files',
+        label: 'Write static',
+        run: async () => {
+          throw new Error('disk full')
+        },
+      },
+    ]
+
+    await expect(runStages(stages, makeContext({ projectPath, regenerate: true }))).rejects.toBeInstanceOf(
+      InitPipelineError,
+    )
+    // The folder predated the run, so it must survive the failure.
+    await expect(pathExists(projectPath)).resolves.toBe(true)
+  })
+
   it('surfaces the original pipeline error even when cleanup fails', async () => {
     const original = new Error('stage boom')
     const cleanup = vi.fn(async () => {

--- a/packages/pipes-cli/src/commands/init/pipeline/run-stages.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/run-stages.ts
@@ -40,7 +40,8 @@ export async function runStages(
       }
 
       const pipelineError = new InitPipelineError(stage.id, error as Error)
-      if (i > 0 && isSafeToRemove(ctx.projectPath)) {
+      // Never delete a pre-existing project we were only regenerating into.
+      if (i > 0 && !ctx.regenerate && isSafeToRemove(ctx.projectPath)) {
         try {
           await cleanup(ctx.projectPath)
         } catch {

--- a/packages/pipes-cli/src/commands/init/pipeline/stages/check-project-path.test.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/stages/check-project-path.test.ts
@@ -30,4 +30,10 @@ describe('checkProjectPathStage', () => {
 
     await expect(checkProjectPathStage.run(ctx)).rejects.toBeInstanceOf(ProjectAlreadyExistError)
   })
+
+  it('allows an existing directory when regenerating', async () => {
+    const { ctx } = makeTestContext({ projectFolder: tmpRoot, regenerate: true })
+
+    await expect(checkProjectPathStage.run(ctx)).resolves.toBeUndefined()
+  })
 })

--- a/packages/pipes-cli/src/commands/init/pipeline/stages/check-project-path.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/stages/check-project-path.ts
@@ -7,6 +7,9 @@ export const checkProjectPathStage: InitStage = {
   id: 'check-project-path',
   label: 'Checking project path',
   run: async (ctx) => {
+    // Regeneration targets an existing pipes project on purpose — let it through.
+    if (ctx.regenerate) return
+
     try {
       const projectStat = statSync(ctx.projectPath)
       if (projectStat.isDirectory()) throw new ProjectAlreadyExistError(ctx.projectPath)

--- a/packages/pipes-cli/src/commands/init/pipeline/stages/write-target-files.test.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/stages/write-target-files.test.ts
@@ -19,8 +19,10 @@ describe('writeTargetFilesStage', () => {
 
     await writeTargetFilesStage.run(ctx)
 
-    const env = writer.createFileCalls.find((c) => c.relativePath === '.env')
+    // .env is written preserve-existing so regeneration keeps user secrets.
+    const env = writer.createFileIfAbsentCalls.find((c) => c.relativePath === '.env')
     expect(env?.content).toContain('CLICKHOUSE_URL=')
+    expect(writer.createFileCalls.some((c) => c.relativePath === '.env')).toBe(false)
   })
 
   it('creates per-template migration files for a clickhouse target', async () => {
@@ -55,7 +57,8 @@ describe('writeTargetFilesStage', () => {
 
     await writeTargetFilesStage.run(ctx)
 
-    const env = writer.createFileCalls.find((c) => c.relativePath === '.env')
+    const env = writer.createFileIfAbsentCalls.find((c) => c.relativePath === '.env')
     expect(env?.content).toContain('DB_CONNECTION_STR=')
+    expect(writer.createFileCalls.some((c) => c.relativePath === '.env')).toBe(false)
   })
 })

--- a/packages/pipes-cli/src/commands/init/pipeline/stages/write-target-files.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/stages/write-target-files.ts
@@ -10,7 +10,11 @@ export const writeTargetFilesStage: InitStage = {
     // discarding the project.
     const artifacts = buildTarget(ctx.config)
     for (const file of artifacts.files) {
-      ctx.projectWriter.createFile(file.path, file.content)
+      if (file.preserveExisting) {
+        ctx.projectWriter.createFileIfAbsent(file.path, file.content)
+      } else {
+        ctx.projectWriter.createFile(file.path, file.content)
+      }
     }
   },
 }

--- a/packages/pipes-cli/src/commands/init/pipeline/testing/fake-project-writer.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/testing/fake-project-writer.ts
@@ -7,6 +7,7 @@ export type CopyFileCall = { absoluteSourcePath: string; relativeTargetPath: str
 
 export class FakeProjectWriter {
   readonly createFileCalls: CreateFileCall[] = []
+  readonly createFileIfAbsentCalls: CreateFileCall[] = []
   readonly copyFileCalls: CopyFileCall[] = []
   readonly executeCommandCalls: string[] = []
   private readonly projectAbsolutePath: string
@@ -21,6 +22,10 @@ export class FakeProjectWriter {
 
   createFile(relativePath: string, content: string): void {
     this.createFileCalls.push({ relativePath, content })
+  }
+
+  createFileIfAbsent(relativePath: string, content: string): void {
+    this.createFileIfAbsentCalls.push({ relativePath, content })
   }
 
   copyFile(absoluteSourcePath: string, relativeTargetPath: string): void {

--- a/packages/pipes-cli/src/commands/init/pipeline/testing/make-context.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/testing/make-context.ts
@@ -11,6 +11,7 @@ export type MakeContextOverrides = {
   projectFolder?: string
   templates?: Config<NetworkType>['templates']
   writer?: FakeProjectWriter
+  regenerate?: boolean
 }
 
 export function makeTestContext(overrides: MakeContextOverrides = {}): {
@@ -33,6 +34,7 @@ export function makeTestContext(overrides: MakeContextOverrides = {}): {
       projectName: 'proj',
       projectPath: writer.getAbsolutePath(),
       projectWriter: writer.asProjectWriter(),
+      regenerate: overrides.regenerate,
     },
   }
 }

--- a/packages/pipes-cli/src/commands/init/pipeline/types.ts
+++ b/packages/pipes-cli/src/commands/init/pipeline/types.ts
@@ -6,6 +6,12 @@ export type InitContext = {
   projectName: string
   projectPath: string
   projectWriter: ProjectWriter
+  /**
+   * The target folder already exists and is a pipes project (has a saved
+   * config): regenerate into it instead of erroring, and never delete it on
+   * failure since it predates this run.
+   */
+  regenerate?: boolean
 }
 
 export type InitStage = {

--- a/packages/pipes-cli/src/utils/project-writer.ts
+++ b/packages/pipes-cli/src/utils/project-writer.ts
@@ -23,6 +23,14 @@ export class ProjectWriter {
     writeFileSync(filePath, content)
   }
 
+  /** Writes the file only if it doesn't already exist, so regeneration keeps user edits. */
+  createFileIfAbsent(relativePath: string, content: string) {
+    const filePath = path.join(this.projectAbsolutePath, relativePath)
+    if (existsSync(filePath)) return
+
+    this.createFile(relativePath, content)
+  }
+
   copyFile(absoluteSourcePath: string, relativeTargetPath: string) {
     const absoluteTargetFilePath = path.join(this.projectAbsolutePath, relativeTargetPath)
 


### PR DESCRIPTION
## Problem

The generated project's final instructions say:

> Config saved to `<project>/pipes.config.json`.
> To change the generated code, edit this config and re-run `pipes init --config <project>/pipes.config.json`

But following that command failed:

```
Error: Stage "check-project-path" failed: Project folder already exist. Please, select a new location
```

The saved config's `projectFolder` points at the now-existing folder, so `check-project-path` refused — the promised "edit config → re-run → regenerate" workflow didn't work.

## Fix

A re-run whose target folder is **a pipes project** (identified by a saved `pipes.config.json`) now **regenerates in place**:

- `check-project-path` skips the exists-error when regenerating (`ctx.regenerate`, computed by the handler from the marker file).
- A failed stage **never deletes** a pre-existing folder (cleanup is gated on `!regenerate`), so a mid-run failure can't wipe an existing project.
- `.env` is written **only when absent** (`TargetFile.preserveExisting` → `ProjectWriter.createFileIfAbsent`), so regeneration keeps user secrets while still scaffolding `.env` on a fresh init.

Folders that are **not** pipes projects still error and are left untouched — no clobbering of unrelated directories.

## Verification (end-to-end)

- Fresh init → edit `.env` (add a secret) → re-run the suggested command → **regenerates, exit 0, `.env` secret preserved**.
- `init` into an existing non-pipes folder → still errors, user data intact.
- Unit tests: `check-project-path` allows existing dir when regenerating; `runStages` doesn't delete a pre-existing project on failure; `.env` written via the preserve path.

## Test plan

- [x] `tsc --noEmit` clean; 285 tests pass; Biome clean (one pre-existing unrelated warning)
- [x] E2E regenerate + `.env` preservation verified against the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sx7Ca3ztx8b5Ptt1ruYdfj