### PR TITLE
refactor(errors)!: unified error-code taxonomy across all targets

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,380 @@
+<!--
+  Single source of truth for @subsquid/pipes error codes.
+
+  Every SDK error ends its message with
+  `See: https://docs.sqd.dev/en/sdk/pipes-sdk/errors/<code>`.
+  The docs site imports THIS file and serves it at /en/sdk/pipes-sdk/errors,
+  routing /en/sdk/pipes-sdk/errors/<code> to the matching section anchor below.
+
+  Keep in sync with the code the messages come from:
+    - packages/subsquid-pipes/src/core/errors.ts                          (E0xxx, E1xxx)
+    - packages/subsquid-pipes/src/targets/clickhouse/errors.ts            (E20xx)
+    - packages/subsquid-pipes/src/targets/drizzle/node-postgres/errors.ts (E21xx)
+    - packages/subsquid-pipes/src/targets/bigquery/errors.ts              (E22xx)
+    - packages/subsquid-pipes/src/targets/parquet/errors.ts               (E23xx)
+-->
+
+# Error reference
+
+Every error `@subsquid/pipes` raises carries a stable code and ends its message with a link back to
+this page:
+
+```
+Pipe requires a non-default ID when used with targets.
+...
+See: https://docs.sqd.dev/en/sdk/pipes-sdk/errors/E0001
+```
+
+Match on the code (or the `instanceof` class), not the message text — messages may be reworded, codes
+are stable. Codes are grouped by where they originate:
+
+| Prefix  | Area                        |
+| ------- | --------------------------- |
+| `E0xxx` | Source / pipe configuration |
+| `E1xxx` | Fork handling & rollback    |
+| `E20xx` | ClickHouse target           |
+| `E21xx` | Postgres (Drizzle) target   |
+| `E22xx` | BigQuery target             |
+| `E23xx` | Parquet target              |
+
+---
+
+## Pipe configuration
+
+### E0001 · Pipe requires a unique id
+
+A pipe was connected to a target (`.pipeTo(...)`) while still using the default id. Targets persist
+their resume cursor under the pipe's `id`, so a shared/default id would let two pipes silently
+overwrite each other's progress.
+
+**Fix** — set a stable, globally unique, non-empty `id`:
+
+```ts
+evmPortalStream({ id: 'eth-transfers', portal: '...', outputs })
+```
+
+### E0002 · Invalid block range
+
+A `range` (on the stream or a decoder) is misconfigured — an inverted range (`from` after `to`), an
+invalid date, or a timestamp that can't be resolved to a block. The message names the exact problem.
+
+**Fix** — ensure `from ≤ to` and use a resolvable bound: `'latest'`, a block number (`'12,000,000'`),
+an ISO date (`'2024-01-01'`), or a `Date`.
+
+---
+
+## Fork handling
+
+Raised while unwinding a chain reorganization (fork). The built-in targets handle forks; the first
+three mostly surface in **custom** targets.
+
+### E1001 · Target does not support fork handling
+
+A fork was detected, but the target does not implement `resolveFork()`.
+
+**Fix** — implement `resolveFork(canonicalBlocks)` on the target. It must remove rows above the fork
+point and return the cursor to resume from.
+
+### E1002 · Fork with no canonical blocks
+
+A fork was detected but no canonical blocks were supplied to resolve it — an internal invariant
+violation.
+
+**Fix** — none; please [report it as a bug](https://github.com/subsquid-labs/pipes-sdk/issues).
+
+### E1003 · resolveFork() returned no cursor
+
+The target's `resolveFork()` returned nothing instead of a cursor.
+
+**Fix** — return the cursor to resume from after rolling back.
+
+### E1004 · Portal contract violation
+
+The portal delivered a `canonicalBlocks` set whose highest block is below the target's persisted
+cursor. Rows above it would survive the fork rollback and corrupt the new chain, so the pipe refuses
+to proceed. Any target that tracks a cursor can raise this.
+
+**Fix** — none in user code; please
+[report it as a bug](https://github.com/subsquid-labs/pipes-sdk/issues) against the portal contract.
+
+---
+
+## ClickHouse target
+
+### E2001 · Invalid `maxRows`
+
+The `maxRows` batching option is not a positive number.
+
+**Fix** — set `maxRows` to a value greater than 0 (or omit it for the default).
+
+### E2002 · Unparseable table name
+
+A table identifier could not be parsed as `table` or `database.table`.
+
+**Fix** — pass `table` or `database.table`; quote identifiers that themselves contain dots.
+
+### E2003 · Cannot roll back a Distributed table
+
+Rollback targeted a `Distributed` table. Multi-shard rollback is not supported.
+
+**Fix** — point the rollback at the underlying local table instead.
+
+### E2004 · Rollback engine collapses on the wrong column
+
+The table's collapsing engine collapses on a column other than `sign`. Rollback inserts cancel rows
+with `sign = -1`, so the collapse column must be named `sign`.
+
+**Fix** — rename the collapse column to `sign`.
+
+### E2005 · Rollback table has no `sign` column
+
+The table has no `sign` column, so cancel-row rollback cannot work.
+
+**Fix** — add a `sign` column and use a `CollapsingMergeTree`-family engine for tables you roll back.
+
+### E2006 · Invalid rollback index column
+
+The column passed to `ensureRollbackIndex` is not a plain identifier.
+
+**Fix** — pass a plain identifier (letters, digits, underscores; no spaces or expressions).
+
+---
+
+## Postgres (Drizzle) target
+
+### E2101 · Drizzle client missing
+
+The `db` passed to `drizzleTarget` has no underlying client (`$client`).
+
+**Fix** — pass a Drizzle instance created with a real driver, e.g. `drizzle(pool)`.
+
+### E2102 · Invalid retention
+
+`unfinalizedBlocksRetention` is not a positive number.
+
+**Fix** — set it to a value greater than 0.
+
+### E2103 · Advisory lock not acquired
+
+Another process is holding the PostgreSQL advisory lock for this state id.
+
+**Fix** — ensure only one process writes to a given pipe `id` at a time.
+
+### E2104 · Untracked table
+
+A write targeted a table that isn't registered for rollback tracking.
+
+**Fix** — include the table in the `tables` array passed to `drizzleTarget`.
+
+### E2105 · Missing primary key
+
+A snapshot trigger cannot be built for a tracked table without primary key columns.
+
+**Fix** — declare a primary key on the tracked table.
+
+### E2106 · Circular foreign keys
+
+The tracked tables' foreign keys form a cycle, so no safe delete order can be determined.
+
+**Fix** — break the foreign-key cycle among the tracked tables.
+
+---
+
+## BigQuery target
+
+### E2201 · Cannot determine GCP project id
+
+`bigqueryTarget` could not resolve a project id at construction.
+
+**Fix** — pass `projectId` explicitly, or construct `new BigQuery({ projectId })` so
+`client.bigquery.projectId` is set.
+
+### E2202 · Partition column missing from schema
+
+A tracked table's declared `schema` omits its block-number / partition column.
+
+**Fix** — add the column to `tables[].schema` as `INT64 NOT NULL`. The target forces that type and
+mode, but the column itself must be declared.
+
+### E2203 · Partition column has the wrong type
+
+The partition column is not `INT64`. `FLOAT64`/`NUMERIC` lose precision above 2^53 (Solana slot
+numbers exceed this) and non-integer types break `RANGE_BUCKET` pruning, so reorg-cleanup `BETWEEN`
+predicates become inexact.
+
+**Fix** — type the partition column as `INT64`.
+
+### E2204 · Partition column is nullable
+
+The partition column is `NULLABLE`. Under SQL three-valued logic, rows with a `NULL` block number
+never match the fork `DELETE` predicate and would linger forever.
+
+**Fix** — make the column `REQUIRED` (`NOT NULL`).
+
+### E2205 · Table is not range-partitioned
+
+An existing live table is not range-partitioned on the declared column. A reorg `DELETE` without
+partition pruning scans the whole table — unaffordable at scale.
+
+**Fix** — recreate the table with `RANGE_BUCKET` partitioning on the column (the error prints
+suggested DDL).
+
+### E2206 · Unsupported field shape for auto-create
+
+Auto-creation cannot emit DDL for `REPEATED` (array) or `RECORD`/`STRUCT` fields.
+
+**Fix** — pre-create the table manually with the proper `ARRAY<...>` / `STRUCT<...>` column and
+re-run; the target validates it without recreating.
+
+### E2207 · Declared column missing from live table
+
+A column declared in the schema does not exist in the live table.
+
+**Fix** — add the column to the table, or drop it from the declared schema.
+
+### E2208 · Column type or mode mismatch
+
+A declared column's type or mode (`NULLABLE`/`REQUIRED`/`REPEATED`) differs from the live table.
+
+**Fix** — align the declared schema with the live table, or migrate the table to match.
+
+### E2209 · Write to an unregistered table
+
+Data was written to a table that isn't listed in `tables[]`, so its rows can't be cleaned up on a
+reorg.
+
+**Fix** — add the table to `bigqueryTarget({ tables: [...] })`.
+
+### E2210 · Internal schema-map mismatch
+
+Internal invariant violation (schema map and allowlist disagree).
+
+**Fix** — none; please [report it as a bug](https://github.com/subsquid-labs/pipes-sdk/issues).
+
+### E2211 · Corrupt in-flight sync row
+
+A sync row left in `IN_FLIGHT` state is missing its `range_low`/`range_high` bounds, so recovery
+can't proceed.
+
+**Fix** — manual intervention: inspect the sync table row for this pipe `id` and repair or clear the
+in-flight state.
+
+### E2212 · Orphaned tracked data
+
+The sync table has no row for this pipe `id`, but tracked tables still hold data from a prior run.
+Restarting from the initial cursor would re-process every block and duplicate every row, so the
+target refuses to start.
+
+**Fix** — if you deliberately reset the sync table, also `TRUNCATE`/drop the tracked tables it names.
+If you're upgrading from a pre-`id`-keyed cursor, keep the old cursor by pinning
+`settings: { state: { id: 'stream' } }` — see the
+[migration guide](https://github.com/subsquid-labs/pipes-sdk/blob/main/packages/subsquid-pipes/MIGRATION.md#10-target-cursors-are-now-keyed-by-the-pipe-id).
+
+### E2213 · BigQuery rejected rows in AppendRows
+
+`AppendRows` returned per-row errors (proto-schema mismatch, `NOT NULL` violation, value out of
+range). The affected rows are **not** written.
+
+**Fix** — compare the live table schema against the descriptor the writer uses and fix the offending
+column or values.
+
+---
+
+## Parquet target
+
+### E2301 · No tables declared
+
+`parquetTarget` was given an empty `tables` list — nothing to write.
+
+**Fix** — declare at least one table in `parquetTarget({ tables: [...] })`.
+
+### E2302 · Duplicate table name
+
+Two declared tables share a name.
+
+**Fix** — make each table name unique.
+
+### E2303 · Empty schema
+
+A table declared no columns.
+
+**Fix** — declare at least one column.
+
+### E2304 · Block-number column missing
+
+A table's schema omits the block-number column.
+
+**Fix** — add it as an integer column (`INT64`), or set `blockNumberColumn` to the column that
+carries the block number.
+
+### E2305 · Block-number column has the wrong type
+
+The block-number column is not an integer type.
+
+**Fix** — declare it `INT64` (or `INT32`).
+
+### E2306 · Unsupported compression codec
+
+A column declared a compression codec the target doesn't support.
+
+**Fix** — use one of the supported codecs (the message lists them).
+
+### E2307 · Unsupported column type
+
+A column declared a type the target doesn't support.
+
+**Fix** — use a supported leaf type, or `LIST` / `STRUCT` (the message lists the supported set).
+
+### E2308 · Write to an unregistered table
+
+Data was written to a table that isn't declared in `tables[]`.
+
+**Fix** — add the table to `parquetTarget({ tables: [...] })`.
+
+### E2309 · File collision
+
+`publish()` would overwrite an existing Parquet file for a block range — a sign of overlapping
+segments or a dirty output directory.
+
+**Fix** — write to a clean output directory and don't point two writers at the same one.
+
+### E2310 · Corrupt state file
+
+The persisted state file exists but could not be parsed.
+
+**Fix** — inspect or remove the state file to recover.
+
+### E2311 · Block-number column is optional
+
+The block-number column is declared `optional`, but finalization, file-range naming, and crash
+recovery all key off it — a null coerces to an immutable block-0 row.
+
+**Fix** — declare the block-number column required (remove `optional`).
+
+### E2312 · Invalid block-number value
+
+A row's block-number column held a missing or non-finite value.
+
+**Fix** — ensure every row carries a finite integer block number.
+
+### E2313 · Row value does not match column type
+
+A dev-mode value check failed: a required value was null, a `STRUCT` column got a non-object, a
+`LIST` column got a non-array, or a leaf value didn't match its declared type.
+
+**Fix** — correct the row so it matches the declared schema.
+
+### E2314 · Crash recovery could not delete an over-cursor file
+
+After a crash, a Parquet file whose blocks exceed the committed cursor could not be deleted; leaving
+it would duplicate data on resume.
+
+**Fix** — clear the filesystem error (permissions, locks) and remove the file so recovery can finish.
+
+### E2315 · Invalid nested schema
+
+A nested column declaration is malformed — an empty `STRUCT`, a `LIST` without `element`, a
+non-object column declaration, or nesting too deep (possibly cyclic).
+
+**Fix** — a `STRUCT` needs at least one field and a `LIST` needs an `element`; correct the
+declaration.

--- a/packages/subsquid-pipes/RELEASE_NOTES.md
+++ b/packages/subsquid-pipes/RELEASE_NOTES.md
@@ -544,7 +544,7 @@ and each gets its own scoped logger and cursor persistence keyed by `id`.
 
 ### 7. Typed error system with documentation links
 
-All framework errors extend `PipeError` and carry a unique code linking to the docs (`https://docs.sqd.dev/errors/<code>`).
+All framework errors extend `PipeError` and carry a unique code linking to the docs (`https://docs.sqd.dev/en/sdk/pipes-sdk/errors/<code>`).
 
 | Error | Code | Thrown when |
 |---|---|---|
@@ -553,6 +553,9 @@ All framework errors extend `PipeError` and carry a unique code linking to the d
 | `TargetForkNotSupportedError` | E1001 | Fork detected but target has no `resolveFork()` method |
 | `MissingForkAncestorError` | E1002 | Fork exception carried an empty canonical block list |
 | `ForkCursorMissingError` | E1003 | Target `resolveFork()` returned `null` |
+| `PortalContractViolationError` | E1004 | Portal delivered `canonicalBlocks` whose highest block is below the persisted cursor |
+
+Targets carry their own codes in the `E2xxx` band — `E20xx` ClickHouse, `E21xx` Postgres, `E22xx` BigQuery, `E23xx` Parquet — thrown as `ClickhouseTargetError`, `PostgresTargetError`, `BigQueryTargetError` and `ParquetTargetError`. Every code is documented in the [error reference](https://docs.sqd.dev/en/sdk/pipes-sdk/errors).
 
 
 ### 8. New Prometheus metrics

--- a/packages/subsquid-pipes/src/core/errors.test.ts
+++ b/packages/subsquid-pipes/src/core/errors.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { PipeError, PortalContractViolationError, SdkErrorName } from './errors.js'
+
+describe('PortalContractViolationError (E1004)', () => {
+  it('is a fork-handling PipeError carrying code E1004 and a docs link', () => {
+    const err = new PortalContractViolationError('portal delivered stale canonicalBlocks')
+
+    expect(err).toBeInstanceOf(PipeError)
+    expect(err.code).toBe('E1004')
+    expect(err.name).toBe(SdkErrorName.ForkHandling)
+    expect(err.message).toContain('portal delivered stale canonicalBlocks')
+    expect(err.message).toContain('See: https://docs.sqd.dev/en/sdk/pipes-sdk/errors/E1004')
+  })
+})

--- a/packages/subsquid-pipes/src/core/errors.ts
+++ b/packages/subsquid-pipes/src/core/errors.ts
@@ -2,7 +2,7 @@ import { arrayify } from '~/internal/array.js'
 
 import { joinLines } from './formatters.js'
 
-const DOCS_BASE = 'https://docs.sqd.dev/errors'
+const DOCS_BASE = 'https://docs.sqd.dev/en/sdk/pipes-sdk/errors'
 
 export enum SdkErrorName {
   PipeConfiguration = 'PipeConfiguration',
@@ -46,7 +46,7 @@ export class BlockRangeConfigurationError extends PipeError {
   }
 }
 
-// ─── Target errors (E1xxx) ────────────────────────────────────────────────────
+// ─── Fork handling errors (E1xxx) ─────────────────────────────────────────────
 
 /**
  * E1001: Thrown when a fork is detected but the target does not implement fork handling.
@@ -81,5 +81,16 @@ export class ForkCursorMissingError extends PipeError {
       'A blockchain fork was detected, but the target resolveFork() did not return a new cursor.',
       'The resolveFork() method must return the cursor to resume from after rolling back.',
     ])
+  }
+}
+
+/**
+ * E1004: Thrown when the portal breaks its fork contract — it delivered a canonicalBlocks set whose
+ * highest block is below the target's persisted cursor. Rows above it would survive the fork
+ * rollback and corrupt the new chain, so the pipe refuses to proceed rather than write bad data.
+ */
+export class PortalContractViolationError extends PipeError {
+  constructor(message: string | string[]) {
+    super('E1004', SdkErrorName.ForkHandling, message)
   }
 }

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-state.ts
@@ -5,6 +5,7 @@ import {
   CursorKey,
   LEGACY_DEFAULT_CURSOR_ID,
   type Logger,
+  PortalContractViolationError,
   type RollbackRecord,
   type TargetState,
   formatBlock,
@@ -392,8 +393,7 @@ export class BigQuerySyncState {
   async fork(canonicalBlocks: BlockCursor[]): Promise<{ safeCursor: BlockCursor | null; upper: number }> {
     const upper = canonicalBlocks.reduce((m, b) => (b.number > m ? b.number : m), Number.NEGATIVE_INFINITY)
     if (this.#lastCommittedCursor && upper < this.#lastCommittedCursor.number) {
-      throw new BigQueryTargetError(
-        BIGQUERY_ERROR_CODES.PORTAL_INVARIANT,
+      throw new PortalContractViolationError(
         `Portal invariant violated: max(canonicalBlocks).number=${upper} is below the persisted cursor ` +
           `(${this.#lastCommittedCursor.number}). The portal must include every block above the safe ` +
           `cursor in canonicalBlocks, otherwise rows in (${upper}, ${this.#lastCommittedCursor.number}] ` +

--- a/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/bigquery-target.test.ts
@@ -159,7 +159,7 @@ describe('chunkBuffersByByteSize', () => {
 // -----------------------------------------------------------------------------
 
 describe('BigQueryTargetError', () => {
-  it('every target throw is wrapped in BigQueryTargetError with a matching E11xx code', () => {
+  it('every target throw is wrapped in BigQueryTargetError with a matching E22xx code', () => {
     // Spot-check across the surface area: each thrown error is an instance of
     // BigQueryTargetError and carries the expected code. Downstream code can match on
     // `instanceof BigQueryTargetError` instead of scraping `.message`.

--- a/packages/subsquid-pipes/src/targets/bigquery/errors.ts
+++ b/packages/subsquid-pipes/src/targets/bigquery/errors.ts
@@ -3,10 +3,11 @@ import { PipeError, SdkErrorName } from '~/core/errors.js'
 /**
  * Common error wrapper for everything thrown by the BigQuery target.
  *
- * All target-originated errors extend this class and carry an `E11xx` code so
+ * All target-originated errors extend this class and carry an `E22xx` code so
  * downstream code can pattern-match on `instanceof BigQueryTargetError` and react
- * (alerting, retries, etc.) without scraping `.message`. The numeric code prefix
- * follows the project's existing convention (E0xxx = source, E1xxx = targets).
+ * (alerting, retries, etc.) without scraping `.message`. Code bands: E0xxx = source,
+ * E1xxx = fork handling, E2xxx = targets (E20xx ClickHouse, E21xx Postgres, E22xx
+ * BigQuery, E23xx Parquet).
  */
 export class BigQueryTargetError extends PipeError {
   constructor(code: string, message: string | string[]) {
@@ -14,43 +15,41 @@ export class BigQueryTargetError extends PipeError {
   }
 }
 
-// E11xx — BigQuery target codes
+// E22xx — BigQuery target codes
 export const BIGQUERY_ERROR_CODES = {
   /** Cannot determine GCP project id at target construction. */
-  PROJECT_ID: 'E1101',
+  PROJECT_ID: 'E2201',
   /** Tracked table schema is missing the declared partition column. */
-  PARTITION_COLUMN_MISSING: 'E1102',
+  PARTITION_COLUMN_MISSING: 'E2202',
   /** Partition column has the wrong type (must be INT64). */
-  PARTITION_COLUMN_TYPE: 'E1103',
+  PARTITION_COLUMN_TYPE: 'E2203',
   /** Partition column is NULLable (must be REQUIRED). */
-  PARTITION_COLUMN_NULLABLE: 'E1104',
+  PARTITION_COLUMN_NULLABLE: 'E2204',
   /** Existing live table is not range-partitioned on the declared column. */
-  TABLE_NOT_PARTITIONED: 'E1105',
+  TABLE_NOT_PARTITIONED: 'E2205',
   /** Auto-create cannot generate DDL for REPEATED/RECORD/STRUCT fields. */
-  UNSUPPORTED_FIELD_SHAPE: 'E1106',
+  UNSUPPORTED_FIELD_SHAPE: 'E2206',
   /** Declared field missing from the live table. */
-  SCHEMA_FIELD_MISSING: 'E1107',
+  SCHEMA_FIELD_MISSING: 'E2207',
   /** Declared field has a different type in the live table. */
-  SCHEMA_TYPE_MISMATCH: 'E1108',
+  SCHEMA_TYPE_MISMATCH: 'E2208',
   /** User wrote to a table that wasn't registered in tables[]. */
-  UNREGISTERED_TABLE: 'E1109',
+  UNREGISTERED_TABLE: 'E2209',
   /** Internal: schema map and allowlist disagree (should be unreachable). */
-  INTERNAL_SCHEMA_MAP: 'E1110',
+  INTERNAL_SCHEMA_MAP: 'E2210',
   /** Sync row in IN_FLIGHT state lacks the range_low/range_high it needs for recovery. */
-  CORRUPT_INFLIGHT_ROW: 'E1111',
-  /** Portal sent canonicalBlocks whose max block is below our persisted cursor. */
-  PORTAL_INVARIANT: 'E1112',
+  CORRUPT_INFLIGHT_ROW: 'E2211',
   /**
    * Sync table has no rows for this stream id, but tracked tables still hold data — refusing
    * to silently restart from the initial cursor (would re-process and duplicate everything).
    * Surfaces accidental sync truncation / drop / row deletion before it becomes corruption.
    */
-  ORPHAN_TRACKED_DATA: 'E1113',
+  ORPHAN_TRACKED_DATA: 'E2212',
   /**
    * `AppendRows` resolved without a channel error, but the response carries per-row
    * `rowErrors` from BigQuery (proto-schema mismatch, NOT NULL violation, etc.). The SDK
    * does not propagate these as rejections — without an explicit check the row is silently
    * dropped while our code believes the write succeeded.
    */
-  APPEND_ROW_REJECTED: 'E1114',
+  APPEND_ROW_REJECTED: 'E2213',
 } as const

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-state.ts
@@ -12,6 +12,7 @@ import {
 } from '~/core/index.js'
 
 import { ClickhouseStore } from './clickhouse-store.js'
+import { CLICKHOUSE_ERROR_CODES, ClickhouseTargetError } from './errors.js'
 
 // FIXME: we need refactor it to make order more deterministic and predictable - WHY?
 // ORDER BY (timestamp, id) isn't a good choice
@@ -78,7 +79,7 @@ export class ClickhouseState {
 
     const maxRows = options.maxRows ?? 10_000
     if (maxRows <= 0) {
-      throw new Error('Max rows must be greater than 0')
+      throw new ClickhouseTargetError(CLICKHOUSE_ERROR_CODES.MAX_ROWS, 'Max rows must be greater than 0')
     }
 
     this.options = {

--- a/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/clickhouse-store.ts
@@ -12,6 +12,7 @@ import type {
 
 import type { Logger } from '~/core/index.js'
 
+import { CLICKHOUSE_ERROR_CODES, ClickhouseTargetError } from './errors.js'
 import { loadSqlFiles } from './fs.js'
 
 export type QueryParamsWithFormat<Format extends DataFormat> = Omit<QueryParams, 'format'> & {
@@ -125,7 +126,10 @@ export class ClickhouseStore {
     parts.push(current)
 
     if (parts.length > 2) {
-      throw new Error(`Invalid table name "${table}": expected "table" or "database.table"`)
+      throw new ClickhouseTargetError(
+        CLICKHOUSE_ERROR_CODES.INVALID_TABLE_NAME,
+        `Invalid table name "${table}": expected "table" or "database.table"`,
+      )
     }
 
     const [database, name] = parts.length === 2 ? parts : [null, parts[0]]
@@ -185,7 +189,8 @@ export class ClickhouseStore {
     const match = meta.engineFull.match(/^Distributed\('[^']*',\s*'([^']*)',\s*'([^']*)'/)
     const underlying = match ? `${match[1]}.${match[2]}` : 'the underlying local table'
 
-    throw new Error(
+    throw new ClickhouseTargetError(
+      CLICKHOUSE_ERROR_CODES.DISTRIBUTED_ROLLBACK,
       `Cannot roll back "${table}": it is a Distributed table. ` +
         `Rollback must target the local table (${underlying}) directly; multi-shard rollback is not supported.`,
     )
@@ -201,14 +206,18 @@ export class ClickhouseStore {
       .map((arg) => arg.trim())
       .find((arg) => arg && !arg.startsWith("'"))
     if (collapseColumn && collapseColumn !== 'sign') {
-      throw new Error(
+      throw new ClickhouseTargetError(
+        CLICKHOUSE_ERROR_CODES.ROLLBACK_COLLAPSE_COLUMN,
         `Cannot roll back "${table}": the engine collapses on "${collapseColumn}", not "sign". ` +
           `Rollback inserts cancel rows with sign = -1, so the collapse column must be named "sign".`,
       )
     }
 
     if (!meta.columns.some((c) => c.name === 'sign')) {
-      throw new Error(`Cannot roll back "${table}": the table has no "sign" column`)
+      throw new ClickhouseTargetError(
+        CLICKHOUSE_ERROR_CODES.ROLLBACK_MISSING_SIGN,
+        `Cannot roll back "${table}": the table has no "sign" column`,
+      )
     }
   }
 
@@ -227,7 +236,10 @@ export class ClickhouseStore {
   async ensureRollbackIndex({ table, column = 'block_number' }: { table: string; column?: string }) {
     // The column is interpolated into DDL below; restrict it to a plain identifier
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(column)) {
-      throw new Error(`Invalid rollback index column "${column}": expected a plain identifier`)
+      throw new ClickhouseTargetError(
+        CLICKHOUSE_ERROR_CODES.INVALID_ROLLBACK_INDEX_COLUMN,
+        `Invalid rollback index column "${column}": expected a plain identifier`,
+      )
     }
 
     const { database, name } = this.#parseTableName(table)

--- a/packages/subsquid-pipes/src/targets/clickhouse/errors.test.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { PipeError } from '~/core/errors.js'
+
+import { ClickhouseStore } from './clickhouse-store.js'
+import { CLICKHOUSE_ERROR_CODES, ClickhouseTargetError } from './errors.js'
+
+describe('ClickhouseTargetError', () => {
+  it('carries the given E20xx code and a docs link', () => {
+    const err = new ClickhouseTargetError(CLICKHOUSE_ERROR_CODES.MAX_ROWS, 'boom')
+
+    expect(err).toBeInstanceOf(PipeError)
+    expect(err.code).toBe('E2001')
+    expect(err.message).toContain('boom')
+    expect(err.message).toContain('See: https://docs.sqd.dev/en/sdk/pipes-sdk/errors/E2001')
+  })
+
+  // These validations fire before any client call, so a stub client is enough to reach them.
+  const store = new ClickhouseStore({} as any)
+
+  it('rejects a non-identifier rollback index column (E2006)', async () => {
+    try {
+      await store.ensureRollbackIndex({ table: 't', column: 'bad col' })
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ClickhouseTargetError)
+      expect((e as ClickhouseTargetError).code).toBe(CLICKHOUSE_ERROR_CODES.INVALID_ROLLBACK_INDEX_COLUMN)
+    }
+  })
+
+  it('rejects an unparseable table name (E2002)', async () => {
+    try {
+      await store.ensureRollbackIndex({ table: 'a.b.c', column: 'block_number' })
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ClickhouseTargetError)
+      expect((e as ClickhouseTargetError).code).toBe(CLICKHOUSE_ERROR_CODES.INVALID_TABLE_NAME)
+    }
+  })
+})

--- a/packages/subsquid-pipes/src/targets/clickhouse/errors.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/errors.ts
@@ -1,0 +1,32 @@
+import { PipeError, SdkErrorName } from '~/core/errors.js'
+
+/**
+ * Common error wrapper for everything thrown by the ClickHouse target.
+ *
+ * All target-originated errors extend this class and carry an `E20xx` code so
+ * downstream code can pattern-match on `instanceof ClickhouseTargetError` and react
+ * (alerting, retries, etc.) without scraping `.message`. Code bands: E0xxx = source,
+ * E1xxx = fork handling, E2xxx = targets (E20xx ClickHouse, E21xx Postgres, E22xx
+ * BigQuery, E23xx Parquet).
+ */
+export class ClickhouseTargetError extends PipeError {
+  constructor(code: string, message: string | string[]) {
+    super(code, SdkErrorName.TargetConfiguration, message)
+  }
+}
+
+// E20xx — ClickHouse target codes
+export const CLICKHOUSE_ERROR_CODES = {
+  /** The `maxRows` batching option is not a positive number. */
+  MAX_ROWS: 'E2001',
+  /** A table identifier could not be parsed as `table` or `database.table`. */
+  INVALID_TABLE_NAME: 'E2002',
+  /** Rollback targeted a Distributed table — it must target the local table instead. */
+  DISTRIBUTED_ROLLBACK: 'E2003',
+  /** The table's collapsing engine collapses on a column other than `sign`. */
+  ROLLBACK_COLLAPSE_COLUMN: 'E2004',
+  /** The table has no `sign` column, so cancel-row rollback cannot work. */
+  ROLLBACK_MISSING_SIGN: 'E2005',
+  /** `ensureRollbackIndex` was given a column name that is not a plain identifier. */
+  INVALID_ROLLBACK_INDEX_COLUMN: 'E2006',
+} as const

--- a/packages/subsquid-pipes/src/targets/clickhouse/index.ts
+++ b/packages/subsquid-pipes/src/targets/clickhouse/index.ts
@@ -1,2 +1,3 @@
 export * from './clickouse-target.js'
+export * from './errors.js'
 export * from './utils.js'

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
@@ -9,6 +9,7 @@ import { nonNullable } from '~/internal/array.js'
 import { doWithRetry } from '~/internal/function.js'
 
 import { DrizzleTracker } from './drizzle-tracker.js'
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
 import { PostgresState, StateOptions } from './postgres-state.js'
 import { orderTablesForDelete } from './rollback.js'
 
@@ -62,7 +63,10 @@ export function drizzleTarget<T>({
   const tracker = new DrizzleTracker()
   const client = (db as any).$client
   if (!client) {
-    throw new Error('Drizzle client not found on the provided database instance')
+    throw new PostgresTargetError(
+      POSTGRES_ERROR_CODES.DRIZZLE_CLIENT_MISSING,
+      'Drizzle client not found on the provided database instance',
+    )
   }
 
   const state = new PostgresState(client, settings?.state)

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-tracker.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/drizzle-tracker.ts
@@ -5,6 +5,7 @@ import { BlockCursor } from '~/core/index.js'
 
 import { SQD_PRIMARY_COLS, getDrizzleTableName } from './consts.js'
 import { Transaction } from './drizzle-target.js'
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
 import { generateTriggerSQL } from './rollback.js'
 
 /** @internal */
@@ -100,7 +101,8 @@ export class DrizzleTracker {
 
       tx[method] = (table: Table, ...args: any[]) => {
         if (!this.#knownTables.has(table)) {
-          throw new Error(
+          throw new PostgresTargetError(
+            POSTGRES_ERROR_CODES.UNTRACKED_TABLE,
             `Table "${getDrizzleTableName(table)}" is not tracked for rollbacks. Make sure to include it in the "tables" array when creating the target.`,
           )
         }

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/errors.test.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/errors.test.ts
@@ -1,0 +1,51 @@
+import { integer, pgTable } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+
+import { PipeError } from '~/core/errors.js'
+
+import { drizzleTarget } from './drizzle-target.js'
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
+import { PostgresState } from './postgres-state.js'
+import { generateTriggerSQL } from './rollback.js'
+
+describe('PostgresTargetError', () => {
+  it('carries the given E21xx code and a docs link', () => {
+    const err = new PostgresTargetError(POSTGRES_ERROR_CODES.RETENTION_INVALID, 'boom')
+
+    expect(err).toBeInstanceOf(PipeError)
+    expect(err.code).toBe('E2102')
+    expect(err.message).toContain('boom')
+    expect(err.message).toContain('See: https://docs.sqd.dev/en/sdk/pipes-sdk/errors/E2102')
+  })
+
+  it('drizzleTarget on a db without a client throws DRIZZLE_CLIENT_MISSING (E2101)', () => {
+    try {
+      drizzleTarget({ db: {} as any, tables: [], onData: async () => {} })
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PostgresTargetError)
+      expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.DRIZZLE_CLIENT_MISSING)
+    }
+  })
+
+  it('PostgresState with non-positive retention throws RETENTION_INVALID (E2102)', () => {
+    try {
+      new PostgresState({} as any, { unfinalizedBlocksRetention: -1 })
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PostgresTargetError)
+      expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.RETENTION_INVALID)
+    }
+  })
+
+  it('generateTriggerSQL on a table without a primary key throws MISSING_PRIMARY_KEY (E2105)', () => {
+    const table = pgTable('t', { a: integer('a') })
+    try {
+      generateTriggerSQL('t', 'snap', table)
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PostgresTargetError)
+      expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.MISSING_PRIMARY_KEY)
+    }
+  })
+})

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/errors.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/errors.ts
@@ -1,0 +1,32 @@
+import { PipeError, SdkErrorName } from '~/core/errors.js'
+
+/**
+ * Common error wrapper for everything thrown by the Postgres (Drizzle) target.
+ *
+ * All target-originated errors extend this class and carry an `E21xx` code so
+ * downstream code can pattern-match on `instanceof PostgresTargetError` and react
+ * (alerting, retries, etc.) without scraping `.message`. Code bands: E0xxx = source,
+ * E1xxx = fork handling, E2xxx = targets (E20xx ClickHouse, E21xx Postgres, E22xx
+ * BigQuery, E23xx Parquet).
+ */
+export class PostgresTargetError extends PipeError {
+  constructor(code: string, message: string | string[]) {
+    super(code, SdkErrorName.TargetConfiguration, message)
+  }
+}
+
+// E21xx — Postgres (Drizzle) target codes
+export const POSTGRES_ERROR_CODES = {
+  /** The provided Drizzle db instance has no underlying client (`$client`). */
+  DRIZZLE_CLIENT_MISSING: 'E2101',
+  /** `unfinalizedBlocksRetention` is not a positive number. */
+  RETENTION_INVALID: 'E2102',
+  /** Could not acquire the advisory lock — another process holds this state id. */
+  ADVISORY_LOCK_FAILED: 'E2103',
+  /** A write targeted a table not registered in `tables` for rollback tracking. */
+  UNTRACKED_TABLE: 'E2104',
+  /** Cannot build a snapshot trigger for a table without primary key columns. */
+  MISSING_PRIMARY_KEY: 'E2105',
+  /** Foreign keys form a cycle, so a safe delete order cannot be determined. */
+  CIRCULAR_DEPENDENCY: 'E2106',
+} as const

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/index.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/index.ts
@@ -1,2 +1,3 @@
 export * from './drizzle-target.js'
+export * from './errors.js'
 export * from './utils.js'

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/postgres-state.ts
@@ -17,6 +17,8 @@ import { parseNumber } from '~/internal/number.js'
 import { Transaction } from '~/targets/drizzle/node-postgres/drizzle-target.js'
 import { syncTable, tableNotExists } from '~/targets/drizzle/node-postgres/tables.js'
 
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
+
 type DeleteResult = {
   rowCount: number
 }
@@ -97,7 +99,7 @@ export class PostgresState {
     }
 
     if (this.options?.unfinalizedBlocksRetention && this.options?.unfinalizedBlocksRetention <= 0) {
-      throw new Error('Retention strategy must be greater than 0')
+      throw new PostgresTargetError(POSTGRES_ERROR_CODES.RETENTION_INVALID, 'Retention strategy must be greater than 0')
     }
 
     this.#key = new CursorKey(options?.id)
@@ -136,7 +138,8 @@ export class PostgresState {
 
     if (res.rows[0]?.got_lock) return
 
-    throw new Error(
+    throw new PostgresTargetError(
+      POSTGRES_ERROR_CODES.ADVISORY_LOCK_FAILED,
       [
         `Could not acquire advisory lock for state id "${this.#key.value}".`,
         `Another process might be holding the lock.`,

--- a/packages/subsquid-pipes/src/targets/drizzle/node-postgres/rollback.ts
+++ b/packages/subsquid-pipes/src/targets/drizzle/node-postgres/rollback.ts
@@ -9,6 +9,7 @@ import {
   getDrizzleTableExtraConfig,
   getDrizzleTableName,
 } from './consts.js'
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
 
 export function generateTriggerSQL(from: string, to: string, table: Table) {
   const columns = getDrizzleTableColumns(table)
@@ -35,7 +36,10 @@ export function generateTriggerSQL(from: string, to: string, table: Table) {
   }
 
   if (primaryCols.length === 0) {
-    throw new Error(`Cannot generate snapshot trigger for table ${from} without primary key columns`)
+    throw new PostgresTargetError(
+      POSTGRES_ERROR_CODES.MISSING_PRIMARY_KEY,
+      `Cannot generate snapshot trigger for table ${from} without primary key columns`,
+    )
   }
 
   ;(table as any)[SQD_PRIMARY_COLS] = primaryCols
@@ -149,13 +153,11 @@ export function orderTablesForDelete(tables: Table[]): Table[] {
   }
 
   if (order.length !== nodes.size) {
-    throw new Error(
-      [
-        'Circular dependency detected in foreign key references.',
-        'Cannot determine a safe order for delete operations.',
-        'Please check your table definitions for circular foreign key constraints.',
-      ].join('\n'),
-    )
+    throw new PostgresTargetError(POSTGRES_ERROR_CODES.CIRCULAR_DEPENDENCY, [
+      'Circular dependency detected in foreign key references.',
+      'Cannot determine a safe order for delete operations.',
+      'Please check your table definitions for circular foreign key constraints.',
+    ])
   }
 
   // Reverse to get children→parents

--- a/packages/subsquid-pipes/src/targets/parquet/errors.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/errors.ts
@@ -3,11 +3,11 @@ import { PipeError, SdkErrorName } from '~/core/errors.js'
 /**
  * Common error wrapper for everything thrown by the Parquet target.
  *
- * All target-originated errors extend this class and carry an `E12xx` code so
+ * All target-originated errors extend this class and carry an `E23xx` code so
  * downstream code can pattern-match on `instanceof ParquetTargetError` and react
- * (alerting, retries, etc.) without scraping `.message`. The numeric code prefix
- * follows the project's existing convention (E0xxx = source, E1xxx = targets);
- * BigQuery occupies E11xx, so the Parquet target uses E12xx.
+ * (alerting, retries, etc.) without scraping `.message`. Code bands: E0xxx = source,
+ * E1xxx = fork handling, E2xxx = targets (E20xx ClickHouse, E21xx Postgres, E22xx
+ * BigQuery, E23xx Parquet).
  */
 export class ParquetTargetError extends PipeError {
   constructor(code: string, message: string | string[]) {
@@ -15,36 +15,36 @@ export class ParquetTargetError extends PipeError {
   }
 }
 
-// E12xx — Parquet target codes
+// E23xx — Parquet target codes
 export const PARQUET_ERROR_CODES = {
   /** `tables[]` is empty — the target has nothing to write. */
-  NO_TABLES: 'E1201',
+  NO_TABLES: 'E2301',
   /** Two declared tables share the same name. */
-  DUPLICATE_TABLE: 'E1202',
+  DUPLICATE_TABLE: 'E2302',
   /** A table schema is empty (no columns declared). */
-  EMPTY_SCHEMA: 'E1203',
+  EMPTY_SCHEMA: 'E2303',
   /** Table schema is missing the declared block-number column. */
-  BLOCK_COLUMN_MISSING: 'E1204',
+  BLOCK_COLUMN_MISSING: 'E2304',
   /** Block-number column is not an integer type (must be INT64/INT32). */
-  BLOCK_COLUMN_TYPE: 'E1205',
+  BLOCK_COLUMN_TYPE: 'E2305',
   /** A column declared an unsupported compression codec. */
-  UNSUPPORTED_COMPRESSION: 'E1206',
+  UNSUPPORTED_COMPRESSION: 'E2306',
   /** A column declared an unsupported Parquet type. */
-  UNSUPPORTED_TYPE: 'E1207',
+  UNSUPPORTED_TYPE: 'E2307',
   /** User wrote to a table that wasn't registered in `tables[]`. */
-  UNREGISTERED_TABLE: 'E1208',
+  UNREGISTERED_TABLE: 'E2308',
   /** `publish()` refused to overwrite an existing data file (would lose data). */
-  FILE_COLLISION: 'E1209',
+  FILE_COLLISION: 'E2309',
   /** Persisted state file exists but could not be parsed. */
-  STATE_CORRUPT: 'E1210',
+  STATE_CORRUPT: 'E2310',
   /** The block-number column is declared `optional` — it must be present on every row. */
-  BLOCK_COLUMN_OPTIONAL: 'E1211',
+  BLOCK_COLUMN_OPTIONAL: 'E2311',
   /** A row carried a missing/non-finite block number (would corrupt finalization & recovery). */
-  BLOCK_VALUE_INVALID: 'E1212',
+  BLOCK_VALUE_INVALID: 'E2312',
   /** A row value does not match its declared column type (dev-mode value check). */
-  VALUE_INVALID: 'E1213',
+  VALUE_INVALID: 'E2313',
   /** Crash recovery could not delete an over-cursor data file (leaving it would duplicate data). */
-  RECOVERY_DELETE_FAILED: 'E1214',
+  RECOVERY_DELETE_FAILED: 'E2314',
   /** A nested column declaration is malformed (empty STRUCT fields, LIST without element, over-deep nesting). */
-  NESTED_SCHEMA_INVALID: 'E1215',
+  NESTED_SCHEMA_INVALID: 'E2315',
 } as const

--- a/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/subsquid-pipes/src/targets/parquet/parquet-target.test.ts
@@ -825,6 +825,6 @@ describe('parquet index barrel', () => {
     expect(typeof mod.parquetTarget).toBe('function')
     expect(typeof mod.ParquetStore).toBe('function')
     expect(typeof mod.ParquetTargetError).toBe('function')
-    expect(mod.PARQUET_ERROR_CODES.NO_TABLES).toBe('E1201')
+    expect(mod.PARQUET_ERROR_CODES.NO_TABLES).toBe('E2301')
   })
 })


### PR DESCRIPTION
## What

Restructures the SDK error-code scheme so code bands map cleanly to concerns, extends coded errors to **all four** targets, and rewrites `docs/errors.md` to match.

This started as the error-reference page. Review flagged that `E1112 PORTAL_INVARIANT` — a portal-contract violation — was filed under the BigQuery band, and that ClickHouse/Postgres had no codes at all. This fixes both.

## Taxonomy (new)

| Band | Area |
| --- | --- |
| `E0xxx` | Source / pipe config |
| `E1xxx` | Fork handling & rollback (core) |
| `E20xx` | ClickHouse |
| `E21xx` | Postgres (Drizzle) |
| `E22xx` | BigQuery |
| `E23xx` | Parquet |

## Changes

- **Portal invariant → core.** `PORTAL_INVARIANT` moves out of the BigQuery target into a core `PortalContractViolationError` (`SdkErrorName.ForkHandling`) — a portal/fork concern every cursor-tracking target shares, not a BigQuery config error.
- **Target bands renumbered to `E2xxx`**, ClickHouse/Postgres first.
- **ClickHouse (E20xx) and Postgres (E21xx) are now coded.** Their bare `throw new Error(...)` sites are wrapped in `ClickhouseTargetError` / `PostgresTargetError` and exported for `instanceof` matching. Messages are preserved, so existing `toThrow` tests still pass. The internal ClickHouse `TableNotFoundError` sentinel stays uncoded — it's caught and handled, never surfaced to users.
- **`docs/errors.md`** regrouped and extended. All **46** codes cross-checked against the `errors.ts` definitions — exact match, no drift.

## ⚠️ Breaking

`instanceof` matching is unaffected, but the string codes change:

- `E1112` (portal invariant) → **`E1004`**
- BigQuery `E11xx` → **`E22xx`**
- Parquet `E12xx` → **`E23xx`**

Pre-1.0, no aliases — consistent with the other major-release breaks. Anyone matching these codes in logs/alerts must update.

## Tests

`104 passed`. New unit tests: `PortalContractViolationError` (E1004); ClickHouse validations (invalid index column, unparseable table name); Postgres paths (client missing, non-positive retention, missing primary key). Existing BigQuery/Parquet suites pass against the renumbered codes. `tsc --noEmit` clean, Biome clean.

Service-backed suites (ClickHouse/Postgres/BigQuery integration) were not run locally (no services), but they assert on message substrings, which are preserved by the wrapping.

## Single source, imported by docs

`docs/errors.md` stays the one source the docs site imports and serves at `/errors`, routing `/errors/<code>` to each section. Follow-up still open: a drift check that fails CI when `errors.ts` and this page diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
