### PR TITLE
docs(readme): update to current API naming and shipped targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 Documentation: https://docs.sqd.dev  ·  Website: https://sqd.dev
 
-SQD Pipes is a TypeScript toolkit for streaming blockchain data, decoding it in flight, and writing the
-results to your own storage. A pipeline is a composition of three parts:
+SQD Pipes is a TypeScript library for building blockchain indexers. It streams onchain data from SQD
+Portal, decodes it in flight, handles chain reorgs, and writes the results to your own storage. A
+pipeline is a composition of three parts:
 
 - **Streams** tap managed SQD Portal datasets for EVM, Solana, Hyperliquid, Bitcoin, and Tron.
 - **Decoders** turn raw blocks, logs, and instructions into strongly-typed objects.
-- **Targets** persist or forward the decoded data, managing offsets and chain forks for you.
+- **Targets** persist or forward the decoded data, managing offsets and chain reorgs.
 
-Built-in profiling, structured logging, and Prometheus metrics come along for the ride, and the same
-pipeline runs in a CLI, a backend service, or a long-running worker.
+Profiling, structured logging, and Prometheus metrics are built in. The same pipeline runs in a CLI, a
+backend service, or a long-running worker.
 
 ## Install
 
@@ -64,7 +65,7 @@ pnpm dlx tsx erc20-transfers.ts
 ## Persist to a target
 
 Replace the `for await` loop with `.pipeTo(target)`. Each target batches writes, tracks the cursor under
-the stream `id`, and rolls back cleanly on chain forks.
+the stream `id`, and rolls back cleanly on chain reorgs.
 
 | Target | Import | Example |
 | --- | --- | --- |
@@ -97,9 +98,9 @@ await evmPortalStream({
 
 ## Learn more
 
-- **Quickstart & guides** — https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
-- **EVM examples** — [docs/examples/evm](docs/examples/evm)
-- **Solana examples** — [docs/examples/solana](docs/examples/solana)
+- **Quickstart & guides:** https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
+- **EVM examples:** [docs/examples/evm](docs/examples/evm)
+- **Solana examples:** [docs/examples/solana](docs/examples/solana)
 - Bitcoin, Hyperliquid, and Tron examples live alongside them under [docs/examples](docs/examples).
 
 Run any example from the repo root with `pnpm tsx <path/to/example.ts>`.

--- a/README.md
+++ b/README.md
@@ -6,52 +6,46 @@
 
 Documentation: https://docs.sqd.dev  ·  Website: https://sqd.dev
 
-SQD Pipes is a TypeScript-first toolkit for streaming blockchain data, transforming it in-flight, and delivering the results to your own systems. It glues together:
+SQD Pipes is a TypeScript toolkit for streaming blockchain data, decoding it in flight, and writing the
+results to your own storage. A pipeline is a composition of three parts:
 
-- **Sources** that tap into managed SQD Portal datasets for chains like Ethereum and Solana.
-- **Transforms/decoders** that turn raw blocks and logs into strongly-typed objects.
-- **Targets** that persist or forward processed data (ClickHouse today, with community hooks for more sinks).
-- **Observability** utilities such as profiling, structured logging, and Prometheus metrics.
+- **Streams** tap managed SQD Portal datasets for EVM, Solana, Hyperliquid, Bitcoin, and Tron.
+- **Decoders** turn raw blocks, logs, and instructions into strongly-typed objects.
+- **Targets** persist or forward the decoded data, managing offsets and chain forks for you.
 
-Every pipeline is described as a composition of these pieces via the `pipe()` helper.
-You can run the same code in CLIs, backend services, or long-running workers.
+Built-in profiling, structured logging, and Prometheus metrics come along for the ride, and the same
+pipeline runs in a CLI, a backend service, or a long-running worker.
 
-
----
-
-## 1. Install the SDK
-
-Add the Pipes package to any TypeScript/Node project.
+## Install
 
 ```bash
 pnpm add @subsquid/pipes
-# or
-npm install @subsquid/pipes
 ```
 
----
+Or scaffold a ready-to-run project with the CLI:
 
-## 2. Create your first pipeline
+```bash
+pnpm dlx @subsquid/pipes-cli init
+```
 
-The snippet below streams ERC-20 transfers from Ethereum Mainnet via the SQD Portal and prints them to the console.
+## Quick start
 
-Create `src/erc20-transfers.ts`:
+Stream ERC-20 transfers from Ethereum Mainnet and print them:
 
 ```ts
-import { commonAbis, evmDecoder, evmPortalStream } from '@subsquid/pipes/evm'
+import { commonAbis, evmEventDecoder, evmPortalStream } from '@subsquid/pipes/evm'
 
 async function main() {
   const stream = evmPortalStream({
+    id: 'erc20-transfers',
     portal: 'https://portal.sqd.dev/datasets/ethereum-mainnet',
-  }).pipe(
-    evmDecoder({
-      profiler: { name: 'erc20-transfers' },
+    outputs: evmEventDecoder({
       range: { from: '12,000,000' },
       events: {
         transfers: commonAbis.erc20.events.Transfer,
       },
     }),
-  )
+  })
 
   for await (const { data } of stream) {
     console.log(`parsed ${data.transfers.length} transfers`)
@@ -61,69 +55,55 @@ async function main() {
 void main()
 ```
 
-Run it with [`tsx`](https://github.com/privatenumber/tsx) (fast TypeScript executor):
+Run it with [`tsx`](https://github.com/privatenumber/tsx):
 
 ```bash
-pnpm dlx tsx src/erc20-transfers.ts
+pnpm dlx tsx erc20-transfers.ts
 ```
 
-You should see logs as transfers are decoded.
+## Persist to a target
 
----
+Replace the `for await` loop with `.pipeTo(target)`. Each target batches writes, tracks the cursor under
+the stream `id`, and rolls back cleanly on chain forks.
 
-## 3. Persist data (optional)
+| Target | Import | Example |
+| --- | --- | --- |
+| ClickHouse | `@subsquid/pipes/targets/clickhouse` | [04.clickhouse](docs/examples/evm/04.clickhouse.example.ts) |
+| PostgreSQL (Drizzle) | `@subsquid/pipes/targets/drizzle/node-postgres` | [08.drizzle](docs/examples/evm/08.drizzle.example.ts) |
+| Parquet | `@subsquid/pipes/targets/parquet` | [17.parquet](docs/examples/evm/17.parquet.example.ts) |
+| BigQuery | `@subsquid/pipes/targets/bigquery` | [16.bigquery](docs/examples/evm/16.bigquery.example.ts) |
 
-### ClickHouse target
+```ts
+import { createClient } from '@clickhouse/client'
+import { clickhouseTarget } from '@subsquid/pipes/targets/clickhouse'
 
-If you have ClickHouse and want automatic offset management, read the [ClickHouse example](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/04.clickhouse.example.ts).
-It uses the `createClickhouseTarget` from the core package to batch writes and handle forks gracefully.
+await evmPortalStream({
+  id: 'erc20-transfers',
+  portal: 'https://portal.sqd.dev/datasets/ethereum-mainnet',
+  outputs: evmEventDecoder({
+    range: { from: '12,000,000' },
+    events: { transfers: commonAbis.erc20.events.Transfer },
+  }),
+}).pipeTo(
+  clickhouseTarget({
+    client: createClient({ url: 'http://localhost:8123' }),
+    onRollback: async () => {},
+    onData: async ({ data }) => {
+      // insert data.transfers ...
+    },
+  }),
+)
+```
 
-#### Rollbacks and materialized views
+## Learn more
 
-On a blockchain fork the target removes rolled-back rows by inserting CollapsingMergeTree
-cancel rows (`sign = -1`) — the only delete mechanism in ClickHouse that propagates through
-materialized views. To get this behavior, a table must use a `CollapsingMergeTree`
-(or `VersionedCollapsingMergeTree`) engine with a `sign` column, and materialized views
-built on top of it should be written rollback-aware: aggregate with the sign, e.g.
-`sum(value * sign)` for sums and `sum(sign)` for counts, so cancel rows revert the
-aggregate automatically.
+- **Quickstart & guides** — https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
+- **EVM examples** — [docs/examples/evm](docs/examples/evm)
+- **Solana examples** — [docs/examples/solana](docs/examples/solana)
+- Bitcoin, Hyperliquid, and Tron examples live alongside them under [docs/examples](docs/examples).
 
-Tables on any other engine still roll back — the target falls back to a lightweight
-`DELETE` and logs a warning — but materialized views built on such tables keep the
-rolled-back data, because ClickHouse fires MVs on `INSERT` only. Picking the mechanism
-requires read access to `system.tables` / `system.columns`; without it the target logs a
-warning and uses the legacy `FINAL`-based cancel-row rollback, which assumes a
-`CollapsingMergeTree` table with a `sign` column.
+Run any example from the repo root with `pnpm tsx <path/to/example.ts>`.
 
-Irreversible aggregates — `min`, `max`, `uniq`, `argMax` and similar — cannot "subtract" a
-value, so no write mechanism can roll them back. If you need such an MV, the only correct
-recovery after a fork is recomputing its affected tail (drop the tail partition and
-`INSERT ... SELECT` the range from the base table).
+## License
 
-Rollback reads are pruned by a small `minmax` skip index on `block_number` that
-`store.removeAllRows` creates automatically on first use; call
-`store.ensureRollbackIndex({ table })` in `onStart` to set it up eagerly.
-
-### PostgreSQL with Drizzle
-
-If you prefer PostgreSQL, check out the [Drizzle example](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/08.drizzle.example.ts),
-which demonstrates how to use Drizzle ORM to define your schema and persist decoded data.
-
----
-
-## 4. Explore more examples
-
-- [`docs/examples/evm`](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples/evm): combining sources, decoders, and targets for EVM chains.
-- [`docs/examples/solana`](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples/solana): Solana Portal pipelines, including token balance over-fetch and parallel processing demos.
-
-From the repository root you can run any example with `pnpm tsx <path/to/example.ts>`.
-
----
-
-## 5. Next steps
-
-1. Wire your own sinks by implementing `createTarget` (see `packages/subsquid-pipes/src/targets` for references).
-2. Add instrumentation with the built-in profiler and Prometheus metrics (`packages/subsquid-pipes/src/core`).
-3. Try the UI tooling in `@sqd-pipes/pipe-ui`.
-
-Need help or found a bug? Open an issue or discussion on the repository. Happy hacking!
+Apache-2.0 © SQD

--- a/packages/subsquid-pipes/README.md
+++ b/packages/subsquid-pipes/README.md
@@ -59,8 +59,8 @@ void main()
 ```
 
 To persist instead of printing, replace the loop with `.pipeTo(target)`. See the
-[ClickHouse](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/04.clickhouse.example.ts)
-and [Drizzle/PostgreSQL](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/08.drizzle.example.ts)
+[ClickHouse](https://github.com/subsquid/pipes-sdk/blob/main/docs/examples/evm/04.clickhouse.example.ts)
+and [Drizzle/PostgreSQL](https://github.com/subsquid/pipes-sdk/blob/main/docs/examples/evm/08.drizzle.example.ts)
 examples.
 
 ---
@@ -68,7 +68,7 @@ examples.
 ## Documentation & examples
 
 - **Quickstart & guides:** https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
-- **Examples:** [docs/examples](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples)
+- **Examples:** [docs/examples](https://github.com/subsquid/pipes-sdk/tree/main/docs/examples)
   (EVM, Solana, Bitcoin, Hyperliquid, Tron)
 
 Extend the system by implementing custom components against the `Transformer` / `Target` interfaces.

--- a/packages/subsquid-pipes/README.md
+++ b/packages/subsquid-pipes/README.md
@@ -4,29 +4,22 @@
 > APIs may change without notice.
 > Use with caution in production environments.
 
-Core package of the **SQD Pipes** ecosystem. It provides specialized, composable streams for blockchain data ingestion, transformation, and storage.
+Core package of the **SQD Pipes** ecosystem — composable streams for blockchain data ingestion,
+decoding, and storage.
 
 ---
 
 ## Overview
 
-`@subsquid/pipes` is a TypeScript library designed for **efficient blockchain data processing**.  
-It implements a **pipeline-based architecture** that makes it easy to consume, decode, and persist blockchain data, while remaining flexible and extensible.
+`@subsquid/pipes` is a TypeScript library for **efficient blockchain data processing**. A pipeline is
+built from three composable parts:
 
----
+- **Streams** pull data from managed SQD Portal datasets for EVM, Solana, Hyperliquid, Bitcoin, and Tron.
+- **Decoders** turn raw blocks, logs, and instructions into strongly-typed objects.
+- **Targets** persist or forward the decoded data, managing offsets and chain forks for you.
 
-## Features
-
-- **TypeScript-first** — full type safety with both ESM and CJS builds.
-- **Blockchain integration**:
-  - EVM helpers (portal sources, event decoders).
-- **Storage targets**:
-  - Built-in support for ClickHouse with batching and rollback handling.
-- **Observability**:
-  - Prometheus metrics.
-  - Pino-compatible logging.
-  - Benchmarking utilities.
-- **Extensible architecture** — create custom sources, decoders, and targets for any chain or sink.
+Storage targets ship for **ClickHouse**, **PostgreSQL** (via Drizzle), **Parquet**, and **BigQuery**.
+Observability comes built in: Prometheus metrics, Pino-compatible logging, and profiling utilities.
 
 ---
 
@@ -38,57 +31,47 @@ npm install @subsquid/pipes
 
 ---
 
-## Quick Start
+## Quick start
 
-Example: consume events from an EVM chain and write them into ClickHouse.
+Stream ERC-20 transfers from an EVM chain and print them:
 
 ```ts
-import { commonAbis, evmDecoder, evmPortalStream } from '@subsquid/pipes/evm'
+import { commonAbis, evmEventDecoder, evmPortalStream } from '@subsquid/pipes/evm'
 
-async function cli() {
+async function main() {
   const stream = evmPortalStream({
+    id: 'erc20-transfers',
     portal: 'https://portal.sqd.dev/datasets/ethereum-mainnet',
-  }).pipe(
-    evmDecoder({
-      profiler: { name: 'ERC20 transfers' },
+    outputs: evmEventDecoder({
       range: { from: '12,000,000' },
       events: {
         transfers: commonAbis.erc20.events.Transfer,
       },
     }),
-  )
+  })
 
   for await (const { data } of stream) {
     console.log(`parsed ${data.transfers.length} transfers`)
   }
 }
 
-void cli()
+void main()
 ```
 
----
-
-## Usage
-
-Pipelines are fully composable:
-
-- **Sources** provide blockchain data (e.g., blocks, logs, transactions).
-- **Decoders** transform raw data into structured objects.
-- **Targets** handle persistence in databases, message queues, or custom sinks.
-
-You can easily extend the system by implementing custom components that conform to the `Transformer` / `Target` interfaces.
+To persist instead of printing, replace the loop with `.pipeTo(target)` — see the
+[ClickHouse](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/04.clickhouse.example.ts)
+and [Drizzle/PostgreSQL](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/08.drizzle.example.ts)
+examples.
 
 ---
 
-## Documentation
+## Documentation & examples
 
-Full documentation is available in the [project wiki](./docs) (WIP).
+- **Quickstart & guides** — https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
+- **Examples** — [docs/examples](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples)
+  (EVM, Solana, Bitcoin, Hyperliquid, Tron)
 
----
-
-## Contributing
-
-Contributions are welcome! Please open an issue or submit a PR with improvements.
+Extend the system by implementing custom components against the `Transformer` / `Target` interfaces.
 
 ---
 

--- a/packages/subsquid-pipes/README.md
+++ b/packages/subsquid-pipes/README.md
@@ -4,22 +4,22 @@
 > APIs may change without notice.
 > Use with caution in production environments.
 
-Core package of the **SQD Pipes** ecosystem — composable streams for blockchain data ingestion,
-decoding, and storage.
+Core package of the **SQD Pipes** ecosystem. Composable streams for building blockchain indexers:
+onchain data ingestion, decoding, and storage.
 
 ---
 
 ## Overview
 
-`@subsquid/pipes` is a TypeScript library for **efficient blockchain data processing**. A pipeline is
-built from three composable parts:
+`@subsquid/pipes` is a TypeScript library for building **blockchain indexers**. A pipeline is built from
+three composable parts:
 
 - **Streams** pull data from managed SQD Portal datasets for EVM, Solana, Hyperliquid, Bitcoin, and Tron.
 - **Decoders** turn raw blocks, logs, and instructions into strongly-typed objects.
-- **Targets** persist or forward the decoded data, managing offsets and chain forks for you.
+- **Targets** persist or forward the decoded data, managing offsets and chain reorgs.
 
-Storage targets ship for **ClickHouse**, **PostgreSQL** (via Drizzle), **Parquet**, and **BigQuery**.
-Observability comes built in: Prometheus metrics, Pino-compatible logging, and profiling utilities.
+Storage targets are available for **ClickHouse**, **PostgreSQL** (via Drizzle), **Parquet**, and **BigQuery**.
+Observability is built in: Prometheus metrics, Pino-compatible logging, and profiling utilities.
 
 ---
 
@@ -58,7 +58,7 @@ async function main() {
 void main()
 ```
 
-To persist instead of printing, replace the loop with `.pipeTo(target)` — see the
+To persist instead of printing, replace the loop with `.pipeTo(target)`. See the
 [ClickHouse](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/04.clickhouse.example.ts)
 and [Drizzle/PostgreSQL](https://github.com/subsquid-labs/pipes-sdk/blob/main/docs/examples/evm/08.drizzle.example.ts)
 examples.
@@ -67,8 +67,8 @@ examples.
 
 ## Documentation & examples
 
-- **Quickstart & guides** — https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
-- **Examples** — [docs/examples](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples)
+- **Quickstart & guides:** https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart
+- **Examples:** [docs/examples](https://github.com/subsquid-labs/pipes-sdk/tree/main/docs/examples)
   (EVM, Solana, Bitcoin, Hyperliquid, Tron)
 
 Extend the system by implementing custom components against the `Transformer` / `Target` interfaces.


### PR DESCRIPTION
## What

Refreshes the root `README.md` and the npm-facing `packages/subsquid-pipes/README.md` to match the current 1.0 API, and slims both down so they point at the examples and docs rather than inlining everything.

## Why

Both READMEs still documented the pre-1.0 surface, so the quick-start no longer compiled:

- `evmDecoder` → **`evmEventDecoder`**
- `createClickhouseTarget` → **`clickhouseTarget`**
- `stream.pipe(decoder)` → decoders now go in **`outputs:`**, persistence via **`.pipeTo(target)`**
- dropped the old **"sink"** vocabulary
- added the now-**required `id`** stream field (was omitted → sample wouldn't type-check)

They also listed only ClickHouse as a target.

## Changes

- List all four shipped targets — **ClickHouse, PostgreSQL (Drizzle), Parquet, BigQuery** — in a table linking each to its example.
- Cut the ~25-line ClickHouse rollback/CollapsingMergeTree section; that detail lives in the example + docs.
- Broaden the chain list to EVM, Solana, Hyperliquid, Bitcoin, Tron.
- Link to the [docs quickstart](https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart) and `docs/examples`.
- Package README uses absolute GitHub links (relative links break on npmjs.com).

## Test coverage

Docs-only change — two Markdown files, no code paths touched, so there is no coverage delta. Code samples were transcribed from the working examples (`docs/examples/evm/01`, `04`) and checked against the current exports (`evmEventDecoder`, `clickhouseTarget`, required `id`).

## Note for a follow-up

The published [docs quickstart](https://docs.sqd.dev/en/sdk/pipes-sdk/evm/quickstart) still shows the old `evmDecoder` / `evmPortalSource` / `chunk` names — it lags the code and needs the same rename pass. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)