### PR TITLE
fix(ci): sync pnpm-lock.yaml with pipes-cli's runtime typescript dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       ora:
         specifier: 9.3.0
         version: 9.3.0
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
       zod:
         specifier: ^4.3.4
         version: 4.3.6
@@ -257,9 +260,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.8.2))
-      typescript:
-        specifier: 5.9.2
-        version: 5.9.2
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.8.2)


### PR DESCRIPTION
Fixes the `Test @subsquid/pipes` workflow failure on main (run 29459012314): `ERR_PNPM_OUTDATED_LOCKFILE` — the lockfile is not up to date with `packages/pipes-cli/package.json`.

## Cause

PR #114 moved `typescript` from `devDependencies` to `dependencies` in `packages/pipes-cli` (the AST-based import merging in `src/utils/merge-imports.ts` uses the TypeScript compiler API at runtime, so it must ship as a runtime dependency), but the corresponding `pnpm-lock.yaml` regeneration never landed on main. CI installs with `--frozen-lockfile` and fails at the install step before any tests run.

## Fix

`pnpm install` with the pinned pnpm@10.17.0 — the resulting diff is exactly the missed move: the `typescript: 5.9.2` entry in the pipes-cli importer shifts from the devDependencies block to dependencies. No versions change.

## Verification

- `pnpm install --frozen-lockfile` fails on main, passes with this change
- pipes-cli test suite passes after reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)